### PR TITLE
(ultra petty) Remove an unused import

### DIFF
--- a/test/test_issue535.py
+++ b/test/test_issue535.py
@@ -1,5 +1,4 @@
 from rdflib import ConjunctiveGraph, URIRef
-from rdflib.parser import StringInputSource
 
 def test_nquads_default_graph():
     ds = ConjunctiveGraph()


### PR DESCRIPTION
Just something I spotted while reading the code.