### PR TITLE
revert closednamespace inheritance fix

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -95,6 +95,11 @@ class Namespace(unicode):
             rt = unicode.__new__(cls, value, 'utf-8')
         return rt
 
+
+    @property
+    def title(self):
+        return URIRef(self + 'title')
+
     def term(self, name):
         # need to handle slices explicitly because of __getitem__ override
         return URIRef(self + (name if isinstance(name, basestring) else ''))
@@ -143,33 +148,26 @@ class URIPattern(unicode):
 
 
 
-class ClosedNamespace(Namespace):
+class ClosedNamespace(object):
     """
     A namespace with a closed list of members
 
     Trying to create terms not listen is an error
     """
 
-    def __new__(cls, uri, terms):
-        rt = Namespace.__new__(cls, uri)
-
-        rt.__uris = {}
+    def __init__(self, uri, terms):
+        self.uri = uri
+        self.__uris = {}
         for t in terms:
-            rt.__uris[t] = URIRef(rt + t)
-
-        return rt
+            self.__uris[t] = URIRef(self.uri + t)
 
     def term(self, name):
         uri = self.__uris.get(name)
         if uri is None:
             raise Exception(
-                "term '%s' not in namespace '%s'" % (name, self))
+                "term '%s' not in namespace '%s'" % (name, self.uri))
         else:
             return uri
-
-    @property
-    def uri(self): # support legacy code from before ClosedNamespace extended unicode
-        return self
 
     def __getitem__(self, key, default=None):
         return self.term(key)
@@ -180,18 +178,21 @@ class ClosedNamespace(Namespace):
         else:
             return self.term(name)
 
+    def __str__(self):
+        return str(self.uri)
+
     def __repr__(self):
-        return """rdf.namespace.ClosedNamespace('%s')""" % self
+        return """rdf.namespace.ClosedNamespace('%s')""" % str(self.uri)
 
 
 class _RDFNamespace(ClosedNamespace):
     """
     Closed namespace for RDF terms
     """
-
-    def __new__(cls):
-        return ClosedNamespace.__new__(cls, "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              terms=[
+    def __init__(self):
+        super(_RDFNamespace, self).__init__(
+            URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+            terms=[
                 # Syntax Names
                 "RDF", "Description", "ID", "about", "parseType",
                 "resource", "li", "nodeID", "datatype",
@@ -212,11 +213,10 @@ class _RDFNamespace(ClosedNamespace):
                 "XMLLiteral", "HTML", "langString"]
         )
 
-
     def term(self, name):
         try:
             i = int(name)
-            return URIRef("%s_%s" % (self, i))
+            return URIRef("%s_%s" % (self.uri, i))
         except ValueError:
             return super(_RDFNamespace, self).term(name)
 

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -95,11 +95,6 @@ class Namespace(unicode):
             rt = unicode.__new__(cls, value, 'utf-8')
         return rt
 
-    @property
-    def title(self):
-        # overrides unicode.title to allow DCTERMS.title for example
-        return URIRef(self + 'title')
-
     def term(self, name):
         # need to handle slices explicitly because of __getitem__ override
         return URIRef(self + (name if isinstance(name, basestring) else ''))

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,15 +1,8 @@
 import unittest
 
-from rdflib.namespace import DCTERMS
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 from rdflib.py3compat import b
-
-
-class NamespaceTest(unittest.TestCase):
-    def test_dcterms_title(self):
-        self.assertEqual(DCTERMS.title, URIRef(DCTERMS + 'title'))
-
 
 class NamespacePrefixTest(unittest.TestCase):
 
@@ -21,7 +14,7 @@ class NamespacePrefixTest(unittest.TestCase):
 
         self.assertEqual(g.compute_qname(URIRef("http://foo/bar#baz")),
             ("ns2", URIRef("http://foo/bar#"), "baz"))
-
+        
         # should skip to ns4 when ns3 is already assigned
         g.bind("ns3", URIRef("http://example.org/"))
         self.assertEqual(g.compute_qname(URIRef("http://blip/blop")),
@@ -35,7 +28,7 @@ class NamespacePrefixTest(unittest.TestCase):
         n3 = g.serialize(format="n3")
         # Gunnar disagrees that this is right:
         # self.assertTrue("<http://example.com/foo> ns1:bar <http://example.com/baz> ." in n3)
-        # as this is much prettier, and ns1 is already defined:
+        # as this is much prettier, and ns1 is already defined: 
         self.assertTrue(b("ns1:foo ns1:bar ns1:baz .") in n3)
 
     def test_n32(self):


### PR DESCRIPTION
reverts #551 and ae1f6397fe47be7bd6912dae8b08c4007eb9d2ac as they're backwards incompatible

related issue #542

will be moved to rdflib 5.0.0