### PR TITLE
Allow duplicates in rdf:List

### DIFF
--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -82,12 +82,7 @@ class Collection(object):
 
     def __len__(self):
         """length of items in collection."""
-        count = 0
-        links = set()
-        for item in self.graph.items(self.uri):
-            links.add(item)
-            count += 1
-        return count
+        return len(list(self.graph.items(self.uri)))
 
     def index(self, item):
         """

--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -85,9 +85,6 @@ class Collection(object):
         count = 0
         links = set()
         for item in self.graph.items(self.uri):
-            assert item not in links, \
-                "There is a loop in the RDF list! " + \
-                "(%s has been processed before)" % item
             links.add(item)
             count += 1
         return count

--- a/test/test_issue223.py
+++ b/test/test_issue223.py
@@ -1,0 +1,17 @@
+from rdflib.graph import Graph
+from rdflib.term import URIRef
+from rdflib.collection import Collection
+
+ttl = """
+@prefix : <http://example.org/>.
+
+:s :p (:a :b :a).
+"""
+def test_collection_with_duplicates():
+    g = Graph().parse(data=ttl, format="turtle")
+    for _,_,o in g.triples((URIRef("http://example.org/s"), URIRef("http://example.org/p"), None)):
+        break
+    c = list(Collection(g, o))
+
+if __name__ == '__main__':
+    test_collection_with_duplicates()

--- a/test/test_issue223.py
+++ b/test/test_issue223.py
@@ -11,8 +11,9 @@ def test_collection_with_duplicates():
     g = Graph().parse(data=ttl, format="turtle")
     for _,_,o in g.triples((URIRef("http://example.org/s"), URIRef("http://example.org/p"), None)):
         break
-    c = list(Collection(g, o))
-    assert c == list(URIRef("http://example.org/" + x) for x in ["a", "b", "a"])
-
+    c = Collection(g, o)
+    assert list(c) == list(URIRef("http://example.org/" + x) for x in ["a", "b", "a"])
+    assert len(c) == 3
+    
 if __name__ == '__main__':
     test_collection_with_duplicates()

--- a/test/test_issue223.py
+++ b/test/test_issue223.py
@@ -12,6 +12,7 @@ def test_collection_with_duplicates():
     for _,_,o in g.triples((URIRef("http://example.org/s"), URIRef("http://example.org/p"), None)):
         break
     c = list(Collection(g, o))
+    assert c == list(URIRef("http://example.org/" + x) for x in ["a", "b", "a"])
 
 if __name__ == '__main__':
     test_collection_with_duplicates()


### PR DESCRIPTION
The check causing the problem in #223 is incorrect. This addresses the first half of the issue, allowing duplicates in lists. It does not address closing the list.