### PR TITLE
Avoid class reference to imported function

### DIFF
--- a/rdflib/plugins/parsers/pyMicrodata/utils.py
+++ b/rdflib/plugins/parsers/pyMicrodata/utils.py
@@ -294,7 +294,7 @@ class URIOpener :
 			self.headers	= self.data.info()
 
 			if URIOpener.CONTENT_LOCATION in self.headers :
-				self.location = urlparse.urljoin(self.data.geturl(),self.headers[URIOpener.CONTENT_LOCATION])
+				self.location = urljoin(self.data.geturl(),self.headers[URIOpener.CONTENT_LOCATION])
 			else :
 				self.location = name
 


### PR DESCRIPTION
We import the urljoin() function directly to support both Py2 and Py3, so the
reference to urlparse.urljoin() raises an exception. Don't do that!

Fixes 574.

Signed-off-by: Dan Scott <dan@coffeecode.net>