### PR TITLE
NTriples: Newline in final line is optional

### DIFF
--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -164,7 +164,8 @@ class NTriplesParser(object):
             else:
                 buffer = self.file.read(bufsiz)
                 if not buffer and not self.buffer.isspace():
-                    raise ParseError("EOF in line")
+                    # Last line does not need to be terminated with a newline
+                    buffer += b("\n")
                 elif not buffer:
                     return None
                 self.buffer += buffer

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -93,7 +93,6 @@ class NTTestCase(unittest.TestCase):
     def test__no_EOF(self):
         data = '''<http://example.org/resource32> <http://example.org/property> <http://example.org/datatype1> .'''
         p = ntriples.NTriplesParser()
-        self.assertRaises(ntriples.ParseError, p.parsestring, data)
 
     def test_bad_line(self):
         data = '''<http://example.org/resource32> 3 <http://example.org/datatype1> .\n'''


### PR DESCRIPTION
According to
http://www.w3.org/TR/2013/NOTE-n-triples-20130409/#grammar-production-ntriplesDoc
the newline at the end of the document is optional, but the current code throws an error in this case. There is even a test which requires an error to be thrown.

I attempted to fix this, including the test. Does it make sense like this? Now let's see what travis thinks ...
