### PR TITLE
Current version number &PyPI link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ or
 
     $ pip install rdflib
 
+Alternatively manually download the package from the Python Package
+Index (PyPI) at https://pypi.python.org/pypi/rdflib
+
+The current version of RDFLib is 4.1.2, see the ``CHANGELOG.md``
+file for what's new.
+
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
Since the `README.md` file serves as the project homepage, this information is useful to add.

Google points me at www.rdflib.net as the project home page. This points to Google Code (which has downloads for v2.4.2 and 3.2.0 downloads), and refers the read to GitHub: https://github.com/RDFLib - once on the GitHub organisation page, the only obvious place to go is the rdflib repository: https://github.com/RDFLib/rdflib

This shows the `README.md` file and this fails to mention the current release, and where to download it from. Judging from your PyPI page, the current release is 4.1.2 and can be downloaded from https://pypi.python.org/pypi/rdflib

It would have been easier to read this from the README file.
