### PR TITLE
Bugfix manchestersyntax function for Virtuoso

### DIFF
--- a/rdflib/extras/infixowl.py
+++ b/rdflib/extras/infixowl.py
@@ -338,7 +338,7 @@ def manchesterSyntax(thing, store, boolean=None, transientList=False):
             ["PREFIX %s: <%s>" % (k, nsBinds[k]) for k in nsBinds])
         qstr = \
             prolog + \
-            "SELECT ?p ?bool WHERE {?class a owl:Class; ?p ?bool ." + \
+            "\nSELECT ?p ?bool WHERE {?class a owl:Class; ?p ?bool ." + \
             "?bool rdf:first ?foo }"
         initb = {Variable("?class"): thing}
         for boolProp, col in \


### PR DESCRIPTION
This adds a newline to the query when passing it to the triplestore.
Virtuoso did not like it without the newline, which resulted in "None" being returned and a whole list of stuff breaking...
