### PR TITLE
added support for nt in utf-8 encoding

### DIFF
--- a/rdflib/plugins/parsers/nt.py
+++ b/rdflib/plugins/parsers/nt.py
@@ -20,8 +20,8 @@ class NTParser(Parser):
     def __init__(self):
         super(NTParser, self).__init__()
 
-    def parse(self, source, sink, baseURI=None):
+    def parse(self, source, sink, baseURI=None, encoding="ascii"):
         f = source.getByteStream()  # TODO getCharacterStream?
         parser = NTriplesParser(NTSink(sink))
-        parser.parse(f)
+        parser.parse(f, encoding)
         f.close()

--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -10,7 +10,7 @@ from rdflib.term import URIRef as URI
 from rdflib.term import BNode as bNode
 from rdflib.term import Literal
 
-from rdflib.py3compat import cast_bytes, decodeUnicodeEscape, ascii
+from rdflib.py3compat import cast_bytes, decodeUnicodeEscape, ascii, utf8
 
 __all__ = ['unquote', 'uriquote', 'Sink', 'NTriplesParser']
 
@@ -120,12 +120,17 @@ class NTriplesParser(object):
         else:
             self.sink = Sink()
 
-    def parse(self, f):
+    def parse(self, f, encoding="ascii"):
         """Parse f as an N-Triples file."""
         if not hasattr(f, 'read'):
             raise ParseError("Item to parse must be a file-like object.")
 
-        f = ascii(f)
+        if encoding == "ascii":
+            f = ascii(f)
+        elif encoding == "utf-8":
+            f = utf8(f)
+        else:
+            raise ParseError("Invalid encoding: %s" % encoding)
 
         self.file = f
         self.buffer = ''

--- a/rdflib/py3compat.py
+++ b/rdflib/py3compat.py
@@ -108,6 +108,9 @@ else:
     def ascii(stream):
         return stream
 
+    def utf8(stream):
+        return stream
+
     bopen = open
 
     bytestype = str

--- a/rdflib/py3compat.py
+++ b/rdflib/py3compat.py
@@ -52,6 +52,9 @@ if PY3:
     def ascii(stream):
         return codecs.getreader('ascii')(stream)
 
+    def utf8(stream):
+        return codecs.getreader('utf-8')(stream)
+
     def bopen(*args, **kwargs):
         return open(*args, mode = 'rb', **kwargs)
 


### PR DESCRIPTION
By default it will work like previously but now you can add encoding parameter when parsing file

### usage

g is standard Graph
`g = rdflib.Graph()`

old syntax
`result = g.parse( 'c:\\sample_ascii_file.nt', format="nt") # still works`

new syntax
`result = g.parse( 'c:\\sample_unicode_file.nt', format="nt", encoding="utf-8")`