### PR TITLE
URLInputSource Accept headers for json-ld format

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -88,6 +88,9 @@ class URLInputSource(InputSource):
             myheaders['Accept'] = 'text/n3, */*;q=0.1'
         elif format == 'nt':
             myheaders['Accept'] = 'text/plain, */*;q=0.1'
+        elif format == 'json-ld':
+            myheaders['Accept'] = (
+                'application/ld+json, application/json;p=0.9, */*;q=0.1')
         else:
             myheaders['Accept'] = (
                 'application/rdf+xml,text/rdf+n3;q=0.9,' +


### PR DESCRIPTION
Required by rdflib-jsonld to use http://schema.org context which requires fetching with `Accept: application/ld+json`
