### PR TITLE
SPARQLStore: Use SPARQLWrapper for updates 

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -610,7 +610,7 @@ class SPARQLUpdateStore(SPARQLStore):
         self.resetQuery()
         self.setQuery(update)
         self.setMethod(POST)
-        self.setUpdateMethod(URLENCODED if self.postAsEncoded else POSTDIRECTLY)
+        self.setRequestMethod(URLENCODED if self.postAsEncoded else POSTDIRECTLY)
 
         result = SPARQLWrapper.query(self)
         return result


### PR DESCRIPTION
SPARQLStore was using its own implementation to send SPARQL Update requests.
I modified it to use SPARQLWrapper's update mechanism as it already does for queries.

Remaining problems to sort out before merge:
- SPARQLWrapper does not allow to choose whether to send an update as `application/x-www-form-urlencoded` or as `application/sparql-update`. Since this has been possible with SPARQLStore, this currently breaks backwards compatibility of the API. See also RDFLib/sparqlwrapper/issues/28
- I would have liked to get rid of the classes `NSSPARQLWrapper` and `TraverseSPARQLResultDOM`, but SPARQLWrapper doesn't seem to have similar capabilies.

fixes #392
