### PR TITLE
prepared quey now carry the original (unparsed) parameters

### DIFF
--- a/rdflib/plugins/sparql/processor.py
+++ b/rdflib/plugins/sparql/processor.py
@@ -22,7 +22,9 @@ def prepareQuery(queryString, initNs={}, base=None):
     """
     Parse and translate a SPARQL Query
     """
-    return translateQuery(parseQuery(queryString), base, initNs)
+    ret = translateQuery(parseQuery(queryString), base, initNs)
+    ret.original_args = (queryString, initNs, base)
+    return ret
 
 
 def processUpdate(graph, updateString, initBindings={}, initNs={}, base=None):


### PR DESCRIPTION
Here is my use case: I use prepareQuery in my code when a query is used several times. It looks like this:
```python
# some module
from rdflib.plugins.sparql.processor import prepareQuery
Q = prepareQuery("SELECT * { ?x <http://example.org/prop> ?y }")

def get_y(graph, x):
    return graph.query(Q, initBindings={"x": x})
```
This saves some time by parsing the query once an for all.

Except that... this works fine when ``graph`` uses the SPARQL processor shipped with RDFlib. But if I use a third-party Store, which has its own native implementation of SPARQL, Q is not usable anymore...

The solution I found is to add an attribute to the object produced by ``prepareQuery``, containing the original query string, so that alternative Store implementations can get the original query string and pass it to their own parser. Granted, in that case, ``prepareQuery`` works for nothing, but at least the code above works regardless of the underlying store (and the spurious parsing is done only once, so it is not too bad).