### PR TITLE
Fix for filters in sub-queries

### DIFF
--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -431,15 +431,18 @@ def _findVars(x, res):
 
 
 def _addVars(x, children):
-    # import pdb; pdb.set_trace()
+    """
+    find which variables may be bound by this part of the query
+    """
     if isinstance(x, Variable):
         return set([x])
     elif isinstance(x, CompValue):
-        if x.name == "Extend":
+        if x.name == "RelationalExpression":
+            x["_vars"] = set()
+        elif x.name == "Extend":
             # vars only used in the expr for a bind should not be included
             x["_vars"] = reduce(operator.or_, [ child for child,part in zip(children,x) if part!='expr' ], set())
 
-            return set([x.var]) # perhaps this should expose all vars here too?
         else:
             x["_vars"] = set(reduce(operator.or_, children, set()))
 
@@ -450,6 +453,9 @@ def _addVars(x, children):
                     s = set()
 
                 return s
+
+        return x["_vars"]
+
     return reduce(operator.or_, children, set())
 
 

--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -152,7 +152,7 @@ def evalLeftJoin(ctx, join):
 def evalFilter(ctx, part):
     # TODO: Deal with dict returned from evalPart!
     for c in evalPart(ctx, part.p):
-        if _ebv(part.expr, c.forget(ctx) if not part.no_isolated_scope else c):
+        if _ebv(part.expr, c.forget(ctx, _except=part._vars) if not part.no_isolated_scope else c):
             yield c
 
 

--- a/test/DAWG/rdflib/filteroptional.rq
+++ b/test/DAWG/rdflib/filteroptional.rq
@@ -1,0 +1,8 @@
+SELECT  ?this
+WHERE {
+    VALUES ?this { <http://ex.com/a>  "HI"  }
+    OPTIONAL {
+        VALUES ?this { <http://ex.com/a> "HI" }
+        FILTER ( isIRI(?this) )
+    }
+}

--- a/test/DAWG/rdflib/filtersubquery.tsv
+++ b/test/DAWG/rdflib/filtersubquery.tsv
@@ -1,0 +1,2 @@
+?this
+<http://ex.com/a>

--- a/test/DAWG/rdflib/filtersubquery1.rq
+++ b/test/DAWG/rdflib/filtersubquery1.rq
@@ -1,0 +1,4 @@
+SELECT ?this WHERE {
+  VALUES ?this { <http://ex.com/a> "HI" }
+  FILTER ( isIRI(?this) )
+}

--- a/test/DAWG/rdflib/filtersubquery2.rq
+++ b/test/DAWG/rdflib/filtersubquery2.rq
@@ -1,0 +1,10 @@
+SELECT  ?this
+WHERE {
+    { SELECT ?this WHERE {
+        VALUES ?this { <http://ex.com/a>  "HI"  }
+        FILTER ( isIRI(?this) )
+      } }
+    { SELECT ?this WHERE {
+        VALUES ?this { <http://ex.com/a> "HI" }
+      } }
+}

--- a/test/DAWG/rdflib/filtersubquery3.rq
+++ b/test/DAWG/rdflib/filtersubquery3.rq
@@ -1,0 +1,10 @@
+SELECT  ?this
+WHERE {
+    { SELECT ?this WHERE {
+        VALUES ?this { <http://ex.com/a>  "HI"  }
+      } }
+    { SELECT ?this WHERE {
+        VALUES ?this { <http://ex.com/a> "HI" }
+        FILTER ( isIRI(?this) )
+      } }
+}

--- a/test/DAWG/rdflib/manifest.ttl
+++ b/test/DAWG/rdflib/manifest.ttl
@@ -18,6 +18,10 @@
     :notexistsfilter
     :bindscope
     :bindscope2
+    :filtersubquery1
+    :filtersubquery2
+    :filtersubquery3
+    :filteroptional
 	) .
 
 
@@ -110,4 +114,55 @@ From https://github.com/RDFLib/rdflib/issues/615, contributed by https://github.
          [ qt:query  <bindscope2.rq> ;
            qt:data <bindscope.ttl> ] ;
     mf:result  <bindscope2.tsv>
+    .
+
+:filtersubquery1 rdf:type mf:QueryEvaluationTest ;
+    mf:name "filters in subqueries 1";
+    rdfs:comment """
+    From https://github.com/RDFLib/rdflib/issues/619, contributed by https://github.com/pfps
+""";
+    dawgt:approval dawgt:Approved ;
+    dawgt:approvedBy <http://gromgull.net/me> ;
+    mf:action
+         [ qt:query  <filtersubquery1.rq> ] ;
+    mf:result  <filtersubquery.tsv>
+    .
+
+
+:filtersubquery2 rdf:type mf:QueryEvaluationTest ;
+    mf:name "filters in subqueries 2 - filter in first subquery";
+    rdfs:comment """
+    From https://github.com/RDFLib/rdflib/issues/619, contributed by https://github.com/pfps
+""";
+    dawgt:approval dawgt:Approved ;
+    dawgt:approvedBy <http://gromgull.net/me> ;
+    mf:action
+         [ qt:query  <filtersubquery2.rq> ] ;
+    mf:result  <filtersubquery.tsv>
+    .
+
+
+:filtersubquery3 rdf:type mf:QueryEvaluationTest ;
+    mf:name "filters in subqueries 2 - filter in second subquery";
+    rdfs:comment """
+    From https://github.com/RDFLib/rdflib/issues/619, contributed by https://github.com/pfps
+""";
+    dawgt:approval dawgt:Approved ;
+    dawgt:approvedBy <http://gromgull.net/me> ;
+    mf:action
+         [ qt:query  <filtersubquery3.rq> ] ;
+    mf:result  <filtersubquery.tsv>
+    .
+
+
+:filteroptional rdf:type mf:QueryEvaluationTest ;
+    mf:name "filters in optional";
+    rdfs:comment """
+    From https://github.com/RDFLib/rdflib/issues/619, contributed by https://github.com/pfps
+""";
+    dawgt:approval dawgt:Approved ;
+    dawgt:approvedBy <http://gromgull.net/me> ;
+    mf:action
+         [ qt:query  <filteroptional.rq> ] ;
+    mf:result  <filtersubquery.tsv>
     .


### PR DESCRIPTION
This was the same error as #580, but for SubQueries instead of binds.
Same fix as
https://github.com/RDFLib/rdflib/pull/688/commits/c1b29aea3803e6e25287cfdf794f030538bdfa7c

Excempt vars bound in the local scope from forgetting.