### PR TITLE
Trig serialized based on Turtle

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -132,6 +132,8 @@ register('n3', Serializer,
                 'rdflib.plugins.serializers.n3','N3Serializer')
 register('turtle', Serializer, 
                 'rdflib.plugins.serializers.turtle', 'TurtleSerializer')
+register('trig', Serializer,
+                'rdflib.plugins.serializers.trig', 'TrigSerializer')
 register('nt', Serializer, 
                 'rdflib.plugins.serializers.nt', 'NTSerializer')
 register('pretty-xml', Serializer,

--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -1,0 +1,83 @@
+"""
+Trig RDF graph serializer for RDFLib.
+See <http://www.w3.org/2010/01/Trig/Trig> for syntax specification.
+"""
+
+from rdflib.plugins.serializers.turtle import TurtleSerializer, VERB, _GEN_QNAME_FOR_DT
+
+from rdflib.term import BNode, Literal
+
+from collections import defaultdict
+
+__all__ = ['TrigSerializer']
+
+class TrigSerializer(TurtleSerializer):
+
+    short_name = "trig"
+    indentString = 4 * u' '
+
+    def __init__(self, store):
+        if store.context_aware:
+            self.contexts = store.contexts()
+        else:
+            self.contexts = [store]
+
+        super(TrigSerializer, self).__init__(store)
+
+    def preprocess(self):
+        for context in self.contexts:
+            for triple in context:
+               self.preprocessTriple(triple, context.identifier)
+
+    def preprocessTriple(self, triple, identifier):
+        s, p, o = triple
+        references = self.refCount(o) + 1
+        self._references[o] = references
+        self._subjects[s] = True
+        self._contexts[identifier].add(s)
+        for i, node in enumerate(triple):
+            if node in self.keywords:
+                continue
+            # Don't use generated prefixes for subjects and objects
+            self.getQName(node, gen_prefix=(i==VERB))
+            if isinstance(node, Literal) and node.datatype:
+                self.getQName(node.datatype, gen_prefix=_GEN_QNAME_FOR_DT)
+        p = triple[1]
+        if isinstance(p, BNode):
+            self._references[p] = self.refCount(p) + 1
+
+    def reset(self):
+        super(TrigSerializer, self).reset()
+        self._contexts = defaultdict(set)
+
+    def serialize(self, stream, base=None, encoding=None, spacious=None, **args):
+        self.reset()
+        self.stream = stream
+        self.base = base
+
+        if spacious is not None:
+            self._spacious = spacious
+
+        self.preprocess()
+        subjects_list = self.orderSubjects()
+
+        self.startDocument()
+
+        firstTime = True
+        for identifier, subjects in self._contexts.items():
+            self.write(self.indent() + '\n<%s> = {' % identifier)
+            self.depth += 1
+            for subject in subjects:
+                if self.isDone(subject):
+                    continue
+                if firstTime:
+                    firstTime = False
+                if self.statement(subject) and not firstTime:
+                    self.write('\n')
+            self.depth -= 1
+            self.write('}\n')
+
+        self.endDocument()
+        stream.write(u"\n".encode('ascii'))
+
+

--- a/test/test_trig_serialize.py
+++ b/test/test_trig_serialize.py
@@ -1,0 +1,12 @@
+import unittest
+from rdflib.graph import ConjunctiveGraph
+
+class TestTrigSerialize(unittest.TestCase):
+
+    def test_empty_graph(self):
+        graph = ConjunctiveGraph()
+        text = graph.serialize(format='trig')
+        self.assertIsNotNone(text)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi,
I implemented a basic Trig serializer support, it is based on TurtleSerializer instead of ntriples as the one available in the trig named branch; it also is very handy if you need to keep track of default graph without resorting to nquads, which is really verbose and does not handle IRI but just URI.

The result is a valid trig output that could be ingested in e.g. virtuoso.
