### PR TITLE
Parse implicit string

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -286,6 +286,7 @@ DECIMAL_DATATYPE = _XSD_PFX + "decimal"
 DOUBLE_DATATYPE = _XSD_PFX + "double"
 FLOAT_DATATYPE = _XSD_PFX + "float"
 INTEGER_DATATYPE = _XSD_PFX + "integer"
+STRING_DATATYPE = _XSD_PFX + "string"
 
 option_noregen = 0    # If set, do not regenerate genids on output
 
@@ -1790,6 +1791,10 @@ class RDFSink(object):
 
         if isinstance(n, float):
             s = Literal(str(n), datatype=DOUBLE_DATATYPE)
+            return s
+
+        if isinstance(n, Literal) and (n.datatype is None):
+            s = Literal(str(n), datatype=STRING_DATATYPE)
             return s
 
         if isinstance(f, Formula):

--- a/test/test_issue657.py
+++ b/test/test_issue657.py
@@ -3,7 +3,7 @@ from rdflib.compare import to_isomorphic
 import unittest
 
 
-class TestIssuexxx(unittest.TestCase):
+class TestIssue657(unittest.TestCase):
 
     def test_graph_equivalence(self):
         g1_ttl = """

--- a/test/test_issuexxx.py
+++ b/test/test_issuexxx.py
@@ -1,0 +1,34 @@
+from rdflib import Graph
+from rdflib.compare import to_isomorphic
+import unittest
+
+
+class TestIssuexxx(unittest.TestCase):
+
+    def test_graph_equivalence(self):
+        g1_ttl = """
+        @prefix prov: <http://www.w3.org/ns/prov#> .
+        @prefix ex: <http://example.org/#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:Bob prov:label "Bob"^^xsd:string ;
+               prov:value "10.0"^^xsd:double .
+        """
+        g1 = Graph()
+        g1.parse(data=g1_ttl, format='turtle')
+
+        g2_ttl = """
+        @prefix prov: <http://www.w3.org/ns/prov#> .
+        @prefix ex: <http://example.org/#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:Bob prov:label "Bob" ;
+               prov:value 10E0.0 .
+        """
+        g2 = Graph()
+        g2.parse(data=g2_ttl, format='turtle')
+
+        self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request is a proposed fix for the parsing of quoted literals with implicit string datatype, such as `"Bob"` in:
```
        @prefix prov: <http://www.w3.org/ns/prov#> .
        @prefix ex: <http://example.org/#> .
        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

        ex:Bob prov:label "Bob" .
```

Currently parsing the above example creates a Literal with a `None` datatype. 

This PR includes:
 - Update of `notation3.py` to deserialise quoted literals with no datatype as `xsd:string` (cf. https://www.w3.org/TR/turtle/#h4_turtle-literals). 
 - The updated behaviour is tested in `test_issuexxx.py`.
