### PR TITLE
if query result source has no encoding set, fall back to utf-8 encoding. resolves #344

### DIFF
--- a/rdflib/plugins/sparql/results/csvresults.py
+++ b/rdflib/plugins/sparql/results/csvresults.py
@@ -23,7 +23,10 @@ class CSVResultParser(ResultParser):
 
         r = Result('SELECT')
 
-        if hasattr(source, 'mode') and 'b' in source.mode:
+        if not hasattr(source, 'mode') or 'b' in source.mode and not getattr(source, 'encoding', None):
+            # if there is no mode, or source is in binary mode
+            # assume we need to decode from utf-8.
+            # if there is a mode set and it's not binary, check if source has encoding set.
             source = codecs.getreader('utf-8')(source)
 
         reader = csv.reader(source, delimiter=self.delim)

--- a/rdflib/plugins/sparql/results/tsvresults.py
+++ b/rdflib/plugins/sparql/results/tsvresults.py
@@ -40,7 +40,10 @@ HEADER.parseWithTabs()
 class TSVResultParser(ResultParser):
     def parse(self, source):
 
-        if hasattr(source, 'mode') and 'b' in source.mode:
+        if not hasattr(source, 'mode') or 'b' in source.mode and not getattr(source, 'encoding', None):
+            # if there is no mode, or source is in binary mode
+            # assume we need to decode from utf-8.
+            # if there is a mode set and it's not binary, check if source has encoding set.
             source = codecs.getreader('utf-8')(source)
 
         try:


### PR DESCRIPTION
It's a bit tricky to do this properly for python 2 and 3, but I think this patch goes into the right direction.

For later on I think rdflib should be clear about what source is, and what attributes, methods and return values are expected.

If that would be defined, then a user of the library would know when to wrap a source within a codec or not. 

cheers,
