### PR TITLE
Don't include *.pyc files in source/binary distributions.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include examples *.py
 include run_tests.py
 graft test
 graft docs
+global-exclude *.pyc


### PR DESCRIPTION
This is almost always wrong, you only want to distribute source code,
not Interpreter-dependant binary code. As an example, using the current
tarballs hosted on PyPI breaks with Python-2.6 due to non-matching
magic number of the *.pyc files.
