### PR TITLE
Reduce amount of warnings, especially closing opened file pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ script:
     # Must run the tests in build/src so python3 doesn't get confused and run
     # the python2 code from the current directory instead of the installed
     # 2to3 version in build/src.
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then PYTHONWARNINGS=always nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib ; fi
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then PYTHONWARNINGS=always nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=build/src/rdflib --where=./build/src; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib ; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=build/src/rdflib --where=./build/src; fi
 
 after_success:
     - if [[ $HAS_COVERALLS ]] ; then coveralls ; fi

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1015,8 +1015,8 @@ class Graph(Node):
         2
 
         >>> g = Graph()
-        >>> result = g.parse(file=open(file_name, "r"),
-        ...     format="application/rdf+xml")
+        >>> with open(file_name, "r") as f:
+        ...     result = g.parse(f, format="application/rdf+xml")
         >>> len(g)
         2
 
@@ -1034,7 +1034,11 @@ class Graph(Node):
             # "expicitly specify one with the format argument." % source)
             format = "application/rdf+xml"
         parser = plugin.get(format, Parser)()
-        parser.parse(source, self, **args)
+        try:
+            parser.parse(source, self, **args)
+        finally:
+            if source.auto_close:
+                source.close()
         return self
 
     def load(self, source, publicID=None, format="xml"):

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1464,8 +1464,7 @@ class ConjunctiveGraph(Graph):
 
         context = Graph(store=self.store, identifier=g_id)
         context.remove((None, None, None)) # hmm ?
-        context.parse(source, publicID=publicID, format=format,
-                      location=location, file=file, data=data, **args)
+        context.parse(source, publicID=publicID, format=format, **args)
         return context
 
     def __reduce__(self):

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -49,6 +49,12 @@ class InputSource(xmlreader.InputSource, object):
     def __init__(self, system_id=None):
         xmlreader.InputSource.__init__(self, system_id=system_id)
         self.content_type = None
+        self.auto_close = False  # see Graph.parse(), true if opened by us
+
+    def close(self):
+        f = self.getByteStream()
+        if f and hasattr(f, 'close'):
+            f.close()
 
 
 class StringInputSource(InputSource):
@@ -158,6 +164,7 @@ def create_input_source(source=None, publicID=None,
 
     absolute_location = None  # Further to fix for issue 130
 
+    auto_close = False  # make sure we close all file handles we open
     if location is not None:
         # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
         if os.path.exists(location):
@@ -169,6 +176,7 @@ def create_input_source(source=None, publicID=None,
             file = open(filename, "rb")
         else:
             input_source = URLInputSource(absolute_location, format)
+        auto_close = True
         # publicID = publicID or absolute_location  # Further to fix
                                                     # for issue 130
 
@@ -179,10 +187,12 @@ def create_input_source(source=None, publicID=None,
         if isinstance(data, unicode):
             data = data.encode('utf-8')
         input_source = StringInputSource(data)
+        auto_close = True
 
     if input_source is None:
         raise Exception("could not create InputSource")
     else:
+        input_source.auto_close |= auto_close
         if publicID is not None:  # Further to fix for issue 130
             input_source.setPublicId(publicID)
         # Further to fix for issue 130

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -139,8 +139,16 @@ def create_input_source(source=None, publicID=None,
     parameters.
     """
 
-    # TODO: test that exactly one of source, location, file, and data
-    # is not None.
+    # test that exactly one of source, location, file, and data is not None.
+    if sum((
+        source is not None,
+        location is not None,
+        file is not None,
+        data is not None,
+    )) != 1:
+        raise ValueError(
+            'exactly one of source, location, file or data must be given'
+        )
 
     input_source = None
 

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -316,7 +316,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
 
         self.resetQuery()
         if self._is_contextual(queryGraph):
-            self.addDefaultGraph(queryGraph)
+            self.addParameter("default-graph-uri", queryGraph)
         self.setQuery(query)
 
         return Result.parse(SPARQLWrapper.query(self).response)
@@ -403,7 +403,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
 
         self.resetQuery()
         if self._is_contextual(context):
-            self.addDefaultGraph(context.identifier)
+            self.addParameter("default-graph-uri", context.identifier)
         self.setQuery(query)
 
         doc = ElementTree.parse(SPARQLWrapper.query(self).response)
@@ -435,7 +435,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
             self.resetQuery()
             q = "SELECT (count(*) as ?c) WHERE {?s ?p ?o .}"
             if self._is_contextual(context):
-                self.addDefaultGraph(context.identifier)
+                self.addParameter("default-graph-uri", context.identifier)
             self.setQuery(q)
             doc = ElementTree.parse(SPARQLWrapper.query(self).response)
             rt, vars = iter(

--- a/test/rdfa/run_w3c_rdfa_testsuite.py
+++ b/test/rdfa/run_w3c_rdfa_testsuite.py
@@ -59,7 +59,8 @@ def run_tc(tc):
     graph = Graph()
     source = create_input_source(cached_file(tc.html_url), publicID=tc.html_url)
     parser.parse(source, graph)
-    sparql = open(cached_file(tc.sparql_url)).read()
+    with open(cached_file(tc.sparql_url)) as sparql_f:
+        sparql = sparql_f.read()
     ok = verify_ask(sparql, graph, tc.expected)
     return ok, sparql, graph
 
@@ -103,11 +104,10 @@ def cached_file(url):
     fname = os.path.basename(url2pathname(url.split(':', 1)[1]))
     fpath = os.path.join(CACHE_DIR, fname)
     if not os.path.exists(fpath):
-        f = open(fpath, 'w')
-        try:
-            f.write(urlopen(url).read())
-        finally:
-            f.close()
+        with open(fpath, 'w') as f:
+            furl = urlopen(url)
+            f.write(furl.read())
+            furl.close()
     return fpath
 
 
@@ -148,7 +148,7 @@ def manual_run():
         count += 1
         print(test.description)
         try:
-            test() 
+            test()
             print "PASSED"
         except AssertionError, e:
             failed += 1

--- a/test/test_empty_xml_base.py
+++ b/test/test_empty_xml_base.py
@@ -1,7 +1,7 @@
 """
 Test for empty xml:base values
 
-xml:base='' should resolve to the given publicID per XML Base specification 
+xml:base='' should resolve to the given publicID per XML Base specification
 and RDF/XML dependence on it
 """
 
@@ -15,7 +15,7 @@ import unittest
 FOAF = Namespace('http://xmlns.com/foaf/0.1/')
 
 test_data = """
-<rdf:RDF 
+<rdf:RDF
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xml:base="">
@@ -25,7 +25,7 @@ test_data = """
 </rdf:RDF>"""
 
 test_data2 = """
-<rdf:RDF 
+<rdf:RDF
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xml:base="../">
@@ -43,19 +43,19 @@ class TestEmptyBase(unittest.TestCase):
         self.graph = ConjunctiveGraph()
         self.graph.parse(StringIO(test_data),publicID=baseUri)
 
-    def test_base_ref(self):        
-        self.failUnless(len(self.graph) == 1,"There should be at least one statement in the graph")
-        self.failUnless((baseUri,RDF.type,FOAF.Document) in self.graph,"There should be a triple with %s as the subject" % baseUri)
+    def test_base_ref(self):
+        self.assertTrue(len(self.graph) == 1,"There should be at least one statement in the graph")
+        self.assertTrue((baseUri,RDF.type,FOAF.Document) in self.graph,"There should be a triple with %s as the subject" % baseUri)
 
 class TestRelativeBase(unittest.TestCase):
     def setUp(self):
         self.graph = ConjunctiveGraph()
         self.graph.parse(StringIO(test_data2),publicID=baseUri2)
 
-    def test_base_ref(self):        
-        self.failUnless(len(self.graph) == 1,"There should be at least one statement in the graph")
+    def test_base_ref(self):
+        self.assertTrue(len(self.graph) == 1,"There should be at least one statement in the graph")
         resolvedBase = URIRef('http://example.com/baz')
-        self.failUnless((resolvedBase,RDF.type,FOAF.Document) in self.graph,"There should be a triple with %s as the subject" % resolvedBase)
+        self.assertTrue((resolvedBase,RDF.type,FOAF.Document) in self.graph,"There should be a triple with %s as the subject" % resolvedBase)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -6,14 +6,6 @@ from rdflib.py3compat import format_doctest_out as uformat
 
 # these are actually meant for test_term.py, which is not yet merged into trunk
 
-class TestMd5(unittest.TestCase):
-    def testMd5(self):
-        self.assertEqual(rdflib.URIRef("http://example.com/").md5_term_hash(),
-                         "40f2c9c20cc0c7716fb576031cceafa4")
-        self.assertEqual(rdflib.Literal("foo").md5_term_hash(),
-                         "da9954ca5f673f8ab9ebd6faf23d1046")
-    
-
 class TestLiteral(unittest.TestCase):
     def setUp(self):
         pass

--- a/test/test_nquads.py
+++ b/test/test_nquads.py
@@ -8,8 +8,8 @@ class NQuadsParserTest(unittest.TestCase):
 
     def _load_example(self):
         g = ConjunctiveGraph()
-        data = open("test/nquads.rdflib/example.nquads", "rb")
-        g.parse(data, format="nquads")
+        with open("test/nquads.rdflib/example.nquads", "rb") as data:
+            g.parse(data, format="nquads")
         return g
 
     def test_01_simple_open(self):
@@ -37,8 +37,8 @@ class NQuadsParserTest(unittest.TestCase):
 
     def test_context_is_optional(self):
         g = ConjunctiveGraph()
-        data = open("test/nquads.rdflib/test6.nq", "rb")
-        g.parse(data, format="nquads")
+        with open("test/nquads.rdflib/test6.nq", "rb") as data:
+            g.parse(data, format="nquads")
         assert len(g) > 0
 
     def test_serialize(self):

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -75,7 +75,8 @@ class NTTestCase(unittest.TestCase):
         data = 3
         self.assertRaises(ntriples.ParseError, p.parsestring, data)
         fname = "test/nt/lists-02.nt"
-        data = open(fname, 'r').read()
+        with open(fname, 'r') as f:
+            data = f.read()
         p = ntriples.NTriplesParser()
         res = p.parsestring(data)
         self.assert_(res == None)


### PR DESCRIPTION
after enabling warnings in our test runs in #517 it seems as if there is a huge amount of warning output cause we have deprecation warnings and don't really care to close files we open

see
- https://travis-ci.org/RDFLib/rdflib/jobs/77465398
- https://travis-ci.org/RDFLib/rdflib/jobs/77465400

fixes:
- plugins/stores/sparqlstore.py:438 DeprecationWarning: Call to deprecated function addDefaultGraph.
- test/test_empty_xml_base.py:47: PendingDeprecationWarning: Please use assertTrue instead.
- py3: thousands of unclosed file warnings:
  - `Graph.parse()` now takes care that if it opens files it also closes them
  - `ConjunctiveGraph.parse()` takes care not to double open source via args passed to `Graph.parse()`
  - many files opened in tests closed as well