### PR TITLE
Bugfix: term.Literal.__add__

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -655,7 +655,7 @@ class Literal(Identifier):
             except TypeError:
                 pass  # fall-through
 
-        s = unicode.__add__(self, val)
+        s = py + val.toPython()
         return Literal(s, self.language, self.datatype)
 
     def __nonzero__(self):


### PR DESCRIPTION
As long as Literal(1) is internaly casted by int, Literal(1) + Literal(1) may return Literal(2) instead of Literal('11').
