### PR TITLE
BUG,DOC,BLD: conf.py, docs/sphinx-requirements.txt: add sphinx_epytext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,9 @@ import sys, os, re
 extensions = ['sphinx.ext.autodoc', #'sphinx.ext.autosummary',
               'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
               'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
+              'sphinx_epytext'  # pypi:sphinx-epytext
+]
 
 autodoc_default_flags = [ "special-members" ]
 

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -1,2 +1,3 @@
+sphinx-epytext
 -e git+git://github.com/gjhiggins/n3_pygments_lexer.git#egg=Notation3_Pygments_Lexer
 -e git+git://github.com/gjhiggins/sparql_pygments_lexer.git#egg=SPARQL_Pygments_Lexer


### PR DESCRIPTION
- | Issue: BUG,DOC,BLD: parse {@param, @type, @returns, @rtype} docstrings #569

sphinx_epytext
- | Src: https://github.com/jayvdb/sphinx-epytext/
- | Src: https://github.com/jayvdb/sphinx-epytext/blob/master/sphinx_epytext/process_docstring.py

pyment
- | Src: https://github.com/dadadel/pyment
- | Desc: pyment converts between docstring formats and generates docstring param stubs
- In fixing the epydoc syntax, e.g. see plugin_parsers.html, it could instead/alternatively be useful to just use a syntax compatible w/ the (now bundled) sphinx.ext.napoleon .

closes #569
