### PR TITLE
changed prefix for SPARQL namespace in XML serialization

### DIFF
--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -145,7 +145,7 @@ class SPARQLXMLWriter:
     def __init__(self, output, encoding='utf-8'):
         writer = XMLGenerator(output, encoding)
         writer.startDocument()
-        writer.startPrefixMapping(u'sparql', SPARQL_XML_NAMESPACE)
+        writer.startPrefixMapping(u'', SPARQL_XML_NAMESPACE)
         writer.startPrefixMapping(u'xml', XML_NAMESPACE)
         writer.startElementNS(
             (SPARQL_XML_NAMESPACE, u'sparql'),


### PR DESCRIPTION
Although #493 is not really a bug (the current serialization _is_ valid after all), several tools are not fully compliant and require the namespace prefix to be empty.
As this change help those "not so compliant" tools without hurting "fully compliant" tools, I think it is worth it.
(plus: it reduces the size of the XML serialization...)
