### PR TITLE
Namespace and ClosedNamespace no longer inherit from unicode, closes #596, #542

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -95,11 +95,6 @@ class Namespace(unicode):
             rt = unicode.__new__(cls, value, 'utf-8')
         return rt
 
-
-    @property
-    def title(self):
-        return URIRef(self + 'title')
-
     def term(self, name):
         # need to handle slices explicitly because of __getitem__ override
         return URIRef(self + (name if isinstance(name, basestring) else ''))
@@ -148,26 +143,33 @@ class URIPattern(unicode):
 
 
 
-class ClosedNamespace(object):
+class ClosedNamespace(Namespace):
     """
     A namespace with a closed list of members
 
     Trying to create terms not listen is an error
     """
 
-    def __init__(self, uri, terms):
-        self.uri = uri
-        self.__uris = {}
+    def __new__(cls, uri, terms):
+        rt = Namespace.__new__(cls, uri)
+
+        rt.__uris = {}
         for t in terms:
-            self.__uris[t] = URIRef(self.uri + t)
+            rt.__uris[t] = URIRef(rt + t)
+
+        return rt
 
     def term(self, name):
         uri = self.__uris.get(name)
         if uri is None:
             raise Exception(
-                "term '%s' not in namespace '%s'" % (name, self.uri))
+                "term '%s' not in namespace '%s'" % (name, self))
         else:
             return uri
+
+    @property
+    def uri(self): # support legacy code from before ClosedNamespace extended unicode
+        return self
 
     def __getitem__(self, key, default=None):
         return self.term(key)
@@ -178,21 +180,18 @@ class ClosedNamespace(object):
         else:
             return self.term(name)
 
-    def __str__(self):
-        return str(self.uri)
-
     def __repr__(self):
-        return """rdf.namespace.ClosedNamespace('%s')""" % str(self.uri)
+        return """rdf.namespace.ClosedNamespace('%s')""" % self
 
 
 class _RDFNamespace(ClosedNamespace):
     """
     Closed namespace for RDF terms
     """
-    def __init__(self):
-        super(_RDFNamespace, self).__init__(
-            URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-            terms=[
+
+    def __new__(cls):
+        return ClosedNamespace.__new__(cls, "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              terms=[
                 # Syntax Names
                 "RDF", "Description", "ID", "about", "parseType",
                 "resource", "li", "nodeID", "datatype",
@@ -213,10 +212,11 @@ class _RDFNamespace(ClosedNamespace):
                 "XMLLiteral", "HTML", "langString"]
         )
 
+
     def term(self, name):
         try:
             i = int(name)
-            return URIRef("%s_%s" % (self.uri, i))
+            return URIRef("%s_%s" % (self, i))
         except ValueError:
             return super(_RDFNamespace, self).term(name)
 

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -147,7 +147,8 @@ class Namespace(object):
         return self.__prefix__
 
     def __repr__(self):
-        return "rdflib.namespace.Namespace(%r)" % str(self)
+        t = type(self)
+        return "%s(%r)" % (t.__module__ + '.' + t.__name__, self.__prefix__)
 
 
 class URIPattern(unicode):
@@ -201,9 +202,6 @@ class ClosedNamespace(Namespace):
             raise ValueError("term %r not in namespace %r" % (name, self))
         else:
             return uri
-
-    def __repr__(self):
-        return """rdf.namespace.ClosedNamespace(%r)""" % str(self)
 
 
 class _RDFNamespace(ClosedNamespace):

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -95,6 +95,11 @@ class Namespace(unicode):
             rt = unicode.__new__(cls, value, 'utf-8')
         return rt
 
+    @property
+    def title(self):
+        # overrides unicode.title to allow DCTERMS.title for example
+        return URIRef(self + 'title')
+
     def term(self, name):
         # need to handle slices explicitly because of __getitem__ override
         return URIRef(self + (name if isinstance(name, basestring) else ''))

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -122,6 +122,27 @@ class Namespace(object):
         else:
             return self.term(name)
 
+    def __contains__(self, uri):
+        """Allows to check if a URI is within (starts with) this Namespace.
+
+        >>> from rdflib import URIRef
+        >>> n = Namespace('http://example.org/')
+        >>> u = URIRef('http://example.org/foo')
+        >>> u in n
+        True
+        >>> p = n['Person']
+        >>> p in n
+        True
+        >>> o = URIRef('http://not.example.org/bar')
+        >>> o in n
+        False
+        """
+        return unicode(uri).startswith(self.__prefix__)
+
+    def __add__(self, other):
+        """Syntactic sugar to allow to write ns[foo] as ns + foo."""
+        return self[other]
+
     def __str__(self):
         return self.__prefix__
 

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -1,4 +1,4 @@
-from rdflib.py3compat import format_doctest_out
+from rdflib.py3compat import format_doctest_out, PY3
 
 __doc__ = format_doctest_out("""
 ===================
@@ -143,8 +143,16 @@ class Namespace(object):
         """Syntactic sugar to allow to write ns[foo] as ns + foo."""
         return self[other]
 
-    def __str__(self):
+    def __unicode__(self):
         return self.__prefix__
+
+    def __bytes__(self):
+        return self.__prefix__.encode('utf-8')
+
+    if PY3:
+        __str__ = __unicode__
+    else:
+        __str__ = __bytes__
 
     def __repr__(self):
         t = type(self)

--- a/rdflib/plugins/serializers/xmlwriter.py
+++ b/rdflib/plugins/serializers/xmlwriter.py
@@ -99,8 +99,8 @@ class XMLWriter(object):
     def qname(self, uri):
         """Compute qname for a uri using our extra namespaces,
         or the given namespace manager"""
-
         for pre, ns in self.extra_ns.items():
+            ns = unicode(ns)
             if uri.startswith(ns):
                 if pre != "":
                     return ":".join(pre, uri[len(ns):])

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -31,7 +31,7 @@ from rdflib.plugins.sparql.sparql import SPARQLError, SPARQLTypeError
 
 
 # closed namespace, langString isn't in it
-RDF_langString = URIRef(RDF.uri + "langString")
+RDF_langString = URIRef(str(RDF) + "langString")
 
 
 def Builtin_IRI(expr, ctx):

--- a/rdflib/serializer.py
+++ b/rdflib/serializer.py
@@ -26,7 +26,7 @@ class Serializer(object):
         """Abstract method"""
 
     def relativize(self, uri):
-        base = self.base
+        base = unicode(self.base)
         if base is not None and uri.startswith(base):
             uri = URIRef(uri.replace(base, "", 1))
         return uri

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,14 +1,28 @@
+# coding=utf-8
 import unittest
 
 from rdflib.namespace import DCTERMS
+from rdflib.namespace import Namespace
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 from rdflib.py3compat import b
+from rdflib.py3compat import PY3
 
 
 class NamespaceTest(unittest.TestCase):
     def test_dcterms_title(self):
         self.assertEqual(DCTERMS.title, URIRef(DCTERMS + 'title'))
+
+    def test_iri(self):
+        prefix = u'http://jörn.loves.encoding.problems/'
+        ns = Namespace(prefix)
+        self.assertEqual(bytes(ns), prefix.encode('utf-8'))
+        self.assertEqual(unicode(ns), prefix)
+        if PY3:
+            self.assertEqual(str(ns), prefix)
+        else:
+            self.assertEqual(str(ns), prefix.encode('utf-8'))
+        self.assert_(unicode(ns[u'jörn']).startswith(unicode(ns)))
 
 
 class NamespacePrefixTest(unittest.TestCase):

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,8 +1,15 @@
 import unittest
 
+from rdflib.namespace import DCTERMS
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 from rdflib.py3compat import b
+
+
+class NamespaceTest(unittest.TestCase):
+    def test_dcterms_title(self):
+        self.assertEqual(DCTERMS.title, URIRef(DCTERMS + 'title'))
+
 
 class NamespacePrefixTest(unittest.TestCase):
 
@@ -14,7 +21,7 @@ class NamespacePrefixTest(unittest.TestCase):
 
         self.assertEqual(g.compute_qname(URIRef("http://foo/bar#baz")),
             ("ns2", URIRef("http://foo/bar#"), "baz"))
-        
+
         # should skip to ns4 when ns3 is already assigned
         g.bind("ns3", URIRef("http://example.org/"))
         self.assertEqual(g.compute_qname(URIRef("http://blip/blop")),
@@ -28,7 +35,7 @@ class NamespacePrefixTest(unittest.TestCase):
         n3 = g.serialize(format="n3")
         # Gunnar disagrees that this is right:
         # self.assertTrue("<http://example.com/foo> ns1:bar <http://example.com/baz> ." in n3)
-        # as this is much prettier, and ns1 is already defined: 
+        # as this is much prettier, and ns1 is already defined:
         self.assertTrue(b("ns1:foo ns1:bar ns1:baz .") in n3)
 
     def test_n32(self):


### PR DESCRIPTION
as mentioned in #595 and #596 this moves #551 and ae1f639 to the 5.0.0-dev branch and if accepted closes #542.

additionally as discussed removes the inheritance from unicode, meaning that all implicit string-ops like `n.startswith(...)` and `n + ...` are no longer supported
