### PR TITLE
Variable.__repr__ should return a python representation string, not n3

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1527,7 +1527,12 @@ class Variable(Identifier):
         return unicode.__new__(cls, value)
 
     def __repr__(self):
-        return self.n3()
+        if self.__class__ is Variable:
+            clsName = "rdflib.term.Variable"
+        else:
+            clsName = self.__class__.__name__
+
+        return """%s(%s)""" % (clsName, super(Variable, self).__repr__())
 
     def toPython(self):
         return "?%s" % self


### PR DESCRIPTION
For other terms like `URIRef`, `Literal` and `BNodes` we return a
`repr` string that is a string representation of the term and allows
re-creating the object when passed to `eval`. Variable isn't that
consistent it seems:

```python
In [1]: import rdflib
INFO:rdflib:RDFLib Version: 4.2.1-dev

In [2]: eval(repr(rdflib.term.URIRef('foo')))
Out[2]: rdflib.term.URIRef(u'foo')

In [3]: eval(repr(rdflib.term.Variable('foo')))
  File "<string>", line 1
    ?foo
    ^
SyntaxError: invalid syntax
```

https://docs.python.org/2/library/functions.html#func-repr doesn't
really enforce this, but it's nice to have for debugging for example.

This commit returns a repr like `rdflib.term.Variable('foo')`.