### PR TITLE
Serializing to a file fails in Python 3

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -881,7 +881,7 @@ class Graph(Node):
                       "is not a local file reference")
                 return
             fd, name = tempfile.mkstemp()
-            stream = os.fdopen(fd, "w")
+            stream = os.fdopen(fd, "wb")
             serializer.serialize(stream, base=base, encoding=encoding, **args)
             stream.close()
             if hasattr(shutil, "move"):


### PR DESCRIPTION
```
Python 3.2.3 (default, Jun 25 2012, 23:10:56)
[GCC 4.7.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from rdflib import ConjunctiveGraph
>>> g = ConjunctiveGraph()
>>> g.serialize(destination='test_serialization.trix',format='trix')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/graph.py", line 889, in serialize
    serializer.serialize(stream, base=base, encoding=encoding, **args)
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/plugins/serializers/trix.py", line 29, in serialize
    self.writer = XMLWriter(stream, nm, encoding, extra_ns={"": TRIXNS})
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/plugins/serializers/xmlwriter.py", line 19, in __init__
    stream.write('<?xml version="1.0" encoding="%s"?>' % encoding)
  File "/usr/lib/python3.2/codecs.py", line 356, in write
    self.stream.write(data)
TypeError: must be str, not bytes
>>> g.serialize(destination='test_serialization.trix',format='xml')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/graph.py", line 889, in serialize
    serializer.serialize(stream, base=base, encoding=encoding, **args)
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/plugins/serializers/rdfxml.py", line 56, in serialize
    write('<?xml version="1.0" encoding="%s"?>\n' % self.encoding)
  File "/home/urs/.local/lib/python3.2/site-packages/rdflib/plugins/serializers/rdfxml.py", line 53, in <lambda>
    uni.encode(encoding, 'replace'))
TypeError: must be str, not bytes
```

The fix is to open the file in binary mode.
