### PR TITLE
removing pyparsing version requirement

### DIFF
--- a/requirements.py2.txt
+++ b/requirements.py2.txt
@@ -1,5 +1,5 @@
 flake8
 html5lib
 isodate
-pyparsing<=1.5.7
+pyparsing
 SPARQLWrapper


### PR DESCRIPTION
The versioning requirement was put in place 4 years ago to handle older
versions of Python. setuptools no longer supports pyparsing < 2.1, so
we'll need to adhere to that to continue using pip or put a hard version
on pip. This seems like the more reasonable approach.