### PR TITLE
Correct indentation in python sample code

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -70,7 +70,7 @@ A more extensive example:
 .. code-block:: python
 
     from rdflib import Graph, Literal, BNode, Namespace, RDF
-	from rdflib.namespace import DC, FOAF
+    from rdflib.namespace import DC, FOAF
 
     g = Graph()
 
@@ -81,7 +81,7 @@ A more extensive example:
     g.add( (donna, RDF.type, FOAF.Person]) )
     g.add( (donna, FOAF.nick, Literal("donna", lang="foo")) )
     g.add( (donna, FOAF.name, Literal("Donna Fales")) )
-	g.add( (donna, FOAF.mbox, URIRef("mailto:donna@example.org")) )
+    g.add( (donna, FOAF.mbox, URIRef("mailto:donna@example.org")) )
 
     # Iterate over triples in store and print them out.
     print("--- printing raw triples ---")


### PR DESCRIPTION
Two lines where using tabs instead of spaces, causing indentation to be wrong.
