### PR TITLE
SPARQLStore customizable BNode handling

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -240,6 +240,12 @@ class SPARQLStore(NSSPARQLWrapper, Store):
             endpoint, returnFormat=XML, **sparqlwrapper_kwargs)
         self.setUseKeepAlive()
         self.bNodeAsURI = bNodeAsURI
+        if bNodeAsURI:
+            warnings.warn(
+                "bNodeAsURI argument was never supported and will be dropped "
+                "in favor of node_to_sparql and node_from_result args.",
+                category=DeprecationWarning,
+            )
         self.node_to_sparql = node_to_sparql
         self.node_from_result = node_from_result
         self.nsBindings = {}

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -98,8 +98,8 @@ def _node_from_result(node):
     elif node.tag == '{%s}literal' % SPARQL_NS:
         value = node.text if node.text is not None else ''
         if 'datatype' in node.attrib:
-            dT = URIRef(node.attrib['datatype'])
-            return Literal(value, datatype=dT)
+            dt = URIRef(node.attrib['datatype'])
+            return Literal(value, datatype=dt)
         elif '{http://www.w3.org/XML/1998/namespace}lang' in node.attrib:
             return Literal(value, lang=node.attrib[
                 "{http://www.w3.org/XML/1998/namespace}lang"])
@@ -602,25 +602,25 @@ class SPARQLUpdateStore(SPARQLStore):
         self.autocommit = autocommit
         self._edits = None
 
-    def query(self,*args, **kwargs):
+    def query(self, *args, **kwargs):
         if not self.autocommit:
             self.commit()
-        return SPARQLStore.query(self,*args, **kwargs)
-	
-    def triples(self,*args, **kwargs):
+        return SPARQLStore.query(self, *args, **kwargs)
+
+    def triples(self, *args, **kwargs):
         if not self.autocommit:
             self.commit()
-        return SPARQLStore.triples(self,*args, **kwargs)
-	
-    def contexts(self,*args, **kwargs):
+        return SPARQLStore.triples(self, *args, **kwargs)
+
+    def contexts(self, *args, **kwargs):
         if not self.autocommit:
             self.commit()
-        return SPARQLStore.contexts(self,*args, **kwargs)
-	
-    def __len__(self,*args, **kwargs):
+        return SPARQLStore.contexts(self, *args, **kwargs)
+
+    def __len__(self, *args, **kwargs):
         if not self.autocommit:
             self.commit()
-        return SPARQLStore.__len__(self,*args, **kwargs)
+        return SPARQLStore.__len__(self, *args, **kwargs)
 
     def open(self, configuration, create=False):
         """
@@ -644,7 +644,7 @@ class SPARQLUpdateStore(SPARQLStore):
             self.updateEndpoint = self.endpoint
 
     def _transaction(self):
-        if self._edits == None:
+        if self._edits is None:
             self._edits = []
         return self._edits
 
@@ -657,14 +657,14 @@ class SPARQLUpdateStore(SPARQLStore):
     update_endpoint = property(
         __get_update_endpoint,
         __set_update_endpoint,
-        doc='the HTTP URL for the Update endpoint, typically' +
+        doc='the HTTP URL for the Update endpoint, typically '
             'something like http://server/dataset/update')
 
     # Transactional interfaces
     def commit(self):
-        """ add(), addN(), and remove() are transactional to reduce overhead of many small edits. 
-            Read and update() calls will automatically commit any outstanding edits. 
-            This should behave as expected most of the time, except that alternating writes 
+        """ add(), addN(), and remove() are transactional to reduce overhead of many small edits.
+            Read and update() calls will automatically commit any outstanding edits.
+            This should behave as expected most of the time, except that alternating writes
             and reads can degenerate to the original call-per-triple situation that originally existed.
         """
         if self._edits and len(self._edits) > 0:

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -532,7 +532,7 @@ class SPARQLUpdateStore(SPARQLStore):
 
     """
 
-    where_pattern = re.compile(r"""(?P<where>WHERE\s*{)""", re.IGNORECASE)
+    where_pattern = re.compile(r"""(?P<where>WHERE\s*\{)""", re.IGNORECASE)
 
     ##################################################################
     ### Regex for injecting GRAPH blocks into updates on a context ###


### PR DESCRIPTION
this implements the discussion in #512

- [x] deprecates `CastToTerm`, `TraverseSPARQLResultDOM` and `localName` methods
- [x] deprecates `SPARQLStore(..., bNodeAsURI)` argument
- [x] adds two `SPARQLStore(..., node_to_sparql, node_from_result)` args to customize node transformations
- [x] added a doc example how to transform `BNodes`
- [x] several code cleanups

please check