### PR TITLE
fixed issue #535

### DIFF
--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -45,7 +45,7 @@ class NQuadsParser(NTriplesParser):
         """Parse f as an N-Triples file."""
         assert sink.store.context_aware, ("NQuadsParser must be given"
                                           " a context aware store.")
-        self.sink = ConjunctiveGraph(store=sink.store)
+        self.sink = ConjunctiveGraph(store=sink.store, identifier=sink.identifier)
 
         source = inputsource.getByteStream()
 
@@ -81,7 +81,7 @@ class NQuadsParser(NTriplesParser):
         obj = self.object()
         self.eat(r_wspace)
 
-        context = self.uriref() or self.nodeid()
+        context = self.uriref() or self.nodeid() or self.sink.identifier
         self.eat(r_tail)
 
         if self.line:

--- a/test/test_issue535.py
+++ b/test/test_issue535.py
@@ -4,14 +4,15 @@ from rdflib.parser import StringInputSource
 def test_nquads_default_graph():
     ds = ConjunctiveGraph()
 
-    src = StringInputSource("""
+    data = """
     <http://example.org/s1> <http://example.org/p1> <http://example.org/o1> .
     <http://example.org/s2> <http://example.org/p2> <http://example.org/o2> .
     <http://example.org/s3> <http://example.org/p3> <http://example.org/o3> <http://example.org/g3> .
-    """)
+    """
 
     publicID = URIRef("http://example.org/g0")
-    ds.parse(src, format="nquads", publicID=publicID)
+    
+    ds.parse(data=data, format="nquads", publicID=publicID)
 
     assert len(ds) == 3, len(g)
     assert len(list(ds.contexts())) == 2, len(list(ds.contexts()))

--- a/test/test_issue535.py
+++ b/test/test_issue535.py
@@ -1,0 +1,18 @@
+from rdflib import ConjunctiveGraph, URIRef
+from rdflib.parser import StringInputSource
+
+def test_nquads_default_graph():
+    ds = ConjunctiveGraph()
+
+    src = StringInputSource("""
+    <http://example.org/s1> <http://example.org/p1> <http://example.org/o1> .
+    <http://example.org/s2> <http://example.org/p2> <http://example.org/o2> .
+    <http://example.org/s3> <http://example.org/p3> <http://example.org/o3> <http://example.org/g3> .
+    """)
+
+    publicID = URIRef("http://example.org/g0")
+    ds.parse(src, format="nquads", publicID=publicID)
+
+    assert len(ds) == 3, len(g)
+    assert len(list(ds.contexts())) == 2, len(list(ds.contexts()))
+    assert len(ds.get_context(publicID)) == 2, len(ds.get_context(publicID))


### PR DESCRIPTION
I had to make a choice in how this issue was fixed:
I decided that the "default graph" for the parser was the one identified by the publicID passed to the ``parse`` method, which seems to make sense.