### PR TITLE
fix double reduction of \ escapes in from_n3

### DIFF
--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -177,7 +177,7 @@ def from_n3(s, default=None, backend=None, nsm=None):
             if rest.startswith("@"):
                 language = rest[1:]  # strip leading at sign
 
-        value = value.replace(r'\"', '"').replace('\\\\', '\\')
+        value = value.replace(r'\"', '"')
         # Hack: this should correctly handle strings with either native unicode
         # characters, or \u1234 unicode escapes.
         value = value.encode("raw-unicode-escape").decode("unicode-escape")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -223,6 +223,12 @@ class TestUtilTermConvert(unittest.TestCase):
         s = '"\\""'
         res = util.from_n3(s, default=None, backend=None)
         self.assert_(res, Literal('\\"', lang='en'))
+
+    def test_util_from_n3_expectliteralwithtrailingbackslash(self):
+        s = '"trailing\\\\"^^<http://www.w3.org/2001/XMLSchema#string>'
+        res = util.from_n3(s)
+        self.assert_(res, Literal('trailing\\', datatype=XSD['string']))
+        self.assert_(res.n3(), s)
     
     def test_util_from_n3_expectpartialidempotencewithn3(self):
         for n3 in ('<http://ex.com/foo>',


### PR DESCRIPTION
quick fixes #546 but leaves erroneous `\xhh` escaping in place