### PR TITLE
Small but nice SPARQL Optimisation fix

### DIFF
--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -214,7 +214,11 @@ def evalPart(ctx, part):
             pass  # the given custome-function did not handle this part
 
     if part.name == 'BGP':
-        return evalBGP(ctx, part.triples)  # NOTE pass part.triples, not part!
+        # Reorder triples patterns by number of bound nodes in the current ctx
+        # Do patterns with more bound nodes first
+        triples = sorted(part.triples, key=lambda t: len([n for n in t if ctx[n] is None]))
+
+        return evalBGP(ctx, triples)
     elif part.name == 'Filter':
         return evalFilter(ctx, part)
     elif part.name == 'Join':


### PR DESCRIPTION
This reorders the triples in a BGP while evaluating, so that the "most
bound" triples are evaluated first. The algebra transformation also does
this, but "statically", i.e. without looking at the data.

At runtime, we may have bindings from other places
(BIND/VALUES/initBindings) which can massively improve query time.

In a BerkelyDB store with ~250k triples, I had a query with two triples
patterns that retrieved 38 out of 25000 possible matching triples with a
particular property. Adding this fix brought query time from 8s to
800ms.