### PR TITLE
Adding the option of using POST for queries in SPARQLStore

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -239,7 +239,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                  sparql11=True, context_aware=True,
                  node_to_sparql=_node_to_sparql,
                  node_from_result=_node_from_result,
-                 query_as_post=False,
+                 default_query_method=GET,
                  **sparqlwrapper_kwargs):
         """
         """
@@ -260,7 +260,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         self.context_aware = context_aware
         self.graph_aware = context_aware
         self._timeout = None
-        self.query_as_post = query_as_post
+        self.default_query_method = default_query_method
 
     # Database Management Methods
     def create(self, configuration):
@@ -324,7 +324,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                    " ".join(self.node_to_sparql(initBindings[x]) for x in v))
 
         self.resetQuery()
-        self.setMethod(POST if self.query_as_post else GET)
+        self.setMethod(self.default_query_method)
         if self._is_contextual(queryGraph):
             self.addParameter("default-graph-uri", queryGraph)
         self.timeout = self._timeout

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -260,7 +260,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         self.context_aware = context_aware
         self.graph_aware = context_aware
         self._timeout = None
-        self.default_query_method = default_query_method
+        self.query_method = default_query_method
 
     # Database Management Methods
     def create(self, configuration):
@@ -324,7 +324,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                    " ".join(self.node_to_sparql(initBindings[x]) for x in v))
 
         self.resetQuery()
-        self.setMethod(self.default_query_method)
+        self.setMethod(self.query_method)
         if self._is_contextual(queryGraph):
             self.addParameter("default-graph-uri", queryGraph)
         self.timeout = self._timeout

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -239,6 +239,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                  sparql11=True, context_aware=True,
                  node_to_sparql=_node_to_sparql,
                  node_from_result=_node_from_result,
+                 query_as_post=False,
                  **sparqlwrapper_kwargs):
         """
         """
@@ -259,6 +260,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         self.context_aware = context_aware
         self.graph_aware = context_aware
         self._timeout = None
+        self.query_as_post = query_as_post
 
     # Database Management Methods
     def create(self, configuration):
@@ -322,6 +324,7 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                    " ".join(self.node_to_sparql(initBindings[x]) for x in v))
 
         self.resetQuery()
+        self.setMethod(POST if self.query_as_post else GET)
         if self._is_contextual(queryGraph):
             self.addParameter("default-graph-uri", queryGraph)
         self.timeout = self._timeout


### PR DESCRIPTION
Solution to #672

Just adding a small parameter to be able to use POST for queries in order to to perform long requests.

Previously :
```python
graph = Graph('SPARQLUpdateStore', identifier='http://localhost:8890/WGA') 
graph.query('<VERY LONG STRING>')
# Query get cropped because it's done with HTTP GET
```

Now :
```python
from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
store = sparqlstore.SPARQLUpdateStore(query_as_post=True)
graph = Graph(store, identifier='http://localhost:8890/WGA') 
graph.query('<VERY LONG STRING>')
# Works!
```

Tiny changes based on [postAsEncoded param in SPARQLUpdateStore](https://github.com/RDFLib/rdflib/blob/master/rdflib/plugins/stores/sparqlstore.py#L763)