### PR TITLE
namespace.py fix compute_qname missing namespaces

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -353,6 +353,7 @@ class NamespaceManager(object):
     def __init__(self, graph):
         self.graph = graph
         self.__cache = {}
+        self.__cache_strict = {}
         self.__log = None
         self.__strie = {}
         self.__trie = {}
@@ -380,6 +381,13 @@ class NamespaceManager(object):
             return name
         else:
             return ":".join((prefix, name))
+
+    def qname_strict(self, uri):
+        prefix, namespace, name = self.compute_qname_strict(uri)
+        if prefix == '':
+            return name
+        else:
+            return ':'.join((prefix, name))
 
     def normalizeUri(self, rdfTerm):
         """
@@ -447,6 +455,56 @@ class NamespaceManager(object):
                 self.bind(prefix, namespace)
             self.__cache[uri] = (prefix, namespace, name)
         return self.__cache[uri]
+
+    def compute_qname_strict(self, uri, generate=True):
+        # code repeated to avoid branching on strict every time
+        # if output needs to be strict (e.g. for xml) then
+        # only the strict output should bear the overhead
+        prefix, namespace, name = self.compute_qname(uri)
+        if is_ncname(text_type(name)):
+            return prefix, namespace, name
+        else:
+            if uri not in self.__cache_strict:
+                try:
+                    namespace, name = split_uri(uri, NAME_START_CATEGORIES)
+                except ValueError as e:
+                    message = ('This graph cannot be serialized to a strict format '
+                               'because there is no valid way to shorten {}'.format(uri))
+                    raise ValueError(message)
+                    # omitted for strict since NCNames cannot be empty
+                    #namespace = URIRef(uri)
+                    #prefix = self.store.prefix(namespace)
+                    #if not prefix:
+                        #raise e
+
+                if namespace not in self.__strie:
+                    insert_strie(self.__strie, self.__trie, namespace)
+
+                # omitted for strict
+                #if self.__strie[namespace]:
+                    #pl_namespace = get_longest_namespace(self.__strie[namespace], uri)
+                    #if pl_namespace is not None:
+                        #namespace = pl_namespace
+                        #name = uri[len(namespace):]
+
+                namespace = URIRef(namespace)
+                prefix = self.store.prefix(namespace)  # warning multiple prefixes problem
+
+                if prefix is None:
+                    if not generate:
+                        raise KeyError(
+                            "No known prefix for {} and generate=False".format(namespace)
+                        )
+                    num = 1
+                    while 1:
+                        prefix = "ns%s" % num
+                        if not self.store.namespace(prefix):
+                            break
+                        num += 1
+                    self.bind(prefix, namespace)
+                self.__cache_strict[uri] = (prefix, namespace, name)
+
+            return self.__cache_strict[uri]
 
     def bind(self, prefix, namespace, override=True, replace=False):
         """bind a given namespace to the prefix
@@ -568,27 +626,28 @@ ALLOWED_NAME_CHARS = [u"\u00B7", u"\u0387", u"-", u".", u"_", u":"]
 
 
 def is_ncname(name):
-    first = name[0]
-    if first == "_" or category(first) in NAME_START_CATEGORIES:
-        for i in range(1, len(name)):
-            c = name[i]
-            if not category(c) in NAME_CATEGORIES:
-                if c != ':' and c in ALLOWED_NAME_CHARS:
-                    continue
-                return 0
-            # if in compatibility area
-            # if decomposition(c)!='':
-            #    return 0
+    if name:
+        first = name[0]
+        if first == "_" or category(first) in NAME_START_CATEGORIES:
+            for i in range(1, len(name)):
+                c = name[i]
+                if not category(c) in NAME_CATEGORIES:
+                    if c != ':' and c in ALLOWED_NAME_CHARS:
+                        continue
+                    return 0
+                # if in compatibility area
+                # if decomposition(c)!='':
+                #    return 0
 
-        return 1
-    else:
-        return 0
+            return 1
+
+    return 0
 
 
 XMLNS = "http://www.w3.org/XML/1998/namespace"
 
 
-def split_uri(uri):
+def split_uri(uri, split_start=SPLIT_START_CATEGORIES):
     if uri.startswith(XMLNS):
         return (XMLNS, uri.split(XMLNS)[1])
     length = len(uri)
@@ -598,7 +657,7 @@ def split_uri(uri):
             if c in ALLOWED_NAME_CHARS:
                 continue
             for j in range(-1 - i, length):
-                if category(uri[j]) in SPLIT_START_CATEGORIES or uri[j] == "_":
+                if category(uri[j]) in split_start or uri[j] == "_":
                     # _ prevents early split, roundtrip not generate
                     ns = uri[:j]
                     if not ns:
@@ -641,4 +700,3 @@ def get_longest_namespace(trie, value):
             else:
                 return out
     return None
-

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -606,10 +606,10 @@ def insert_trie(trie, value):  # aka get_subtrie_or_insert
     if value in trie:
         return trie[value]
     multi_check = False
-    for key in list(trie.keys()):
-        if value.startswith(key):
+    for key in tuple(trie.keys()):
+        if len(value) > len(key) and value.startswith(key):
             return insert_trie(trie[key], value)
-        elif key.startswith(value):
+        elif key.startswith(value):  # we know the value is not in the trie
             if not multi_check:
                 trie[value] = {}
                 multi_check = True  # there can be multiple longer existing prefixes

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -354,8 +354,8 @@ class NamespaceManager(object):
         self.graph = graph
         self.__cache = {}
         self.__log = None
-        self.__trie = {}
         self.__strie = {}
+        self.__trie = {}
         for p, n in self.namespaces():  # self.bind is not always called
             insert_trie(self.__trie, str(n))
         self.bind("xml", "http://www.w3.org/XML/1998/namespace")
@@ -365,6 +365,8 @@ class NamespaceManager(object):
 
     def reset(self):
         self.__cache = {}
+        self.__strie = {}
+        self.__trie = {}
 
     def __get_store(self):
         return self.graph.store

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -414,7 +414,13 @@ class NamespaceManager(object):
             )
 
         if uri not in self.__cache:
-            namespace, name = split_uri(uri)
+            try:
+                namespace, name = split_uri(uri)
+            except ValueError as e:
+                namespace = URIRef(uri)
+                prefix = self.store.prefix(namespace)
+                if not prefix:
+                    raise e
             if namespace not in self.__strie:
                 insert_strie(self.__strie, self.__trie, namespace)
 

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -581,13 +581,14 @@ def split_uri(uri):
     if uri.startswith(XMLNS):
         return (XMLNS, uri.split(XMLNS)[1])
     length = len(uri)
+    name_start_plus_nd = NAME_START_CATEGORIES + ["Nd"]
     for i in range(0, length):
         c = uri[-i - 1]
         if not category(c) in NAME_CATEGORIES:
             if c in ALLOWED_NAME_CHARS:
                 continue
             for j in range(-1 - i, length):
-                if category(uri[j]) in NAME_START_CATEGORIES or uri[j] == "_":
+                if category(uri[j]) in name_start_plus_nd or uri[j] == "_":
                     ns = uri[:j]
                     if not ns:
                         break

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -367,6 +367,8 @@ class NamespaceManager(object):
         self.__cache = {}
         self.__strie = {}
         self.__trie = {}
+        for p, n in self.namespaces():  # repopulate the trie
+            insert_trie(self.__trie, str(n))
 
     def __get_store(self):
         return self.graph.store
@@ -547,6 +549,7 @@ class NamespaceManager(object):
 
 
 NAME_START_CATEGORIES = ["Ll", "Lu", "Lo", "Lt", "Nl"]
+SPLIT_START_CATEGORIES = NAME_START_CATEGORIES + ['Nd']
 NAME_CATEGORIES = NAME_START_CATEGORIES + ["Mc", "Me", "Mn", "Lm", "Nd"]
 ALLOWED_NAME_CHARS = [u"\u00B7", u"\u0387", u"-", u".", u"_", u":"]
 
@@ -583,14 +586,14 @@ def split_uri(uri):
     if uri.startswith(XMLNS):
         return (XMLNS, uri.split(XMLNS)[1])
     length = len(uri)
-    name_start_plus_nd = NAME_START_CATEGORIES + ["Nd"]
     for i in range(0, length):
         c = uri[-i - 1]
         if not category(c) in NAME_CATEGORIES:
             if c in ALLOWED_NAME_CHARS:
                 continue
             for j in range(-1 - i, length):
-                if category(uri[j]) in name_start_plus_nd or uri[j] == "_":
+                if category(uri[j]) in SPLIT_START_CATEGORIES or uri[j] == "_":
+                    # _ prevents early split, roundtrip not generate
                     ns = uri[:j]
                     if not ns:
                         break

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -354,6 +354,9 @@ class NamespaceManager(object):
         self.graph = graph
         self.__cache = {}
         self.__log = None
+        self.__trie = {}
+        for p, n in self.namespaces():  # self.bind is not always called
+            insert_trie(self.__trie, n)
         self.bind("xml", "http://www.w3.org/XML/1998/namespace")
         self.bind("rdf", RDF)
         self.bind("rdfs", RDFS)
@@ -404,10 +407,19 @@ class NamespaceManager(object):
             )
 
         if uri not in self.__cache:
-            namespace, name = split_uri(uri)
-            namespace = URIRef(namespace)
-            prefix = self.store.prefix(namespace)
-            if prefix is None:
+            namespace = get_longest_namespace(self.__trie, uri)
+            if namespace is not None:
+                name = uri[len(namespace):]
+                if '/' in name or '#' in name:
+                    name = None
+                else:
+                    prefix = self.store.prefix(namespace)  # warning multiple prefixes problem
+            else:
+                name = None
+
+            if name is None:
+                namespace, name = split_uri(uri)
+                namespace = URIRef(namespace)
                 if not generate:
                     raise KeyError(
                         "No known prefix for {} and generate=False".format(namespace)
@@ -447,6 +459,7 @@ class NamespaceManager(object):
 
             if replace:
                 self.store.bind(prefix, namespace)
+                insert_trie(self.__trie, namespace)
                 return
 
             # prefix already in use for different namespace
@@ -476,6 +489,7 @@ class NamespaceManager(object):
             else:
                 if override or bound_prefix.startswith("_"):  # or a generated prefix
                     self.store.bind(prefix, namespace)
+        insert_trie(self.__trie, namespace)
 
     def namespaces(self):
         for prefix, namespace in self.store.namespaces():
@@ -577,3 +591,27 @@ def split_uri(uri):
                     return (ns, ln)
             break
     raise ValueError("Can't split '{}'".format(uri))
+
+def insert_trie(trie, value):
+    if value in trie:
+        return
+    for key in trie:
+        if value.startswith(key):
+            insert_trie(trie[key], value)
+            return
+        elif key.startswith(value):
+            dict_ = trie.pop(key)
+            trie[value] = {key:dict_}
+            return
+    trie[value] = {}
+
+def get_longest_namespace(trie, value):
+    for key in trie:
+        if value.startswith(key):
+            out = get_longest_namespace(trie[key], value)
+            if out is None:
+                return key
+            else:
+                return out
+    return None
+

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -32,7 +32,7 @@ class XMLSerializer(Serializer):
         bindings = {}
 
         for predicate in set(store.predicates()):
-            prefix, namespace, name = nm.compute_qname(predicate)
+            prefix, namespace, name = nm.compute_qname_strict(predicate)
             bindings[prefix] = URIRef(namespace)
 
         RDFNS = URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
@@ -116,7 +116,7 @@ class XMLSerializer(Serializer):
     def predicate(self, predicate, object, depth=1):
         write = self.write
         indent = "  " * depth
-        qname = self.store.namespace_manager.qname(predicate)
+        qname = self.store.namespace_manager.qname_strict(predicate)
 
         if isinstance(object, Literal):
             attributes = ""
@@ -175,7 +175,7 @@ class PrettyXMLSerializer(Serializer):
             store.objects(None, RDF.type))
 
         for predicate in possible:
-            prefix, namespace, local = nm.compute_qname(predicate)
+            prefix, namespace, local = nm.compute_qname_strict(predicate)
             namespaces[prefix] = namespace
 
         namespaces["rdf"] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/rdflib/plugins/serializers/xmlwriter.py
+++ b/rdflib/plugins/serializers/xmlwriter.py
@@ -107,4 +107,4 @@ class XMLWriter(object):
                 else:
                     return uri[len(ns):]
 
-        return self.nm.qname(uri)
+        return self.nm.qname_strict(uri)

--- a/test/n3/n3-writer-test-30.n3
+++ b/test/n3/n3-writer-test-30.n3
@@ -2,9 +2,21 @@
 
 @prefix :       <http://example.org/here#> .
 @prefix full:   <http://example.org/full> .
+@prefix pref:     <http://example.org/prefix/> .
+@prefix more:   <http://example.org/prefix/more> .
+
+# Test namespace generation
 
 full: :x :y .
 :x full: :y .
 :x :y full: .
 
 full: full: full: . 
+
+# Test existing namespace
+
+more: :x :y .
+:x more: :y .
+:x :y more: .
+
+more: more: more: .

--- a/test/n3/n3-writer-test-30.n3
+++ b/test/n3/n3-writer-test-30.n3
@@ -1,0 +1,10 @@
+# Test full length qnames
+
+@prefix :       <http://example.org/here#> .
+@prefix full:   <http://example.org/full> .
+
+full: :x :y .
+:x full: :y .
+:x :y full: .
+
+full: full: full: . 

--- a/test/n3/n3-writer-test-31.n3
+++ b/test/n3/n3-writer-test-31.n3
@@ -1,0 +1,15 @@
+# Test unshortenable strict qnames no predicates for xml sanity check
+
+@prefix :       <http://example.org/here#> .
+@prefix evil1:   <http://example.org/1> .
+@prefix evil2:   <http://example.org/prefix/1#> .
+
+# Test namespace generation
+
+evil1: :x :y .
+:x :y evil1: .
+
+# Test existing namespace
+
+evil2:1 :x :y .
+:x :y evil2:1 .

--- a/test/test_n3_suite.py
+++ b/test/test_n3_suite.py
@@ -23,8 +23,7 @@ def _get_test_files_formats():
 
 def all_n3_files():
     skiptests = [
-        'test/n3/example-lots_of_graphs.n3',  # the issue here seems to be with QuotedGraph, should this work?
-        # 'test/n3/n3-writer-test-30.n3', # this reveals the broken xml qname handling
+        'test/n3/example-lots_of_graphs.n3',  # only n3 can serialize QuotedGraph, no point in testing roundtrip
     ]
     for fpath, fmt in _get_test_files_formats():
         if fpath in skiptests:

--- a/test/test_n3_suite.py
+++ b/test/test_n3_suite.py
@@ -24,7 +24,6 @@ def _get_test_files_formats():
 def all_n3_files():
     skiptests = [
         'test/n3/example-lots_of_graphs.n3',  # the issue here seems to be with QuotedGraph, should this work?
-        # 'test/n3/n3-writer-test-29.n3', # this reveals the broken xml qname handling
         # 'test/n3/n3-writer-test-30.n3', # this reveals the broken xml qname handling
     ]
     for fpath, fmt in _get_test_files_formats():

--- a/test/test_n3_suite.py
+++ b/test/test_n3_suite.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import logging
+
+log = logging.getLogger(__name__)
 
 try:
     from .testutils import check_serialize_parse
@@ -18,6 +21,17 @@ def _get_test_files_formats():
             elif f.endswith('.n3'):
                 yield fpath, 'n3'
 
+def all_n3_files():
+    skiptests = [
+        'test/n3/example-lots_of_graphs.n3',  # the issue here seems to be with QuotedGraph, should this work?
+        # 'test/n3/n3-writer-test-29.n3', # this reveals the broken xml qname handling
+        # 'test/n3/n3-writer-test-30.n3', # this reveals the broken xml qname handling
+    ]
+    for fpath, fmt in _get_test_files_formats():
+        if fpath in skiptests:
+            log.debug("Skipping %s, known issue" % fpath)
+        else:
+            yield fpath, fmt
 
 def test_n3_writing():
     for fpath, fmt in _get_test_files_formats():

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -22,6 +22,18 @@ class NamespacePrefixTest(unittest.TestCase):
         self.assertEqual(g.compute_qname(URIRef("http://blip/blop")),
                          ("ns4", URIRef("http://blip/"), "blop"))
 
+    def test_reset(self):
+        data = ('@prefix a: <http://example.org/a> .\n'
+                'a: <http://example.org/b> <http://example.org/c> .')
+        graph = Graph().parse(data=data, format='turtle')
+        for p, n in tuple(graph.namespaces()):
+            graph.store._IOMemory__namespace.pop(p)
+            graph.store._IOMemory__prefix.pop(n)
+        graph.namespace_manager.reset()
+        self.assertFalse(tuple(graph.namespaces()))
+        prefix, namespace, name = graph.namespace_manager.compute_qname(URIRef('http://example.org/a'), generate=True)
+        self.assertNotEqual(namespace, URIRef('http://example.org/a'))
+
     def test_n3(self):
         g = Graph()
         g.add((URIRef("http://example.com/foo"),

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -22,6 +22,10 @@ class NamespacePrefixTest(unittest.TestCase):
         self.assertEqual(g.compute_qname(URIRef("http://blip/blop")),
                          ("ns4", URIRef("http://blip/"), "blop"))
 
+        # should return empty qnames correctly
+        self.assertEqual(g.compute_qname(URIRef("http://foo/bar/")),
+            ("ns1", URIRef("http://foo/bar/"), ""))
+
     def test_reset(self):
         data = ('@prefix a: <http://example.org/a> .\n'
                 'a: <http://example.org/b> <http://example.org/c> .')

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -31,8 +31,19 @@ class NamespacePrefixTest(unittest.TestCase):
             graph.store._IOMemory__prefix.pop(n)
         graph.namespace_manager.reset()
         self.assertFalse(tuple(graph.namespaces()))
-        prefix, namespace, name = graph.namespace_manager.compute_qname(URIRef('http://example.org/a'), generate=True)
-        self.assertNotEqual(namespace, URIRef('http://example.org/a'))
+        u = URIRef('http://example.org/a')
+        prefix, namespace, name = graph.namespace_manager.compute_qname(u, generate=True)
+        self.assertNotEqual(namespace, u)
+
+    def test_reset_preserve_prefixes(self):
+        data = ('@prefix a: <http://example.org/a> .\n'
+                'a: <http://example.org/b> <http://example.org/c> .')
+        graph = Graph().parse(data=data, format='turtle')
+        graph.namespace_manager.reset()
+        self.assertTrue(tuple(graph.namespaces()))
+        u = URIRef('http://example.org/a')
+        prefix, namespace, name = graph.namespace_manager.compute_qname(u, generate=True)
+        self.assertEqual(namespace, u)
 
     def test_n3(self):
         g = Graph()

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -29,10 +29,9 @@ tests roundtripping through rdf/xml with only the literals-02 file
 
 SKIP = [
     ('xml', 'test/n3/n3-writer-test-29.n3'),  # has predicates that cannot be shortened to strict qnames
-    ('application/rdf+xml', 'test/n3/n3-writer-test-29.n3'),  # has predicates that cannot be shortened to strict qnames
     ('xml', 'test/nt/qname-02.nt'),  # uses a property that cannot be qname'd
-    # uses a property that cannot be qname'd
-    ('application/rdf+xml', 'test/nt/qname-02.nt'),
+    ('trix', 'test/n3/strquot.n3'),  # contains charachters forbidden by the xml spec
+    ('xml', 'test/n3/strquot.n3'),  # contains charachters forbidden by the xml spec
 ]
 
 
@@ -48,6 +47,7 @@ def roundtrip(e, verbose=False):
     if verbose:
         print("S:")
         print(s)
+        print(s.decode())
 
     g2 = rdflib.ConjunctiveGraph()
     g2.parse(data=s, format=testfmt)
@@ -57,12 +57,12 @@ def roundtrip(e, verbose=False):
         print("Diff:")
         print("%d triples in both" % len(both))
         print("G1 Only:")
-        for t in first:
+        for t in sorted(first):
             print(t)
 
         print("--------------------")
         print("G2 Only")
-        for t in second:
+        for t in sorted(second):
             print(t)
 
     assert rdflib.compare.isomorphic(g1, g2)

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -28,6 +28,8 @@ tests roundtripping through rdf/xml with only the literals-02 file
 
 
 SKIP = [
+    ('xml', 'test/n3/n3-writer-test-29.n3'),  # has predicates that cannot be shortened to strict qnames
+    ('application/rdf+xml', 'test/n3/n3-writer-test-29.n3'),  # has predicates that cannot be shortened to strict qnames
     ('xml', 'test/nt/qname-02.nt'),  # uses a property that cannot be qname'd
     # uses a property that cannot be qname'd
     ('application/rdf+xml', 'test/nt/qname-02.nt'),

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -5,8 +5,11 @@ import rdflib.compare
 try:
     from .test_nt_suite import all_nt_files
     assert all_nt_files
+    from .test_n3_suite import all_n3_files
+    assert all_n3_files
 except:
     from test.test_nt_suite import all_nt_files
+    from test.test_n3_suite import all_n3_files
 
 """
 Test round-tripping by all serializers/parser that are registerd.
@@ -84,6 +87,24 @@ def test_cases():
         if "/" in testfmt:
             continue  # skip double testing
         for f, infmt in all_nt_files():
+            if (testfmt, f) not in SKIP:
+                yield roundtrip, (infmt, testfmt, f)
+
+
+def test_n3():
+    global formats
+    if not formats:
+        serializers = set(
+            x.name for x in rdflib.plugin.plugins(
+                None, rdflib.plugin.Serializer))
+        parsers = set(
+            x.name for x in rdflib.plugin.plugins(
+                None, rdflib.plugin.Parser))
+        formats = parsers.intersection(serializers)
+
+    for testfmt in formats:
+        if "/" in testfmt: continue # skip double testing
+        for f, infmt in all_n3_files():
             if (testfmt, f) not in SKIP:
                 yield roundtrip, (infmt, testfmt, f)
 

--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -69,9 +69,12 @@ def test_turtle_valid_list():
     for o in g.objects(NS.s, NS.p):
         assert turtle_serializer.isValidList(o)
 
+
 def test_turtle_namespace():
    graph = Graph()
+   graph.bind('OBO', 'http://purl.obolibrary.org/obo/')
    graph.bind('GENO', 'http://purl.obolibrary.org/obo/GENO_')
+   graph.bind('RO', 'http://purl.obolibrary.org/obo/RO_')
    graph.bind('RO_has_phenotype',
                    'http://purl.obolibrary.org/obo/RO_0002200')
    graph.add((URIRef('http://example.org'),

--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -69,6 +69,21 @@ def test_turtle_valid_list():
     for o in g.objects(NS.s, NS.p):
         assert turtle_serializer.isValidList(o)
 
+def test_turtle_namespace():
+   graph = Graph()
+   graph.bind('GENO', 'http://purl.obolibrary.org/obo/GENO_')
+   graph.bind('RO_has_phenotype',
+                   'http://purl.obolibrary.org/obo/RO_0002200')
+   graph.add((URIRef('http://example.org'),
+              URIRef('http://purl.obolibrary.org/obo/RO_0002200'),
+              URIRef('http://purl.obolibrary.org/obo/GENO_0000385')))
+   output = [val for val in
+             graph.serialize(format='turtle').decode().splitlines()
+             if not val.startswith('@prefix')]
+   output = ' '.join(output)
+   assert 'RO_has_phenotype:' in output
+   assert 'GENO:0000385' in output
+
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
The way the compute_qname worked was to call split_uri
and then see if there was a match in self.store.prefix.
This produced incomplete behavior for namesapces that
end in LETTERS_ instead of / or #. This commit corrects
this behavior by iterating through name and testing
`namespace + name[:i]` to see if there is a matching prefix.
