### PR TITLE
Allows a graph to limit the number of results from a triple() operation

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -306,13 +306,13 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         results    
         
         ``
-        g.LIMIT = limit
-        g.OFFSET = offset
-        triple_generator = graph.triples(mytriple):
+        a_graph.LIMIT = limit
+        a_graph.OFFSET = offset
+        triple_generator = a_graph.triples(mytriple):
             #do something
         #Removes LIMIT and OFFSET if not required for the next triple() calls
-        del g.LIMIT        
-        del g.OFFSET
+        del a_graph.LIMIT        
+        del a_graph.OFFSET
         ``        
         """
 


### PR DESCRIPTION
I realized that in some situation the triples() method may return a huge number of results and if you are implementing something like 'paging' may be a critical performance issue.
Apart from more complicated solution as caching an easy, partial solution is to add a LIMIT, OFFSET and a necessary GROUP BY clauses to the SPARQLStore.triples(). Those parameters can be passed augmenting the Graph object, which is passes as 'context' to the triples method.
I implemented such solution with a few lines and I hope other may agree in this.

For example, using the LIMIT value is as easy as :

```
graph_instance.LIMIT = 10
graph_instance.OFFSET = 2 #retrieve the results from 20 to 30
# GROUP BY is done automatically on the first None of the triple, the subject in this case
graph_instance.triples((None, None, None))
```
