### PR TITLE
Basic argument checking for add and addN

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -368,10 +368,16 @@ class Graph(Node):
 
     def add(self, (s, p, o)):
         """Add a triple with self as context"""
+        assert isinstance(s,Node), "Subject %s must be an rdflib term" % s
+        assert isinstance(p,Node), "Predicate %s must be an rdflib term" % p
+        assert isinstance(o,Node), "Object %s must be an rdflib term" % o
         self.__store.add((s, p, o), self, quoted=False)
 
     def addN(self, quads):
         """Add a sequence of triple with context"""
+        assert isinstance(s,Node), "Subject %s must be an rdflib term" % s
+        assert isinstance(p,Node), "Predicate %s must be an rdflib term" % p
+        assert isinstance(o,Node), "Object %s must be an rdflib term" % o
         self.__store.addN((s, p, o, c) for s, p, o, c in quads
                                         if isinstance(c, Graph)
                                         and c.identifier is self.identifier)


### PR DESCRIPTION
s,p,o are now asserted to be instances of term.Node.
If they are not, a friendly error is presented to say that they should be.

This should solve #277 and #278.
