### PR TITLE
fix: namespace use for turtle-based serializers

### DIFF
--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -82,7 +82,7 @@ def test_turtle_namespace():
               graph.serialize(format='turtle').decode().splitlines()
               if not val.startswith('@prefix')]
     output = ' '.join(output)
-    assert 'RO_has_phenotype:' in output
+    assert 'RO_has_phenotype: ' in output
     assert 'GENO:0000385' in output
 
 

--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -71,7 +71,19 @@ def test_turtle_valid_list():
 
 
 def test_turtle_namespace():
-    
+    graph = Graph()
+    graph.bind('GENO', 'http://purl.obolibrary.org/obo/GENO_')
+    graph.bind('RO_has_phenotype',
+                    'http://purl.obolibrary.org/obo/RO_0002200')
+    graph.add((URIRef('http://example.org'),
+               URIRef('http://purl.obolibrary.org/obo/RO_0002200'),
+               URIRef('http://purl.obolibrary.org/obo/GENO_0000385')))
+    output = [val for val in
+              graph.serialize(format='turtle').decode().splitlines()
+              if not val.startswith('@prefix')]
+    output = ' '.join(output)
+    assert 'RO_has_phenotype:' in output
+    assert 'GENO:0000385' in output
 
 
 if __name__ == "__main__":

--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -70,6 +70,10 @@ def test_turtle_valid_list():
         assert turtle_serializer.isValidList(o)
 
 
+def test_turtle_namespace():
+    
+
+
 if __name__ == "__main__":
     import nose, sys
     nose.main(defaultTest=sys.argv[0])


### PR DESCRIPTION
this time i do think it addresses #632 and #660 better

@gromgull - could you please take a look? the changes are now restricted to the turtle serializer.