### PR TITLE
improve serialization of inf/nan

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1228,6 +1228,15 @@ class Literal(Identifier):
                 quoted_dt = qname_callback(datatype)
             if not quoted_dt:
                 quoted_dt = "<%s>" % datatype
+            if datatype in _NUMERIC_INF_NAN_LITERAL_TYPES:
+                v = float(self)
+                if math.isinf(v):
+                    # python's string reps: float: 'inf', Decimal: 'Infinity"
+                    # both need to become "INF" in xsd datatypes
+                    encoded = encoded.replace('inf', 'INF').replace(
+                        'Infinity', 'INF')
+                if math.isnan(v):
+                    encoded = encoded.replace('nan', 'NaN')
 
         language = self.language
         if language:
@@ -1262,9 +1271,7 @@ class Literal(Identifier):
                 '\n', '\\n').replace(
                     '\\', '\\\\').replace(
                         '"', '\\"').replace(
-                            '\r', '\\r').replace(
-                                "inf", "INF").replace(
-                                    "nan", "NaN")
+                            '\r', '\\r')
 
     if not py3compat.PY3:
         def __str__(self):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1194,15 +1194,14 @@ class Literal(Identifier):
             %(u)s'"1"^^xsd:integer'
 
         '''
-
-        # If self is infinity or not-a-number, we must use a xsd:float datatype
-        # (no plain representation)
-        is_inf_nan = (self.datatype == _XSD_DOUBLE) and \
-            (math.isinf(float(self)) or math.isnan(float(self)))
-
-        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES \
-                and not is_inf_nan:
+        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES:
             if self.value is not None:
+                # If self is inf or NaN, we need a datatype
+                # (there is no plain representation)
+                if self.datatype in _NUMERIC_INF_NAN_LITERAL_TYPES:
+                    v = float(self)
+                    if math.isinf(v) or math.isnan(v):
+                        return self._literal_n3(False, qname_callback)
 
                 # this is a bit of a mess -
                 # in py >=2.6 the string.format function makes this easier
@@ -1394,6 +1393,13 @@ _NUMERIC_LITERAL_TYPES = (
 _PLAIN_LITERAL_TYPES = (
     _XSD_INTEGER,
     _XSD_BOOLEAN,
+    _XSD_DOUBLE,
+    _XSD_DECIMAL,
+)
+
+# these have special INF and NaN XSD representations
+_NUMERIC_INF_NAN_LITERAL_TYPES = (
+    URIRef(_XSD_PFX + 'float'),
     _XSD_DOUBLE,
     _XSD_DECIMAL,
 )

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -38,6 +38,7 @@ __all__ = [
 import logging
 logger = logging.getLogger(__name__)
 import warnings
+import math
 
 import base64
 import xml.dom.minidom
@@ -1193,7 +1194,12 @@ class Literal(Identifier):
             %(u)s'"1"^^xsd:integer'
 
         '''
-        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES:
+
+        # If self is infinity then we must use a xsd:float datatype
+        # (no plain representation)
+        is_inf = math.isinf(float(self))
+
+        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES and not is_inf:
             if self.value is not None:
 
                 # this is a bit of a mess -
@@ -1255,7 +1261,8 @@ class Literal(Identifier):
                 '\n', '\\n').replace(
                     '\\', '\\\\').replace(
                         '"', '\\"').replace(
-                            '\r', '\\r')
+                            '\r', '\\r').replace(
+                                "inf", "INF")
 
     if not py3compat.PY3:
         def __str__(self):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1197,7 +1197,8 @@ class Literal(Identifier):
 
         # If self is infinity or not-a-number, we must use a xsd:float datatype
         # (no plain representation)
-        is_inf_nan = math.isinf(float(self)) or math.isnan(float(self))
+        is_inf_nan = (self.datatype == _XSD_DOUBLE) and \
+            (math.isinf(float(self)) or math.isnan(float(self)))
 
         if use_plain and self.datatype in _PLAIN_LITERAL_TYPES \
                 and not is_inf_nan:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1195,11 +1195,12 @@ class Literal(Identifier):
 
         '''
 
-        # If self is infinity then we must use a xsd:float datatype
+        # If self is infinity or not-a-number, we must use a xsd:float datatype
         # (no plain representation)
-        is_inf = math.isinf(float(self))
+        is_inf_nan = math.isinf(float(self)) or math.isnan(float(self))
 
-        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES and not is_inf:
+        if use_plain and self.datatype in _PLAIN_LITERAL_TYPES \
+                and not is_inf_nan:
             if self.value is not None:
 
                 # this is a bit of a mess -
@@ -1262,7 +1263,8 @@ class Literal(Identifier):
                     '\\', '\\\\').replace(
                         '"', '\\"').replace(
                             '\r', '\\r').replace(
-                                "inf", "INF")
+                                "inf", "INF").replace(
+                                    "nan", "NaN")
 
     if not py3compat.PY3:
         def __str__(self):

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -19,8 +19,6 @@ class TestIssue655(unittest.TestCase):
         g2 = Graph()
         g2.parse(data=g1.serialize(format='turtle'), format='turtle')
 
-        self.assertTrue(g1.serialize(
-            format='turtle') == g2.serialize(format='turtle'))
         self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
 
         self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -9,11 +9,11 @@ class TestIssue655(unittest.TestCase):
         PROV = Namespace('http://www.w3.org/ns/prov#')
 
         bob = URIRef("http://example.org/object/Bob")
-        value = Literal(float("inf"))
 
-        # g1 is a simple graph with one attribute having an infinite value
+        # g1 is a simple graph with an infinite and a nan values
         g1 = Graph()
-        g1.add((bob, PROV.value, value))
+        g1.add((bob, PROV.value, Literal(float("inf"))))
+        g1.add((bob, PROV.value, Literal(float("nan"))))
 
         # Build g2 out of the deserialisation of g1 serialisation
         g2 = Graph()
@@ -23,5 +23,7 @@ class TestIssue655(unittest.TestCase):
 
         self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')
         self.assertTrue(Literal(float("-inf")).n3().split("^")[0] == '"-INF"')
+        self.assertTrue(Literal(float("nan")).n3().split("^")[0] == '"NaN"')
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -3,9 +3,9 @@ from rdflib.compare import to_isomorphic
 import unittest
 
 
-class TestIssueXXXX(unittest.TestCase):
+class TestIssue655(unittest.TestCase):
 
-    def test_issuexxxx(self):
+    def test_issue655(self):
         PROV = Namespace('http://www.w3.org/ns/prov#')
 
         bob = URIRef("http://example.org/object/Bob")

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -23,5 +23,7 @@ class TestIssue655(unittest.TestCase):
             format='turtle') == g2.serialize(format='turtle'))
         self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
 
+        self.assertTrue(Literal(float("inf")).n3().split("^")[0] == '"INF"')
+        self.assertTrue(Literal(float("-inf")).n3().split("^")[0] == '"-INF"')
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_issuexxx.py
+++ b/test/test_issuexxx.py
@@ -1,0 +1,27 @@
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.compare import to_isomorphic
+import unittest
+
+
+class TestIssueXXXX(unittest.TestCase):
+
+    def test_issuexxxx(self):
+        PROV = Namespace('http://www.w3.org/ns/prov#')
+
+        bob = URIRef("http://example.org/object/Bob")
+        value = Literal(float("inf"))
+
+        # g1 is a simple graph with one attribute having an infinite value
+        g1 = Graph()
+        g1.add((bob, PROV.value, value))
+
+        # Build g2 out of the deserialisation of g1 serialisation
+        g2 = Graph()
+        g2.parse(data=g1.serialize(format='turtle'), format='turtle')
+
+        self.assertTrue(g1.serialize(
+            format='turtle') == g2.serialize(format='turtle'))
+        self.assertTrue(to_isomorphic(g1) == to_isomorphic(g2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
merge closes #655

extends #655 by exempting inf/nan values from plain literal representation (without datatype). Also fixes replacing inf/nan with INF/NaN in non-numerical types on serialization.