### PR TITLE
make test 375 more portable (use sys.executable rather than python)

### DIFF
--- a/test/test_issue375.py
+++ b/test/test_issue375.py
@@ -159,7 +159,7 @@ def test_rdfpipe_bytes_vs_str():
     explicitly exposes sys.stdout.buffer for this purpose. Test
     rdfpipe to ensure that we get the expected results.
     """
-    args = ['python', 'rdflib/tools/rdfpipe.py', '-i', 'rdfa1.1', 'test/rdfa/oreilly.html']
+    args = [sys.executable, 'rdflib/tools/rdfpipe.py', '-i', 'rdfa1.1', 'test/rdfa/oreilly.html']
     proc = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True, env=env)
     res = ''
     while proc.poll() is None:
@@ -174,7 +174,7 @@ def test_rdfpipe_mdata_open():
     The file() builtin has been deprecated for a long time. Use
     the open() builtin instead.
     """
-    args = ['python', 'rdflib/tools/rdfpipe.py', '-i', 'mdata', 'test/mdata/codelab.html']
+    args = [sys.executable, 'rdflib/tools/rdfpipe.py', '-i', 'mdata', 'test/mdata/codelab.html']
     proc = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True, env=env)
     res = ''
     while proc.poll() is None:


### PR DESCRIPTION
thanks to @chrysn, fixes #664