### PR TITLE
Decoding errors on escaped Unicode string in test for narrow build python

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -303,7 +303,7 @@ escapeChars = "(_~.-!$&'()*+,;=/?#@%)" # valid for \ escapes in localnames
 
 def unicodeExpand(m):
     try:
-        return unichr(int(m.group(1), 16))
+        return codecs.decode(m.group(0), 'unicode_escape')
     except:
         raise Exception("Invalid unicode code point: " + m.group(1))
 

--- a/rdflib/py3compat.py
+++ b/rdflib/py3compat.py
@@ -138,7 +138,7 @@ else:
 r_unicodeEscape = re.compile(r'(\\u[0-9A-Fa-f]{4}|\\U[0-9A-Fa-f]{8})')
 
 def _unicodeExpand(s):
-    return r_unicodeEscape.sub(lambda m: unichr(int(m.group(0)[2:], 16)), s)
+    return r_unicodeEscape.sub(lambda m: codecs.decode(m.group(0), 'unicode_escape'), s)
 
 def decodeStringEscape(s):
 


### PR DESCRIPTION
Running the tests on a narrow build of python 2.7 (for example OSX python version) reveal a list of unicode decoding errors on unicode escaped string such as:

```
======================================================================
ERROR: test.test_trig_w3c.test_trig(RDFTest(uri=rdflib.term.URIRef(u'https://dvcs.w3.org/hg/rdf/raw-file/default/trig/tests/manifest.ttl#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries'), name=u'localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries', comment=u'localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZaz\xc0\xd6\xd8\xf6\xf8...)', data=None, graphdata=None, action=u'file:///Users/ymh/dev/projects/rdflib/test/w3c/trig/localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.trig', result=rdflib.term.URIRef(u'file:///Users/ymh/dev/projects/rdflib/test/w3c/trig/localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.nq'), syntax=True),)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ymh/dev/venvs/rdflib/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/ymh/dev/projects/rdflib/test/test_trig_w3c.py", line 26, in trig
    res.parse(test.result, format='nquads')
  File "/Users/ymh/dev/projects/rdflib/rdflib/graph.py", line 1460, in parse
    location=location, file=file, data=data, **args)
  File "/Users/ymh/dev/projects/rdflib/rdflib/graph.py", line 1033, in parse
    parser.parse(source, self, **args)
  File "/Users/ymh/dev/projects/rdflib/rdflib/plugins/parsers/nquads.py", line 64, in parse
    self.parseline()
  File "/Users/ymh/dev/projects/rdflib/rdflib/plugins/parsers/nquads.py", line 81, in parseline
    obj = self.object()
  File "/Users/ymh/dev/projects/rdflib/rdflib/plugins/parsers/ntriples.py", line 228, in object
    objt = self.uriref() or self.nodeid() or self.literal()
  File "/Users/ymh/dev/projects/rdflib/rdflib/plugins/parsers/ntriples.py", line 236, in uriref
    uri = unquote(uri)
  File "/Users/ymh/dev/projects/rdflib/rdflib/plugins/parsers/ntriples.py", line 63, in unquote
    s = decodeUnicodeEscape(s)
  File "/Users/ymh/dev/projects/rdflib/rdflib/py3compat.py", line 171, in decodeUnicodeEscape
    s = _unicodeExpand(s)
  File "/Users/ymh/dev/projects/rdflib/rdflib/py3compat.py", line 141, in _unicodeExpand
    return r_unicodeEscape.sub(lambda m: unichr(int(m.group(0)[2:], 16)), s)
  File "/Users/ymh/dev/projects/rdflib/rdflib/py3compat.py", line 141, in <lambda>
    return r_unicodeEscape.sub(lambda m: unichr(int(m.group(0)[2:], 16)), s)
ValueError: unichr() arg not in range(0x10000) (narrow Python build)
```

There is currently 15 errors of the same kind apparently affecting code in `rdflib/py3compat.py` (line 141) and `rdflib/plugins/parsers/notation3.py` (lines 1594 and 308)
These errors are not observed for python 3.4.