### PR TITLE
Fix date serialization failure

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -820,7 +820,10 @@ class Literal(Identifier):
                     return self.language > other.language
 
             if self.value != None and other.value != None:
-                return self.value > other.value
+                try:
+                    return self.value > other.value
+                except TypeError:
+                    return str(self.value) > str(other.value)
 
             if unicode(self) != unicode(other):
                 return unicode(self) > unicode(other)


### PR DESCRIPTION
If the first comparison doesn't work, it goes to string comparison.
For the issue #648 