### PR TITLE
slight performance increase for graph.all_nodes()

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1163,9 +1163,9 @@ class Graph(Node):
             return False
 
     def all_nodes(self):
-        obj = set(self.objects())
-        allNodes = obj.union(set(self.subjects()))
-        return allNodes
+        res = set(self.objects())
+        res.update(self.subjects())
+        return res
 
     def resource(self, identifier):
         """Create a new ``Resource`` instance.


### PR DESCRIPTION
set.update() seems to be faster than union and we can save the set
creation overhead:

```python
In [1]: %timeit s = set(range(1000)) ; s.update(range(10000))
1000 loops, best of 3: 419 µs per loop

In [2]: %timeit s = set(range(1000)) ; s.update(set(range(10000)))
1000 loops, best of 3: 584 µs per loop

In [3]: %timeit s = set(range(1000)) ; s.union(set(range(10000)))
1000 loops, best of 3: 610 µs per loop
```