### PR TITLE
Graph.update() uses own namespaces if none given, fixes #579

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1084,10 +1084,12 @@ class Graph(Node):
             query_object, initBindings, initNs, **kwargs))
 
     def update(self, update_object, processor='sparql',
-              initNs={}, initBindings={},
+              initNs=None, initBindings=None,
               use_store_provided=True, **kwargs):
-        """
-        """
+        """Update this graph with the given update query."""
+        initBindings = initBindings or {}
+        initNs = initNs or dict(self.namespaces())
+
         if hasattr(self.store, "update") and use_store_provided:
             try:
                 return self.store.update(

--- a/test/test_issue579.py
+++ b/test/test_issue579.py
@@ -1,0 +1,16 @@
+# test for https://github.com/RDFLib/rdflib/issues/579
+
+from rdflib import Graph, URIRef, Literal, Namespace
+from rdflib.namespace import FOAF, RDF
+
+g = Graph()
+g.bind('foaf', FOAF)
+n = Namespace("http://myname/")
+g.add((n.bob, FOAF.name, Literal('bb')))
+# query is successful.
+assert len(g.query("select ?n where { ?n foaf:name 'bb' . }")) == 1
+# update is not.
+g.update("delete where { ?e foaf:name 'ss' .}")
+assert len(g) == 1
+g.update("delete where { ?e foaf:name 'bb' .}")
+assert len(g) == 0


### PR DESCRIPTION
see #579