### PR TITLE
Added trig unit tests to highlight some current parsing/serializing issues

### DIFF
--- a/test/test_trig.py
+++ b/test/test_trig.py
@@ -46,3 +46,72 @@ class TestTrig(unittest.TestCase):
         self.assertEqual(len(re.findall(b("p2"), s)), 1)
 
         self.assert_(b('{}') not in s) # no empty graphs!
+
+    def testGraphParsing(self):
+        # should parse into single default graph context
+        data = """
+<http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .
+"""
+        g = rdflib.ConjunctiveGraph()
+        g.parse(data=data, format='trig')
+        self.assertEqual(len(list(g.contexts())), 1)
+
+        # should parse into single default graph context
+        data = """
+<http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .
+
+{ <http://example.com/thing#thing_c> <http://example.com/knows> <http://example.com/thing#thing_d> . }
+"""
+        g = rdflib.ConjunctiveGraph()
+        g.parse(data=data, format='trig')
+        self.assertEqual(len(list(g.contexts())), 1)
+
+        # should parse into 2 contexts, one default, one named
+        data = """
+<http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .
+
+{ <http://example.com/thing#thing_c> <http://example.com/knows> <http://example.com/thing#thing_d> . }
+
+<http://example.com/graph#graph_a> {
+    <http://example.com/thing/thing_e> <http://example.com/knows> <http://example.com/thing#thing_f> .
+}
+"""
+        g = rdflib.ConjunctiveGraph()
+        g.parse(data=data, format='trig')
+        self.assertEqual(len(list(g.contexts())), 2)
+
+    def testRoundTrips(self):
+        data = """
+<http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .
+
+{ <http://example.com/thing#thing_c> <http://example.com/knows> <http://example.com/thing#thing_d> . }
+
+<http://example.com/graph#graph_a> {
+    <http://example.com/thing/thing_e> <http://example.com/knows> <http://example.com/thing#thing_f> .
+}
+"""
+        g = rdflib.ConjunctiveGraph()
+        for i in range(5):
+            g.parse(data=data, format='trig')
+            data = g.serialize(format='trig')
+
+        # output should only contain 1 mention of each resource/graph name
+        self.assertEqual(data.count('thing_a'), 1)
+        self.assertEqual(data.count('thing_b'), 1)
+        self.assertEqual(data.count('thing_c'), 1)
+        self.assertEqual(data.count('thing_d'), 1)
+        self.assertEqual(data.count('thing_e'), 1)
+        self.assertEqual(data.count('thing_f'), 1)
+        self.assertEqual(data.count('graph_a'), 1)
+
+    def testDefaultGraphSerializesWithoutName(self):
+        data = """
+<http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .
+
+{ <http://example.com/thing#thing_c> <http://example.com/knows> <http://example.com/thing#thing_d> . }
+"""
+        g = rdflib.ConjunctiveGraph()
+        g.parse(data=data, format='trig')
+        data = g.serialize(format='trig')
+
+        self.assertTrue('None' not in data)


### PR DESCRIPTION
This adds some TriG unit tests that currently fail (but should pass when issues are resolved).

`testGraphParsing` currently fails due to the TriG parser treating triples in the default graph with and without enclosing braces as 2 separate contexts, whereas they should both be treated as one.

`testRoundTrips` tests whether repeatedly parsing/serializing the same data results in a graph containing the same items.  Currently this fails due to a combination of the issue mentioned above, and due to an issue with handling QNames in the TriG serializer.

`testDefaultGraphSerializesWithoutName` checks that triples in the default graph are serialized correctly.  Currently this fails, as the default graph is serialized as `<None> { ... }`.

I'm planning to look into fixes for these, but thought adding some failing unit tests first would be more useful, in case anyone else wants to look at or fix them too.
