### PR TITLE
Skip SPARQLWrapper test if SPARQLWrapper is not installed

### DIFF
--- a/test/test_core_sparqlstore.py
+++ b/test/test_core_sparqlstore.py
@@ -1,4 +1,10 @@
 import unittest
+try:
+    import SPARQLWrapper
+except ImportError:
+    from nose.exc import SkipTest
+    raise SkipTest("SPARQLWrapper not installed")
+
 from rdflib.graph import Graph
 
 


### PR DESCRIPTION
Trying to package RDFLib 4.1.0 on Fedora, I ran into a blocker with this test.
SPARQLWrapper is not yet packaged for Fedora, and unlike other tests which are
skipped if SPARQLWrapper is not installed, this one throws a fatal error. So
let's skip it like the others.

Signed-off-by: Dan Scott dan@coffeecode.net
