### PR TITLE
upgrade dependencies to current pyparsing version

### DIFF
--- a/requirements.py2.txt
+++ b/requirements.py2.txt
@@ -1,4 +1,4 @@
 flake8
 isodate
-pyparsing<=1.5.7
+pyparsing
 SPARQLWrapper

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ else:
         kwargs['test_suite'] = "nose.collector"
         kwargs['install_requires'] = [
             'isodate',
-            'pyparsing<=1.5.7', 'SPARQLWrapper']
+            'pyparsing', 'SPARQLWrapper']
 
         if sys.version_info[1]<7:
             kwargs['install_requires'].append('ordereddict')


### PR DESCRIPTION
not sure where the <= dependency came from, tests on my machine pass with pyparsing 2.0.1 as well.
would fix #320
