### PR TITLE
Unpin html5lib 0.95 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,7 @@ else:
             kwargs['install_requires'].append('simplejson')
             kwargs['install_requires'].append('html5lib==0.95')
         else:
-            # 1.0b1 is broken - revert to no version when fixed
-            kwargs['install_requires'].append('html5lib==0.95') 
+            kwargs['install_requires'].append('html5lib') 
 
     except ImportError:
         from distutils.core import setup


### PR DESCRIPTION
Due to an html5lib regression (described in the thread at
https://groups.google.com/d/msg/rdflib-dev/ZcAgKzhS3vI/3mxIJz4rwWUJ) , we
opened https://github.com/html5lib/html5lib-python/issues/67 on June 17th, 2013
and pinned html5lib to 0.95 in setup.py. The bug was fixed and a new release of
html5lib (1.0b3) was cut on July 24, 2013. The current version of html5lib is
0.999; let's unpin that html5lib requirement.

Signed-off-by: Dan Scott dan@coffeecode.net
