### PR TITLE
enable all warnings during travis nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ script:
     # Must run the tests in build/src so python3 doesn't get confused and run
     # the python2 code from the current directory instead of the installed
     # 2to3 version in build/src.
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib ; fi
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=build/src/rdflib --where=./build/src; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then PYTHONWARNINGS=always nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib ; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then PYTHONWARNINGS=always nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=build/src/rdflib --where=./build/src; fi
 
 after_success:
     - if [[ $HAS_COVERALLS ]] ; then coveralls ; fi


### PR DESCRIPTION
enabled all warnings so they are shown during nosetests run by travis... would've helped to spot ce3a871115559880f3f7ca139b6430a9be113ef0 in advance