### PR TITLE
Result objects should close the sockets where the results come from

### DIFF
--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -38,6 +38,7 @@ class XMLResult(Result):
     def __init__(self, source):
 
         xmlstring = source.read()
+        source.close_connection()
 
         if isinstance(xmlstring, unicode):
             xmlstring = xmlstring.encode('utf-8')


### PR DESCRIPTION
The XMLResult never closed the source file where the result was coming from, resulting in "too man opened files" being raised when processing large amounts of SPARQL queries. I have added a line of code to the appropriate file, but I am not sure whether other result parsers need to have the same type of fix added to them.
