### PR TITLE
Literal.toPython() support for xsd:hexBinary

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -563,7 +563,7 @@ class Literal(Identifier):
                 datatype = lexical_or_value.datatype
                 value = lexical_or_value.value
 
-        elif isinstance(lexical_or_value, basestring):
+        elif isinstance(lexical_or_value, basestring) or (py3compat and isinstance(lexical_or_value, bytes)):
                 # passed a string
                 # try parsing lexical form of datatyped literal
                 value = _castLexicalToPython(lexical_or_value, datatype)

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -563,7 +563,7 @@ class Literal(Identifier):
                 datatype = lexical_or_value.datatype
                 value = lexical_or_value.value
 
-        elif isinstance(lexical_or_value, basestring) or (py3compat and isinstance(lexical_or_value, bytes)):
+        elif isinstance(lexical_or_value, basestring) or (py3compat.PY3 and isinstance(lexical_or_value, bytes)):
                 # passed a string
                 # try parsing lexical form of datatyped literal
                 value = _castLexicalToPython(lexical_or_value, datatype)
@@ -1317,6 +1317,13 @@ def _parseHTML(htmltext):
             " html5lib <http://code.google.com/p/html5lib>")
 
 
+def _unhexlify(value):
+    # In Python 3.2, unhexlify does not support str (only bytes)
+    if py3compat.PY3 and isinstance(value, str):
+        value = value.encode()
+    return unhexlify(value)
+
+
 def _writeXML(xmlnode):
     if isinstance(xmlnode, xml.dom.minidom.DocumentFragment):
         d = xml.dom.minidom.Document()
@@ -1447,7 +1454,7 @@ XSDToPython = {
     URIRef(_XSD_PFX + 'time'): parse_time,
     URIRef(_XSD_PFX + 'date'): parse_date,
     URIRef(_XSD_PFX + 'dateTime'): parse_datetime,
-    URIRef(_XSD_PFX + 'hexBinary'): unhexlify,
+    URIRef(_XSD_PFX + 'hexBinary'): _unhexlify,
     URIRef(_XSD_PFX + 'string'): None,
     URIRef(_XSD_PFX + 'normalizedString'): None,
     URIRef(_XSD_PFX + 'token'): None,

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -49,6 +49,7 @@ from re import sub, compile
 from collections import defaultdict
 
 from isodate import parse_time, parse_date, parse_datetime
+from binascii import hexlify, unhexlify
 
 
 try:
@@ -1352,6 +1353,8 @@ _XSD_DATETIME = URIRef(_XSD_PFX + 'dateTime')
 _XSD_DATE = URIRef(_XSD_PFX + 'date')
 _XSD_TIME = URIRef(_XSD_PFX + 'time')
 
+_XSD_HEXBINARY = URIRef(_XSD_PFX + 'hexBinary')
+
 # TODO: duration, gYearMonth, gYear, gMonthDay, gDay, gMonth
 
 _NUMERIC_LITERAL_TYPES = (
@@ -1417,6 +1420,8 @@ from decimal import Decimal
 # rather than some concrete bit-limited datatype
 
 _PythonToXSD = [
+    # Specific first
+    ((basestring, _XSD_HEXBINARY), (hexlify, _XSD_HEXBINARY)),
     ((basestring, None), (None, None)),
     ((float, None), (None, _XSD_DOUBLE)),
     ((bool, None), (lambda i:str(i).lower(), _XSD_BOOLEAN)),
@@ -1434,11 +1439,15 @@ _PythonToXSD = [
     ((xml.dom.minidom.DocumentFragment, None), (_writeXML, _RDF_HTMLLITERAL))
 ]
 
+if py3compat:
+    _PythonToXSD.insert(0, ((bytes, _XSD_HEXBINARY), (hexlify, _XSD_HEXBINARY)))
+
 XSDToPython = {
     None : None, # plain literals map directly to value space
     URIRef(_XSD_PFX + 'time'): parse_time,
     URIRef(_XSD_PFX + 'date'): parse_date,
     URIRef(_XSD_PFX + 'dateTime'): parse_datetime,
+    URIRef(_XSD_PFX + 'hexBinary'): unhexlify,
     URIRef(_XSD_PFX + 'string'): None,
     URIRef(_XSD_PFX + 'normalizedString'): None,
     URIRef(_XSD_PFX + 'token'): None,

--- a/test/test_hex_binary.py
+++ b/test/test_hex_binary.py
@@ -36,6 +36,14 @@ class HexBinaryTestCase(unittest.TestCase):
         self.assertEquals(b_str1.decode('utf-8'), str1)
         self.assertEquals(unicode(l1), hex_str1)
 
+        # b hexstring
+        hex_str1b = binascii.hexlify(str1.encode('utf-8'))
+        l1b = Literal(hex_str1b, datatype=XSD.hexBinary)
+        b_str1b = l1b.toPython()
+        self.assertEquals(b_str1, b_str1b)
+        self.assertEquals(b_str1b.decode('utf-8'), str1)
+        self.assertEquals(unicode(l1b), hex_str1)
 
+        
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_hex_binary.py
+++ b/test/test_hex_binary.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import binascii
+from rdflib import Literal, XSD
+
+class HexBinaryTestCase(unittest.TestCase):
+
+    def test_int(self):
+        self._test_integer(5)
+        self._test_integer(3452)
+        self._test_integer(4886)
+
+    def _test_integer(self, i):
+        hex_i = format(i, "x")
+        # Make it has a even-length (Byte)
+        len_hex_i = len(hex_i)
+        hex_i = hex_i.zfill(len_hex_i + len_hex_i % 2)
+
+        l = Literal(hex_i, datatype=XSD.hexBinary)
+        bin_i = l.toPython()
+        self.assertEquals(int(binascii.hexlify(bin_i), 16), i)
+
+        self.assertEquals(unicode(l), hex_i)
+        self.assertEquals(int(hex_i, 16), i)
+        self.assertEquals(int(unicode(l), 16), i)
+        self.assertEquals(int(str(l), 16), i)
+
+
+    def test_unicode(self):
+        str1 = u"Test utf-8 string éàë"
+        # u hexstring
+        hex_str1 = binascii.hexlify(str1.encode('utf-8')).decode()
+        l1 = Literal(hex_str1, datatype=XSD.hexBinary)
+        b_str1 = l1.toPython()
+        self.assertEquals(b_str1.decode('utf-8'), str1)
+        self.assertEquals(unicode(l1), hex_str1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -140,8 +140,29 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(lb.value,vb)
         self.assertEqual(lb.datatype, dtB)
 
+    def testSpecificBinding(self):
 
+        def lexify(s):
+            return "--%s--" % s
 
+        def unlexify(s):
+            return s[2:-2]
+
+        datatype = rdflib.URIRef('urn:dt:mystring')
+
+        #Datatype-specific rule
+        bind(datatype, basestring, unlexify, lexify, datatype_specific=True)
+
+        s = "Hello"
+        normal_l = Literal(s)
+        self.assertEqual(str(normal_l), s)
+        self.assertEqual(normal_l.toPython(), s)
+        self.assertEqual(normal_l.datatype, None)
+
+        specific_l = Literal("--%s--" % s, datatype=datatype)
+        self.assertEqual(str(specific_l), lexify(s))
+        self.assertEqual(specific_l.toPython(), s)
+        self.assertEqual(specific_l.datatype, datatype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following the discussion #386, here is an implementation of the bytes option, where `toPython()` returns a bytes value.
