### PR TITLE
Serialisation and parsing of infinity

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -38,6 +38,7 @@ __all__ = [
 import logging
 logger = logging.getLogger(__name__)
 import warnings
+import math
 
 import base64
 import xml.dom.minidom
@@ -1193,7 +1194,12 @@ class Literal(Identifier):
             %(u)s'"1"^^xsd:integer'
 
         '''
-        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES:
+
+        # If self is infinity then we must use a xsd:float datatype
+        # (no plain representation)
+        is_inf = math.isinf(float(self))
+
+        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES and not is_inf:
             if self.value is not None:
 
                 # this is a bit of a mess -
@@ -1255,7 +1261,8 @@ class Literal(Identifier):
                 '\n', '\\n').replace(
                     '\\', '\\\\').replace(
                         '"', '\\"').replace(
-                            '\r', '\\r')
+                            '\r', '\\r').replace(
+                                "inf", "INF")
 
     if not py3compat.PY3:
         def __str__(self):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1197,7 +1197,8 @@ class Literal(Identifier):
 
         # If self is infinity or not-a-number, we must use a xsd:float datatype
         # (no plain representation)
-        is_inf_nan = math.isinf(float(self)) or math.isnan(float(self))
+        is_inf_nan = (self.datatype == _XSD_DOUBLE) and \
+            (math.isinf(float(self)) or math.isnan(float(self)))
 
         if use_plain and self.datatype in _PLAIN_LITERAL_TYPES \
                 and not is_inf_nan:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1195,11 +1195,12 @@ class Literal(Identifier):
 
         '''
 
-        # If self is infinity then we must use a xsd:float datatype
+        # If self is infinity or not-a-number, we must use a xsd:float datatype
         # (no plain representation)
-        is_inf = math.isinf(float(self))
+        is_inf_nan = math.isinf(float(self)) or math.isnan(float(self))
 
-        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES and not is_inf:
+        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES \
+                and not is_inf_nan:
             if self.value is not None:
 
                 # this is a bit of a mess -
@@ -1262,7 +1263,8 @@ class Literal(Identifier):
                     '\\', '\\\\').replace(
                         '"', '\\"').replace(
                             '\r', '\\r').replace(
-                                "inf", "INF")
+                                "inf", "INF").replace(
+                                    "nan", "NaN")
 
     if not py3compat.PY3:
         def __str__(self):

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -19,8 +19,6 @@ class TestIssue655(unittest.TestCase):
         g2 = Graph()
         g2.parse(data=g1.serialize(format='turtle'), format='turtle')
 
-        self.assertTrue(g1.serialize(
-            format='turtle') == g2.serialize(format='turtle'))
         self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
 
         self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -9,11 +9,11 @@ class TestIssue655(unittest.TestCase):
         PROV = Namespace('http://www.w3.org/ns/prov#')
 
         bob = URIRef("http://example.org/object/Bob")
-        value = Literal(float("inf"))
 
-        # g1 is a simple graph with one attribute having an infinite value
+        # g1 is a simple graph with an infinite and a nan values
         g1 = Graph()
-        g1.add((bob, PROV.value, value))
+        g1.add((bob, PROV.value, Literal(float("inf"))))
+        g1.add((bob, PROV.value, Literal(float("nan"))))
 
         # Build g2 out of the deserialisation of g1 serialisation
         g2 = Graph()
@@ -23,5 +23,7 @@ class TestIssue655(unittest.TestCase):
 
         self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')
         self.assertTrue(Literal(float("-inf")).n3().split("^")[0] == '"-INF"')
+        self.assertTrue(Literal(float("nan")).n3().split("^")[0] == '"NaN"')
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -3,9 +3,9 @@ from rdflib.compare import to_isomorphic
 import unittest
 
 
-class TestIssueXXXX(unittest.TestCase):
+class TestIssue655(unittest.TestCase):
 
-    def test_issuexxxx(self):
+    def test_issue655(self):
         PROV = Namespace('http://www.w3.org/ns/prov#')
 
         bob = URIRef("http://example.org/object/Bob")

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -23,5 +23,7 @@ class TestIssue655(unittest.TestCase):
             format='turtle') == g2.serialize(format='turtle'))
         self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
 
+        self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')
+        self.assertTrue(Literal(float("-inf")).n3().split("^")[0] == '"-INF"')
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_issuexxx.py
+++ b/test/test_issuexxx.py
@@ -1,0 +1,27 @@
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.compare import to_isomorphic
+import unittest
+
+
+class TestIssueXXXX(unittest.TestCase):
+
+    def test_issuexxxx(self):
+        PROV = Namespace('http://www.w3.org/ns/prov#')
+
+        bob = URIRef("http://example.org/object/Bob")
+        value = Literal(float("inf"))
+
+        # g1 is a simple graph with one attribute having an infinite value
+        g1 = Graph()
+        g1.add((bob, PROV.value, value))
+
+        # Build g2 out of the deserialisation of g1 serialisation
+        g2 = Graph()
+        g2.parse(data=g1.serialize(format='turtle'), format='turtle')
+
+        self.assertTrue(g1.serialize(
+            format='turtle') == g2.serialize(format='turtle'))
+        self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request is a proposed fix for the serialisation of infinite values. 

Currently infinity is serialised as ` inf ` (with no data-type) which causes an error if parsed. 

Here is a minimal example:
```
from rdflib import Graph, Namespace, URIRef, Literal

PROV = Namespace('http://www.w3.org/ns/prov#')
bob = URIRef("http://example.org/object/Bob")
value = Literal(float("inf"))

# g1 is a simple graph with one attribute having an infinite value
g1 = Graph()
g1.add((bob, PROV.value, value))

# Build g2 out of the deserialisation of g1 serialisation
g2 = Graph()
g2.parse(data=g1.serialize(format='turtle'), format='turtle')
```
that throws the following error:
```
Traceback (most recent call last):
  File "test_read_inf.py", line 14, in <module>
    g2.parse(data=g1.serialize(format='turtle'), format='turtle')
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/graph.py", line 1042, in parse
    parser.parse(source, self, **args)
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 1870, in parse
    p.loadStream(source.getByteStream())
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 434, in loadStream
    return self.loadBuf(stream.read())    # Not ideal
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 440, in loadBuf
    self.feed(buf)
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 466, in feed
    i = self.directiveOrStatement(s, j)
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 487, in directiveOrStatement
    j = self.statement(argstr, i)
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 725, in statement
    j = self.property_list(argstr, i, r[0])
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 1089, in property_list
    "objectList expected")
  File "[...]/anaconda/envs/prov_dev/lib/python3.5/site-packages/rdflib-4.2.2.dev0-py3.5.egg/rdflib/plugins/parsers/notation3.py", line 1615, in BadSyntax
    raise BadSyntax(self._thisDoc, self.lines, argstr, i, msg)
rdflib.plugins.parsers.notation3.BadSyntax: at line 7 of <>:
Bad syntax (objectList expected) at ^ in:
"...b'001/XMLSchema#> .\n\n<http://example.org/object/Bob> ns1:value'^b' inf .\n\n'"
```

This PR includes:
 - Update of `term.py` to serialise infinity as `"INF"^^xsd:float` (cf. https://www.w3.org/TR/xmlschema-2/). 
 - The updated behaviour is tested in `test_issuexxx.py`.
