### PR TITLE
SPARQL Update request expression should not depend on the store used by a basic named graph

### DIFF
--- a/requirements.py2.txt
+++ b/requirements.py2.txt
@@ -2,3 +2,4 @@ flake8
 isodate
 pyparsing<=1.5.7
 SPARQLWrapper
+ushlex

--- a/test/test_sparqlupdatestore.py
+++ b/test/test_sparqlupdatestore.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 from rdflib import ConjunctiveGraph, URIRef
 
 import unittest
@@ -174,6 +174,27 @@ class TestSparql11(unittest.TestCase):
             set([(bob, likes, pizza)]),
             'only bob likes pizza'
         )
+        says = URIRef("urn:says")
+        tricky_strs = ["With an unbalanced curly brace %s " % brace
+                       for brace in ["{", "}"]]
+
+        for tricky_str in tricky_strs:
+            r3 = """INSERT { ?b <urn:says> "%s" }
+            WHERE { ?b <urn:likes> <urn:pizza>} """ % tricky_str
+            g.update(r3)
+
+        values = set()
+        for v in g.objects(bob, says):
+            values.add(str(v))
+        self.assertEquals(values, set(tricky_strs))
+
+        bio = u"éï }"
+        r4 = u'INSERT DATA { <urn:michel> <urn:says> "%s" }' % bio
+        g.update(r4)
+        values = set()
+        for v in g.objects(michel, says):
+            values.add(unicode(v))
+        self.assertEquals(values, set([bio]))
 
     def testNamedGraphUpdateWithInitBindings(self):
         g = self.graph.get_context(graphuri)
@@ -184,8 +205,8 @@ class TestSparql11(unittest.TestCase):
                 'c': pizza
             })
         self.assertEquals(
-            set(g.triples((None,None,None))),
-            set([(michel,likes,pizza)]),
+            set(g.triples((None, None, None))),
+            set([(michel, likes, pizza)]),
             'only michel likes pizza'
         )
 


### PR DESCRIPTION
With the default `IOMemory` store, SPARQL update requests given to a basic named graph should not explicit the graph URI by using the GRAPH keyword:

``` python
>>> cg = ConjunctiveGraph()
>>> g = cg.get_context("urn:graph")
>>> g.update("INSERT DATA { <urn:bob> <urn:likes> <urn:pizza> }")
>>> set(g.triples((None, None, None))) == set([(URIRef("urn:bob"), URIRef("urn:likes"), URIRef("urn:pizza"))])
True
>>> g.update("INSERT DATA { GRAPH <urn:graph> { <urn:bob> <urn:likes> <urn:pizza> } }")
Exception: You performed a query operation requiring a dataset (i.e. ConjunctiveGraph), but operating currently on a single graph.
```

For me, this behavior is good and I would expect it to be the same when I use a `SPARQLUpdateStore`. However, in such a case, the first request update the default graph of the conjunctive graph but not the named graph. The second request is not rejected and produces the expected update:

``` python
>>> cg = ConjunctiveGraph(SPARQLUpdateStore(queryEndpoint="http://localhost:3030/test/query", update_endpoint="http://localhost:3030/test/update"))
>>> g = cg.get_context("urn:graph")
>>> g.update("INSERT DATA { <urn:bob> <urn:likes> <urn:pizza> }")
>>> set(g.triples((None, None, None))) == set([(URIRef("urn:bob"), URIRef("urn:likes"), URIRef("urn:pizza"))])
False
>>> g.update("INSERT DATA { GRAPH <urn:graph> { <urn:bob> <urn:likes> <urn:pizza> } }")
>>> set(g.triples((None, None, None))) == set([(URIRef("urn:bob"), URIRef("urn:likes"), URIRef("urn:pizza"))])
True
```

I propose a basic patch to align `SPARQLUpdateStore` with the default store.

One question remains: should we send an Exception when GRAPH is included in the request or just warn?
