### PR TITLE
quad serializations take a long time

### DIFF
--- a/rdflib/plugins/memory.py
+++ b/rdflib/plugins/memory.py
@@ -363,7 +363,9 @@ class IOMemory(Store):
 
     def __len__(self, context=None):
         cid = self.__obj2id(context)
-        return sum(1 for enctriple, contexts in self.__all_triples(cid))
+        if cid not in self.__contextTriples:
+            return 0
+        return len(self.__contextTriples[cid])
 
     def add_graph(self, graph):
         if not self.graph_aware:


### PR DESCRIPTION
I hesitate to report this as a bug since I don't understand all that's going on in serialize, but following up on my report on the list a while ago https://groups.google.com/forum/?hl=en-US#!msg/rdflib-dev/VgV9zNbk_cc/uVtOW5V74TkJ all of the quad serializations take a lot of time. I did a crude time test on my graph of 75k statements, both parsing and serializing:

```
>>> rdflib.__version__
'4.1-dev'

>>> def timeit():
...     start = time()
...     cg.parse('candidates.trig', format='trig')
...     elapsed = time() - start
...     print elapsed
... 
>>> timeit()
22.5815250874
>>> len(cg)
75840
>>> def timeit():
...     start = time()
...     cg.serialize(format='trig')
...     elapsed = time() - start
...     print elapsed
... 
>>> timeit()
2746.05100608
```

As usual, I'm pretty far out of my depth here, but 45min seems long for a graph of this size.
