### PR TITLE
Exposed the timeout of SPARQLWrapper

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -319,9 +319,11 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                 % (" ".join("?" + str(x) for x in v),
                    " ".join(initBindings[x].n3() for x in v))
 
+        timeout = self.timeout
         self.resetQuery()
         if self._is_contextual(queryGraph):
             self.addParameter("default-graph-uri", queryGraph)
+        self.setTimeout(timeout)
         self.setQuery(query)
 
         return Result.parse(SPARQLWrapper.query(self).response)
@@ -406,9 +408,11 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         except (ValueError, TypeError, AttributeError):
             pass
 
+        timeout = self.timeout
         self.resetQuery()
         if self._is_contextual(context):
             self.addParameter("default-graph-uri", context.identifier)
+        self.setTimeout(timeout)
         self.setQuery(query)
 
         doc = ElementTree.parse(SPARQLWrapper.query(self).response)

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -741,9 +741,11 @@ class SPARQLUpdateStore(SPARQLStore):
             self.commit()
 
     def _do_update(self, update):
+        timeout = self.timeout
         self.resetQuery()
         self.setQuery(update)
         self.setMethod(POST)
+        self.setTimeout(timeout)
         self.setRequestMethod(URLENCODED if self.postAsEncoded else POSTDIRECTLY)
 
         result = SPARQLWrapper.query(self)


### PR DESCRIPTION
I want to set a timeout on the connection in SPARQLStore. I can cause `sendall()` in the underlying socket object to timeout through SPARQLWrapper, but SPARQLUpdateStore resets the timeout to 0. This change keeps the timeout in-between updates.

Background:
I have been doing some experiments with sending SPARQL updates of increasing size and hit a limit where the underlying socket in the SPARQLUpdateStore is blocking in `sendall()`. I check with `netstat` and see the state of the connection is "CLOSE_WAIT", so the remote endpoint closed the connection. It seems like `sendall()` should return here; not sure.