### PR TITLE
Add percent (%) to _unquotedChars in RDFa 1.1. parser

### DIFF
--- a/rdflib/plugins/parsers/pyRdfa/utils.py
+++ b/rdflib/plugins/parsers/pyRdfa/utils.py
@@ -140,7 +140,7 @@ class URIOpener :
 
 # 'safe' characters for the URI quoting, ie, characters that can safely stay as they are. Other 
 # special characters are converted to their %.. equivalents for namespace prefixes
-_unquotedChars = ':/\?=#~'
+_unquotedChars = ':/\?=#~%'
 _warnChars     = [' ','\n','\r','\t']
 
 def quote_URI(uri, options = None) :


### PR DESCRIPTION
If the percent (%) character appears in a URI, the parser should not quote it, as this will lead to double quoted URIs that will no longer resolve. 

For instance:

The HTML page at :

http://link.springer.com/chapter/10.1007%2F978-3-642-25093-4_9

contains a link to an image:

http://link.springer.com/static-content/lookinside/613/chp%253A10.1007%252F978-3-642-25093-4_9/000.png

which becomes:

http://link.springer.com/static-content/lookinside/613/chp%25253A10.1007%25252F978-3-642-25093-4_9/000.png

in the resulting RDF graph. 

Adding the percent character to the _unquotedChars should fix this.
