### PR TITLE
Fix ImportError when __main__ already loaded

### DIFF
--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -73,10 +73,17 @@ assert sys.version_info >= (2, 5, 0), "rdflib requires Python 2.5 or higher"
 del sys
 
 import logging
-import __main__
-if not hasattr(__main__, '__file__'):
-    # show log messages in interactive mode
-    logging.basicConfig(level=logging.INFO)
+try:
+    import __main__
+    if not hasattr(__main__, '__file__'):
+        # show log messages in interactive mode
+        logging.basicConfig(level=logging.INFO)
+except ImportError:
+    #Main already imported from elsewhere
+    import warnings
+    warnings.warn('__main__ already imported', ImportWarning)
+    del warnings
+    
 logger = logging.getLogger(__name__)
 logger.info("RDFLib Version: %s" % __version__)
 


### PR DESCRIPTION
In rdflib/\_\_init\_\_ - place import of \_\_main\_\_ into a try catch block to catch ImportError that you get when already imported such as in a Google App Engine instance running webapp2.

Enables the use of rdflib unchanged in this configuration of Google App Engine and potentially other environments that claim \_\_main\_\_ before rdflib gets loaded.

This has been tested as functional in the latest version of the [Schema.org](https://github.com/schemaorg/schemaorg) code base.