### PR TITLE
fix: allow registered prefix use and namespaces which are URIs closes #632

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -370,6 +370,7 @@ class NamespaceManager(object):
 
             if replace:
                 self.store.bind(prefix, namespace)
+                self.__cache[namespace] = (prefix, namespace, '')
                 return
 
             # prefix already in use for different namespace
@@ -390,16 +391,19 @@ class NamespaceManager(object):
                     break
                 num += 1
             self.store.bind(new_prefix, namespace)
+            self.__cache[namespace] = (new_prefix, namespace, '')
         else:
             bound_prefix = self.store.prefix(namespace)
             if bound_prefix is None:
                 self.store.bind(prefix, namespace)
+                self.__cache[namespace] = (prefix, namespace, '')
             elif bound_prefix == prefix:
                 pass  # already bound
             else:
                 if override or bound_prefix.startswith("_"):  # or a generated
                                                               # prefix
                     self.store.bind(prefix, namespace)
+                    self.__cache[namespace] = (prefix, namespace, '')
 
     def namespaces(self):
         for prefix, namespace in self.store.namespaces():

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -20,6 +20,14 @@ class NamespacePrefixTest(unittest.TestCase):
         self.assertEqual(g.compute_qname(URIRef("http://blip/blop")),
             ("ns4", URIRef("http://blip/"), "blop"))
 
+        g.bind("ns5", URIRef("http://example.org/#special"))
+        self.assertEqual(g.compute_qname(URIRef("http://example.org/#special")),
+            ('ns5', URIRef('http://example.org/#special'), ''))
+
+        g.bind("ns6", URIRef("http://example.org/#special"))
+        self.assertEqual(g.compute_qname(URIRef("http://example.org/#special")),
+                     ('ns6', URIRef('http://example.org/#special'), ''))
+
     def test_n3(self):
         g = Graph()
         g.add((URIRef("http://example.com/foo"),

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -26,7 +26,7 @@ class NamespacePrefixTest(unittest.TestCase):
 
         g.bind("ns6", URIRef("http://example.org/#special"))
         self.assertEqual(g.compute_qname(URIRef("http://example.org/#special")),
-                     ('ns6', URIRef('http://example.org/#special'), ''))
+                     ('ns5', URIRef('http://example.org/#special'), ''))
 
     def test_n3(self):
         g = Graph()


### PR DESCRIPTION
cache namespaces during the bind process.

closes #632 