### PR TITLE
Prevent RDFa parser from failing on time elements with child nodes

### DIFF
--- a/rdflib/plugins/parsers/pyRdfa/host/html5.py
+++ b/rdflib/plugins/parsers/pyRdfa/host/html5.py
@@ -172,7 +172,7 @@ def html5_extra_attributes(node, state) :
 			if node.nodeType == node.TEXT_NODE:
 				rc = rc + node.data
 			elif node.nodeType == node.ELEMENT_NODE :
-				rc = rc + self._get_literal(node)
+				rc = rc + _get_literal(node)
 		if state.options.space_preserve :
 			return rc
 		else :

--- a/test/test_issue576.py
+++ b/test/test_issue576.py
@@ -1,0 +1,26 @@
+import rdflib
+
+html = """<!DOCTYPE html>
+<html>
+    <head>
+        <title>Boom</title>
+    </head>
+<body vocab="http://schema.org/" typeof="Book" resource="http://example.com/">
+    <time property="dateCreated"><em>2016-01-01</em></time>
+</body>
+</html>
+"""
+
+
+def test_time_child_element():
+    """
+    Ensure TIME elements that contain child nodes parse cleanly
+    """
+    g = rdflib.Graph()
+    g.parse(data=html, format='rdfa')
+    date = g.value(
+        rdflib.URIRef("http://example.com/"),
+        rdflib.URIRef("http://schema.org/dateCreated")
+    )
+    assert len(g) == 3
+    assert date == rdflib.term.Literal("2016-01-01")


### PR DESCRIPTION
The _get_literal() function in the RDFa parser referred to a self instance that
does not exist. This led to a NameError exception if the HTML to be parsed
included a TIME element with one or more child nodes, such as
'<time><em>2016-01-01</em></time>'. Removing the reference to 'self' fixes
the problem and fixes #576.

Signed-off-by: Dan Scott <dan@coffeecode.net>