### PR TITLE
fix sparql count & sample for unbound

### DIFF
--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -89,7 +89,7 @@ def agg_Count(a, group, bindings):
         try:
             if a.vars != '*':
                 val = _eval(a.vars, x)
-                if type(val) is NotBoundError:
+                if isinstance(val, NotBoundError):
                     continue
             c += 1
         except:
@@ -102,7 +102,7 @@ def agg_Count(a, group, bindings):
 def agg_Sample(a, group, bindings):
     for ctx in group:
         val = _eval(a.vars, ctx)
-        if type(val) is not NotBoundError:
+        if not isinstance(val, NotBoundError):
             bindings[a.res] = val
             break
 

--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -105,9 +105,6 @@ def agg_Sample(a, group, bindings):
         if type(val) is not NotBoundError:
             bindings[a.res] = val
             break
-    else:
-        bindings[a.res] = Literal(0)
-
 
 
 def agg_GroupConcat(a, group, bindings):

--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -1,6 +1,6 @@
 from rdflib import Literal, XSD
 
-from rdflib.plugins.sparql.evalutils import _eval
+from rdflib.plugins.sparql.evalutils import _eval, NotBoundError
 from rdflib.plugins.sparql.operators import numeric
 from rdflib.plugins.sparql.datatypes import type_promotion
 
@@ -88,7 +88,9 @@ def agg_Count(a, group, bindings):
     for x in group:
         try:
             if a.vars != '*':
-                _eval(a.vars, x)
+                val = _eval(a.vars, x)
+                if type(val) is NotBoundError:
+                    continue
             c += 1
         except:
             return  # error in aggregate => no binding
@@ -98,10 +100,14 @@ def agg_Count(a, group, bindings):
 
 
 def agg_Sample(a, group, bindings):
-    try:
-        bindings[a.res] = _eval(a.vars, iter(group).next())
-    except StopIteration:
-        pass  # no res
+    for ctx in group:
+        val = _eval(a.vars, ctx)
+        if type(val) is not NotBoundError:
+            bindings[a.res] = val
+            break
+    else:
+        bindings[a.res] = Literal(0)
+
 
 
 def agg_GroupConcat(a, group, bindings):

--- a/test/test_issue563.py
+++ b/test/test_issue563.py
@@ -24,21 +24,21 @@ def test_sample():
     g = Graph()
     results = set( tuple(i) for i in g.query(QUERY % ("SAMPLE", "SAMPLE")) )
 
-    assert results == {
+    assert results == set([
         (Literal(2), Literal(6), Literal(10)),
         (Literal(3), Literal(9), Literal(15)),
         (Literal(5), Literal(0), Literal(25)),
-    }
+    ])
 
 def test_count():
     g = Graph()
     results = set( tuple(i) for i in g.query(QUERY % ("COUNT", "COUNT")) )
 
-    assert results == {
+    assert results == set([
         (Literal(2), Literal(1), Literal(1)),
         (Literal(3), Literal(1), Literal(1)),
         (Literal(5), Literal(0), Literal(1)),
-    }
+    ])
 
 if __name__ == "__main__":
     #test_sample()

--- a/test/test_issue563.py
+++ b/test/test_issue563.py
@@ -1,0 +1,48 @@
+from rdflib import BNode, Literal, Graph, Namespace
+from rdflib.compare import isomorphic
+
+EX = Namespace("http://example.org/")
+QUERY = """
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?x (%s(?y) as ?ys) (%s(?z) as ?zs) WHERE {
+  VALUES (?x ?y ?z) {
+
+    (2 6 UNDEF)
+    (2 UNDEF 10)
+
+    (3 UNDEF 15)
+    (3 9 UNDEF)
+
+    (5 UNDEF 25)
+  }
+}
+GROUP BY ?x
+"""
+
+def test_sample():
+    g = Graph()
+    results = set( tuple(i) for i in g.query(QUERY % ("SAMPLE", "SAMPLE")) )
+
+    assert results == {
+        (Literal(2), Literal(6), Literal(10)),
+        (Literal(3), Literal(9), Literal(15)),
+        (Literal(5), Literal(0), Literal(25)),
+    }
+
+def test_count():
+    g = Graph()
+    results = set( tuple(i) for i in g.query(QUERY % ("COUNT", "COUNT")) )
+
+    assert results == {
+        (Literal(2), Literal(1), Literal(1)),
+        (Literal(3), Literal(1), Literal(1)),
+        (Literal(5), Literal(0), Literal(1)),
+    }
+
+if __name__ == "__main__":
+    #test_sample()
+    test_count()
+
+
+

--- a/test/test_issue563.py
+++ b/test/test_issue563.py
@@ -22,17 +22,17 @@ GROUP BY ?x
 
 def test_sample():
     g = Graph()
-    results = set( tuple(i) for i in g.query(QUERY % ("SAMPLE", "SAMPLE")) )
+    results = set(tuple(i) for i in g.query(QUERY % ("SAMPLE", "SAMPLE")))
 
     assert results == set([
         (Literal(2), Literal(6), Literal(10)),
         (Literal(3), Literal(9), Literal(15)),
-        (Literal(5), Literal(0), Literal(25)),
+        (Literal(5), None, Literal(25)),
     ])
 
 def test_count():
     g = Graph()
-    results = set( tuple(i) for i in g.query(QUERY % ("COUNT", "COUNT")) )
+    results = set(tuple(i) for i in g.query(QUERY % ("COUNT", "COUNT")))
 
     assert results == set([
         (Literal(2), Literal(1), Literal(1)),
@@ -41,7 +41,7 @@ def test_count():
     ])
 
 if __name__ == "__main__":
-    #test_sample()
+    test_sample()
     test_count()
 
 


### PR DESCRIPTION
fixes #563 and builds on top of #564, changing it to return `None` in case `SAMPLE(?var)` can't find a binding for `?var`.