### PR TITLE
Fix broken link to TriG syntax specification.

### DIFF
--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -1,6 +1,6 @@
 """
 Trig RDF graph serializer for RDFLib.
-See <http://www.w3.org/2010/01/Trig/Trig> for syntax specification.
+See <http://www.w3.org/TR/trig/> for syntax specification.
 """
 
 from collections import defaultdict


### PR DESCRIPTION
The link http://www.w3.org/2010/01/Trig/Trig in the comment is dead, I suggest to change it to the latest published W3C recommendation.
