### PR TITLE
Support newer transport_encoding parameter in html5lib parser call

### DIFF
--- a/rdflib/plugins/parsers/pyRdfa/__init__.py
+++ b/rdflib/plugins/parsers/pyRdfa/__init__.py
@@ -609,7 +609,10 @@ class pyRdfa :
 					if self.charset :
 						# This means the HTTP header has provided a charset, or the
 						# file is a local file when we suppose it to be a utf-8
-						dom = parser.parse(input, encoding=self.charset)
+						try:
+							dom = parser.parse(input, encoding=self.charset)
+						except TypeError:
+							dom = parser.parse(input, transport_encoding=self.charset)
 					else :
 						# No charset set. The HTMLLib parser tries to sniff into the
 						# the file to find a meta header for the charset; if that

--- a/requirements.py2.txt
+++ b/requirements.py2.txt
@@ -1,5 +1,5 @@
 flake8
-html5lib==1.0b8
+html5lib
 isodate
 pyparsing<=1.5.7
 SPARQLWrapper

--- a/requirements.py3.txt
+++ b/requirements.py3.txt
@@ -1,5 +1,5 @@
 flake8
-html5lib==1.0b8
+html5lib
 isodate
 pyparsing
 SPARQLWrapper


### PR DESCRIPTION
Should fix https://github.com/RDFLib/rdflib/issues/642