### PR TITLE
Avoid verbose build logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def setup_python3():
     # Not covered by "setup.py clean --all", so explicit deletion required.
     if exists(tmp_src):
         dir_util.remove_tree(tmp_src)
-    log.set_verbosity(1)
+    # log.set_verbosity(1)
     fl = FileList()
     for line in open("MANIFEST.in"):
         if not line.strip():


### PR DESCRIPTION
For systems that install many packages, very verbose logging for a particular package is a pain when tracking down build errors from other packages.

This removes almost 5000 lines of logs from a standard python3 build.