### PR TITLE
Fix #371: Validation of quads at Graph.addN() doesn't work as expected

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -399,11 +399,10 @@ class Graph(Node):
     def addN(self, quads):
         """Add a sequence of triple with context"""
 
-        self.__store.addN((s, p, o, c) for s, p, o, c in quads
-                          if isinstance(c, Graph)
-                          and c.identifier is self.identifier
+        self.__store.addN([(s, p, o, c) for s, p, o, c in quads
+                          if isinstance(c, URIRef)
                           and _assertnode(s,p,o)
-                          )
+                          ])
 
     def remove(self, (s, p, o)):
         """Remove a triple from the graph

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -591,7 +591,7 @@ class SPARQLUpdateStore(SPARQLStore):
 
 
             triple = "%s %s %s ." % (subject.n3(), predicate.n3(), obj.n3())
-            data += "INSERT DATA { GRAPH <%s> { %s } }\n" % (
+            data += "INSERT DATA { GRAPH <%s> { %s } } ;\n" % (
                 context.identifier, triple)
         r = self._do_update(data)
         content = r.read()  # we expect no content


### PR DESCRIPTION
In addition to the validation issue (#371), a semicolon (;) sign is required at the end of each INSERT statement to separate them from each other.

Tested with OpenRDF 2.7.10.