### PR TITLE
xsd:hexBinary added to XSDToPython

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1435,6 +1435,7 @@ XSDToPython = {
     URIRef(_XSD_PFX + 'normalizedString'): None,
     URIRef(_XSD_PFX + 'token'): None,
     URIRef(_XSD_PFX + 'language'): None,
+    URIRef(_XSD_PFX + 'hexBinary'): None,
     URIRef(_XSD_PFX + 'boolean'): lambda i: i.lower() in ['1', 'true'],
     URIRef(_XSD_PFX + 'decimal'): Decimal,
     URIRef(_XSD_PFX + 'integer'): long,


### PR DESCRIPTION
Literal("b234", datatype=(XSD + "hexBinary")).toPython() now returns a string and not a literal.
