### PR TITLE
updating deprecated testing syntax

### DIFF
--- a/test/test_comparison.py
+++ b/test/test_comparison.py
@@ -40,31 +40,31 @@ class IdentifierEquality(unittest.TestCase):
         self.python_literal_2 = u"foo"
 
     def testA(self):
-        self.assertEquals(self.uriref==self.literal, False)
+        self.assertEqual(self.uriref==self.literal, False)
 
     def testB(self):
-        self.assertEquals(self.literal==self.uriref, False)
+        self.assertEqual(self.literal==self.uriref, False)
 
     def testC(self):
-        self.assertEquals(self.uriref==self.python_literal, False)
+        self.assertEqual(self.uriref==self.python_literal, False)
 
     def testD(self):
-        self.assertEquals(self.python_literal==self.uriref, False)
+        self.assertEqual(self.python_literal==self.uriref, False)
 
     def testE(self):
-        self.assertEquals(self.literal==self.python_literal, False)
+        self.assertEqual(self.literal==self.python_literal, False)
 
     def testE2(self): 
         self.assertTrue(self.literal.eq(self.python_literal), True)
 
     def testF(self):
-        self.assertEquals(self.python_literal==self.literal, False)
+        self.assertEqual(self.python_literal==self.literal, False)
 
     def testG(self):
-        self.assertEquals("foo" in CORE_SYNTAX_TERMS, False)
+        self.assertEqual("foo" in CORE_SYNTAX_TERMS, False)
 
     def testH(self):
-        self.assertEquals(URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#RDF") in CORE_SYNTAX_TERMS, True)
+        self.assertEqual(URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#RDF") in CORE_SYNTAX_TERMS, True)
 
     def testI(self):
         g = Graph()

--- a/test/test_conventions.py
+++ b/test/test_conventions.py
@@ -33,12 +33,11 @@ class A(unittest.TestCase):
             else:
                 if name!=name.lower() and name not in skip_as_ignorably_private:
                     names.add(name)
-                #self.assert_(name==name.lower(), "module name '%s' is not lower case" % name)
         return names
 
     def test_module_names(self):
         names = self.module_names()
-        self.assert_(names==set(), "module names '%s' are not lower case" % names)
+        self.assertTrue(names==set(), "module names '%s' are not lower case" % names)
 
 try:
     getattr(pkgutil, 'iter_modules')

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -89,37 +89,37 @@ class DatasetTestCase(unittest.TestCase):
         # empty named graphs
         if self.store != "SPARQLUpdateStore":
             # added graph exists
-            self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+            self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                               set([self.c1, DATASET_DEFAULT_GRAPH_ID]))
 
         # added graph is empty
-        self.assertEquals(len(g1), 0)
+        self.assertEqual(len(g1), 0)
 
         g1.add( (self.tarek, self.likes, self.pizza) )
 
         # added graph still exists
-        self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+        self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                           set([self.c1, DATASET_DEFAULT_GRAPH_ID]))
 
         # added graph contains one triple
-        self.assertEquals(len(g1), 1)
+        self.assertEqual(len(g1), 1)
 
         g1.remove( (self.tarek, self.likes, self.pizza) )
 
         # added graph is empty
-        self.assertEquals(len(g1), 0)
+        self.assertEqual(len(g1), 0)
 
         # Some SPARQL endpoint backends (e.g. TDB) do not consider
         # empty named graphs
         if self.store != "SPARQLUpdateStore":
             # graph still exists, although empty
-            self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+            self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                               set([self.c1, DATASET_DEFAULT_GRAPH_ID]))
 
         g.remove_graph(self.c1)
 
         # graph is gone
-        self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+        self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                           set([DATASET_DEFAULT_GRAPH_ID]))
 
     def testDefaultGraph(self):
@@ -129,17 +129,17 @@ class DatasetTestCase(unittest.TestCase):
                   "is supported by your SPARQL endpoint"
 
         self.graph.add(( self.tarek, self.likes, self.pizza))
-        self.assertEquals(len(self.graph), 1)
+        self.assertEqual(len(self.graph), 1)
         # only default exists
-        self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+        self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                           set([DATASET_DEFAULT_GRAPH_ID]))
 
         # removing default graph removes triples but not actual graph
         self.graph.remove_graph(DATASET_DEFAULT_GRAPH_ID)
 
-        self.assertEquals(len(self.graph), 0)
+        self.assertEqual(len(self.graph), 0)
         # default still exists
-        self.assertEquals(set(x.identifier for x in self.graph.contexts()),
+        self.assertEqual(set(x.identifier for x in self.graph.contexts()),
                           set([DATASET_DEFAULT_GRAPH_ID]))
 
     def testNotUnion(self):

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -15,7 +15,7 @@ class TestRelativeBase(unittest.TestCase):
     def test_equality(self):        
         x = Literal("2008-12-01T18:02:00Z",
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
-        self.assertEquals(x == x, True)
+        self.assertEqual(x == x, True)
 
     def test_microseconds(self):
         import platform
@@ -27,8 +27,8 @@ class TestRelativeBase(unittest.TestCase):
 
         # datetime with microseconds should be cast as a literal with using
         # XML Schema dateTime as the literal datatype
-        self.assertEquals(unicode(l), '2009-06-15T23:37:06.522630')
-        self.assertEquals(l.datatype, XSD.dateTime)
+        self.assertEqual(unicode(l), '2009-06-15T23:37:06.522630')
+        self.assertEqual(l.datatype, XSD.dateTime)
 
         dt2 = l.toPython()
         self.assertEqual(dt2, dt1)
@@ -38,19 +38,19 @@ class TestRelativeBase(unittest.TestCase):
         l = Literal(dt,
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
 
-        self.assert_(isinstance(l.toPython(), datetime))
-        self.assertEquals(l.toPython().isoformat(), dt)
+        self.assertTrue(isinstance(l.toPython(), datetime))
+        self.assertEqual(l.toPython().isoformat(), dt)
 
     def test_timezone_z(self):
         dt = "2008-12-01T18:02:00.522630Z"
         l = Literal(dt,
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
 
-        self.assert_(isinstance(l.toPython(), datetime))
-        self.assertEquals(datetime_isoformat(l.toPython(),
+        self.assertTrue(isinstance(l.toPython(), datetime))
+        self.assertEqual(datetime_isoformat(l.toPython(),
                                              DATE_EXT_COMPLETE + 'T' + '%H:%M:%S.%f' + TZ_EXT),
                           dt)
-        self.assertEquals(l.toPython().isoformat(),
+        self.assertEqual(l.toPython().isoformat(),
                           "2008-12-01T18:02:00.522630+00:00")
 
     def test_timezone_offset(self):
@@ -58,8 +58,8 @@ class TestRelativeBase(unittest.TestCase):
         l = Literal(dt,
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
 
-        self.assert_(isinstance(l.toPython(), datetime))
-        self.assertEquals(l.toPython().isoformat(), dt)
+        self.assertTrue(isinstance(l.toPython(), datetime))
+        self.assertEqual(l.toPython().isoformat(), dt)
 
     def test_timezone_offset_to_utc(self):
         dt = "2010-02-10T12:36:00+03:00"
@@ -67,7 +67,7 @@ class TestRelativeBase(unittest.TestCase):
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
 
         utc_dt = l.toPython().astimezone(UTC)
-        self.assertEquals(datetime_isoformat(utc_dt),
+        self.assertEqual(datetime_isoformat(utc_dt),
                           "2010-02-10T09:36:00Z")
 
     def test_timezone_offset_millisecond(self):
@@ -75,8 +75,8 @@ class TestRelativeBase(unittest.TestCase):
         l = Literal(dt,
                     datatype=URIRef('http://www.w3.org/2001/XMLSchema#dateTime'))
 
-        self.assert_(isinstance(l.toPython(), datetime))
-        self.assertEquals(l.toPython().isoformat(), dt)
+        self.assertTrue(isinstance(l.toPython(), datetime))
+        self.assertEqual(l.toPython().isoformat(), dt)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -91,7 +91,7 @@ class GraphTestCase(unittest.TestCase):
         hates = self.hates
         pizza = self.pizza
         cheese = self.cheese
-        asserte = self.assertEquals
+        asserte = self.assertEqual
         triples = self.graph.triples
         Any = None
 
@@ -137,14 +137,14 @@ class GraphTestCase(unittest.TestCase):
     def testConnected(self):
         graph = self.graph
         self.addStuff()
-        self.assertEquals(True, graph.connected())
+        self.assertEqual(True, graph.connected())
 
         jeroen = URIRef("jeroen")
         unconnected = URIRef("unconnected")
 
         graph.add((jeroen, self.likes, unconnected))
 
-        self.assertEquals(False, graph.connected())
+        self.assertEqual(False, graph.connected())
 
     def testSub(self):
         g1 = self.graph
@@ -165,19 +165,19 @@ class GraphTestCase(unittest.TestCase):
 
         g3 = g1 - g2
 
-        self.assertEquals(len(g3), 1)
-        self.assertEquals((tarek, likes, pizza) in g3, True)
-        self.assertEquals((tarek, likes, cheese) in g3, False)
+        self.assertEqual(len(g3), 1)
+        self.assertEqual((tarek, likes, pizza) in g3, True)
+        self.assertEqual((tarek, likes, cheese) in g3, False)
 
-        self.assertEquals((bob, likes, cheese) in g3, False)
+        self.assertEqual((bob, likes, cheese) in g3, False)
 
         g1 -= g2
 
-        self.assertEquals(len(g1), 1)
-        self.assertEquals((tarek, likes, pizza) in g1, True)
-        self.assertEquals((tarek, likes, cheese) in g1, False)
+        self.assertEqual(len(g1), 1)
+        self.assertEqual((tarek, likes, pizza) in g1, True)
+        self.assertEqual((tarek, likes, cheese) in g1, False)
 
-        self.assertEquals((bob, likes, cheese) in g1, False)
+        self.assertEqual((bob, likes, cheese) in g1, False)
 
     def testGraphAdd(self):
         g1 = self.graph
@@ -197,19 +197,19 @@ class GraphTestCase(unittest.TestCase):
 
         g3 = g1 + g2
 
-        self.assertEquals(len(g3), 2)
-        self.assertEquals((tarek, likes, pizza) in g3, True)
-        self.assertEquals((tarek, likes, cheese) in g3, False)
+        self.assertEqual(len(g3), 2)
+        self.assertEqual((tarek, likes, pizza) in g3, True)
+        self.assertEqual((tarek, likes, cheese) in g3, False)
 
-        self.assertEquals((bob, likes, cheese) in g3, True)
+        self.assertEqual((bob, likes, cheese) in g3, True)
 
         g1 += g2
 
-        self.assertEquals(len(g1), 2)
-        self.assertEquals((tarek, likes, pizza) in g1, True)
-        self.assertEquals((tarek, likes, cheese) in g1, False)
+        self.assertEqual(len(g1), 2)
+        self.assertEqual((tarek, likes, pizza) in g1, True)
+        self.assertEqual((tarek, likes, cheese) in g1, False)
 
-        self.assertEquals((bob, likes, cheese) in g1, True)
+        self.assertEqual((bob, likes, cheese) in g1, True)
 
     def testGraphIntersection(self):
         g1 = self.graph
@@ -231,24 +231,24 @@ class GraphTestCase(unittest.TestCase):
 
         g3 = g1 * g2
 
-        self.assertEquals(len(g3), 1)
-        self.assertEquals((tarek, likes, pizza) in g3, False)
-        self.assertEquals((tarek, likes, cheese) in g3, False)
+        self.assertEqual(len(g3), 1)
+        self.assertEqual((tarek, likes, pizza) in g3, False)
+        self.assertEqual((tarek, likes, cheese) in g3, False)
 
-        self.assertEquals((bob, likes, cheese) in g3, False)
+        self.assertEqual((bob, likes, cheese) in g3, False)
 
-        self.assertEquals((michel, likes, cheese) in g3, True)
+        self.assertEqual((michel, likes, cheese) in g3, True)
 
         g1 *= g2
 
-        self.assertEquals(len(g1), 1)
+        self.assertEqual(len(g1), 1)
 
-        self.assertEquals((tarek, likes, pizza) in g1, False)
-        self.assertEquals((tarek, likes, cheese) in g1, False)
+        self.assertEqual((tarek, likes, pizza) in g1, False)
+        self.assertEqual((tarek, likes, cheese) in g1, False)
 
-        self.assertEquals((bob, likes, cheese) in g1, False)
+        self.assertEqual((bob, likes, cheese) in g1, False)
 
-        self.assertEquals((michel, likes, cheese) in g1, True)
+        self.assertEqual((michel, likes, cheese) in g1, True)
 
 
 # dynamically create classes for each registered Store

--- a/test/test_graph_context.py
+++ b/test/test_graph_context.py
@@ -107,7 +107,7 @@ class ContextTestCase(unittest.TestCase):
         # add to context 1
         graph = Graph(self.graph.store, self.c1)
         graph.add(triple)
-        self.assertEquals(len(self.graph), len(graph))
+        self.assertEqual(len(self.graph), len(graph))
 
     def testAdd(self):
         self.addStuff()
@@ -126,11 +126,11 @@ class ContextTestCase(unittest.TestCase):
 
         for i in range(0, 10):
             graph.add((BNode(), self.hates, self.hates))
-        self.assertEquals(len(graph), oldLen + 10)
-        self.assertEquals(len(self.graph.get_context(c1)), oldLen + 10)
+        self.assertEqual(len(graph), oldLen + 10)
+        self.assertEqual(len(self.graph.get_context(c1)), oldLen + 10)
         self.graph.remove_context(self.graph.get_context(c1))
-        self.assertEquals(len(self.graph), oldLen)
-        self.assertEquals(len(graph), 0)
+        self.assertEqual(len(self.graph), oldLen)
+        self.assertEqual(len(graph), 0)
 
     def testLenInMultipleContexts(self):
         if self.store == "SQLite":
@@ -140,10 +140,10 @@ class ContextTestCase(unittest.TestCase):
 
         # addStuffInMultipleContexts is adding the same triple to
         # three different contexts. So it's only + 1
-        self.assertEquals(len(self.graph), oldLen + 1)
+        self.assertEqual(len(self.graph), oldLen + 1)
 
         graph = Graph(self.graph.store, self.c1)
-        self.assertEquals(len(graph), oldLen + 1)
+        self.assertEqual(len(graph), oldLen + 1)
 
     def testRemoveInMultipleContexts(self):
         c1 = self.c1
@@ -153,21 +153,21 @@ class ContextTestCase(unittest.TestCase):
         self.addStuffInMultipleContexts()
 
         # triple should be still in store after removing it from c1 + c2
-        self.assert_(triple in self.graph)
+        self.assertTrue(triple in self.graph)
         graph = Graph(self.graph.store, c1)
         graph.remove(triple)
-        self.assert_(triple in self.graph)
+        self.assertTrue(triple in self.graph)
         graph = Graph(self.graph.store, c2)
         graph.remove(triple)
-        self.assert_(triple in self.graph)
+        self.assertTrue(triple in self.graph)
         self.graph.remove(triple)
         # now gone!
-        self.assert_(triple not in self.graph)
+        self.assertTrue(triple not in self.graph)
 
         # add again and see if remove without context removes all triples!
         self.addStuffInMultipleContexts()
         self.graph.remove(triple)
-        self.assert_(triple not in self.graph)
+        self.assertTrue(triple not in self.graph)
 
     def testContexts(self):
         triple = (self.pizza, self.hates, self.tarek)  # revenge!
@@ -176,28 +176,28 @@ class ContextTestCase(unittest.TestCase):
 
         def cid(c):
             return c.identifier
-        self.assert_(self.c1 in map(cid, self.graph.contexts()))
-        self.assert_(self.c2 in map(cid, self.graph.contexts()))
+        self.assertTrue(self.c1 in map(cid, self.graph.contexts()))
+        self.assertTrue(self.c2 in map(cid, self.graph.contexts()))
 
         contextList = map(cid, list(self.graph.contexts(triple)))
-        self.assert_(self.c1 in contextList)
-        self.assert_(self.c2 in contextList)
+        self.assertTrue(self.c1 in contextList)
+        self.assertTrue(self.c2 in contextList)
 
     def testRemoveContext(self):
         c1 = self.c1
 
         self.addStuffInMultipleContexts()
-        self.assertEquals(len(Graph(self.graph.store, c1)), 1)
-        self.assertEquals(len(self.graph.get_context(c1)), 1)
+        self.assertEqual(len(Graph(self.graph.store, c1)), 1)
+        self.assertEqual(len(self.graph.get_context(c1)), 1)
 
         self.graph.remove_context(self.graph.get_context(c1))
-        self.assert_(self.c1 not in self.graph.contexts())
+        self.assertTrue(self.c1 not in self.graph.contexts())
 
     def testRemoveAny(self):
         Any = None
         self.addStuffInMultipleContexts()
         self.graph.remove((Any, Any, Any))
-        self.assertEquals(len(self.graph), 0)
+        self.assertEqual(len(self.graph), 0)
 
     def testTriples(self):
         tarek = self.tarek
@@ -208,7 +208,7 @@ class ContextTestCase(unittest.TestCase):
         pizza = self.pizza
         cheese = self.cheese
         c1 = self.c1
-        asserte = self.assertEquals
+        asserte = self.assertEqual
         triples = self.graph.triples
         graph = self.graph
         c1graph = Graph(self.graph.store, c1)

--- a/test/test_issue161.py
+++ b/test/test_issue161.py
@@ -31,7 +31,7 @@ class EntityTest(TestCase):
         # Shouldn't have got to here
         s=g.serialize(format="turtle")
         
-        self.assert_(b('@prefix _9') not in s)
+        self.assertTrue(b('@prefix _9') not in s)
 
 
 

--- a/test/test_issue248.py
+++ b/test/test_issue248.py
@@ -88,7 +88,7 @@ class TestSerialization(unittest.TestCase):
         sg = graph.serialize(format='n3', base=LCCO).decode('utf8')
         # See issue 248
         # Actual test should be the inverse of the below ...
-        self.assert_('<1> a skos:Concept ;' in sg, sg)
+        self.assertTrue('<1> a skos:Concept ;' in sg, sg)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -13,12 +13,12 @@ class TestLiteral(unittest.TestCase):
     def test_repr_apostrophe(self):
         a = rdflib.Literal("'")
         b = eval(repr(a))
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_repr_quote(self):
         a = rdflib.Literal('"')
         b = eval(repr(a))
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_backslash(self):
         d = r"""
@@ -34,11 +34,11 @@ class TestLiteral(unittest.TestCase):
         g.parse(data=d)
         a = rdflib.Literal('a\\b')
         b = list(g.objects())[0]
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_literal_from_bool(self):
         l = rdflib.Literal(True)
-        self.assertEquals(l.datatype, rdflib.XSD["boolean"])
+        self.assertEqual(l.datatype, rdflib.XSD["boolean"])
 
 class TestNew(unittest.TestCase):
     def testCantPassLangAndDatatype(self):
@@ -62,7 +62,7 @@ class TestNew(unittest.TestCase):
         # drewp disapproves of this behavior, but it should be
         # represented in the tests
         x = Literal("foo", datatype="http://example.com/")
-        self.assert_(isinstance(x.datatype, URIRef))
+        self.assertTrue(isinstance(x.datatype, URIRef))
 
         x = Literal("foo", datatype=Literal("pennies"))
         self.assertEqual(x.datatype, URIRef("pennies"))
@@ -94,7 +94,7 @@ class TestDoubleOutput(unittest.TestCase):
         """confirms the fix for https://github.com/RDFLib/rdflib/issues/237"""
         vv = Literal("0.88", datatype=_XSD_DOUBLE)
         out = vv._literal_n3(use_plain=True)
-        self.assert_(out in ["8.8e-01", "0.88"], out)
+        self.assertTrue(out in ["8.8e-01", "0.88"], out)
 
 class TestBindings(unittest.TestCase):
 

--- a/test/test_memory_store.py
+++ b/test/test_memory_store.py
@@ -16,13 +16,13 @@ class StoreTestCase(unittest.TestCase):
                    rdflib.URIRef("http://example.org/foo#bar4"),                
                    rdflib.URIRef("http://example.org/foo#bar5"))
         g.add(triple1)
-        self.assert_(len(g) == 1)
+        self.assertTrue(len(g) == 1)
         g.add(triple2)
-        self.assert_(len(list(g.triples((subj1, None, None)))) == 2)
-        self.assert_(len(list(g.triples((None, pred1, None)))) == 1)
-        self.assert_(len(list(g.triples((None, None, obj1)))) == 1)
+        self.assertTrue(len(list(g.triples((subj1, None, None)))) == 2)
+        self.assertTrue(len(list(g.triples((None, pred1, None)))) == 1)
+        self.assertTrue(len(list(g.triples((None, None, obj1)))) == 1)
         g.remove(triple1)
-        self.assert_(len(g) == 1)
+        self.assertTrue(len(g) == 1)
         g.serialize()
 
 

--- a/test/test_n3.py
+++ b/test/test_n3.py
@@ -182,8 +182,8 @@ foo-bar:Ex foo-bar:name "Test" . """
         for s, p, o in g:
             if isinstance(s, Graph):
                 i += 1
-        self.assertEquals(i, 3)
-        self.assertEquals(len(list(g.contexts())), 13)
+        self.assertEqual(i, 3)
+        self.assertEqual(len(list(g.contexts())), 13)
 
         g.close()
 

--- a/test/test_nodepickler.py
+++ b/test/test_nodepickler.py
@@ -31,7 +31,7 @@ class UtilTestCase(unittest.TestCase):
         a = Literal(u'''A test with a \\n (backslash n), "\u00a9" , and newline \n and a second line.
 ''')
         b = np.loads(np.dumps(a))
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_literal_cases(self):
         np = NodePickler()
@@ -39,14 +39,14 @@ class UtilTestCase(unittest.TestCase):
         for l in cases:
             a = Literal(l)
             b = np.loads(np.dumps(a))
-            self.assertEquals(a, b)
+            self.assertEqual(a, b)
 
     def test_pickle(self):
         np = NodePickler()
         dump = pickle.dumps(np)
         np2 = pickle.loads(dump)
-        self.assertEquals(np._ids, np2._ids)
-        self.assertEquals(np._objects,  np2._objects)
+        self.assertEqual(np._ids, np2._ids)
+        self.assertEqual(np._objects,  np2._objects)
 
 
 if __name__ == '__main__':

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -13,7 +13,7 @@ class NTTestCase(unittest.TestCase):
         g = Graph()
         g.add((URIRef("foo"), URIRef("foo"), Literal(u"R\u00E4ksm\u00F6rg\u00E5s")))
         s = g.serialize(format='nt')
-        self.assertEquals(type(s), bytestype)
+        self.assertEqual(type(s), bytestype)
         self.assertTrue(b(r"R\u00E4ksm\u00F6rg\u00E5s") in s)
 
     def testIssue146(self):
@@ -24,15 +24,15 @@ class NTTestCase(unittest.TestCase):
 
     def test_sink(self):
         s = ntriples.Sink()
-        self.assert_(s.length == 0)
+        self.assertTrue(s.length == 0)
         s.triple(None, None, None)
-        self.assert_(s.length == 1)
+        self.assertTrue(s.length == 1)
 
     def test_nonvalidating_unquote(self):
         safe = """<http://example.org/alice/foaf.rdf#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> <http://example.org/alice/foaf1.rdf> ."""
         ntriples.validate = False
         res = ntriples.unquote(safe)
-        self.assert_(isinstance(res, unicode))
+        self.assertTrue(isinstance(res, unicode))
 
     def test_validating_unquote(self):
         quot = """<http://example.org/alice/foaf.rdf#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> <http://example.org/alice/foaf1.rdf> ."""
@@ -55,7 +55,7 @@ class NTTestCase(unittest.TestCase):
         ntriples.validate = False
         safe = """<http://example.org/alice/foaf.rdf#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> <http://example.org/alice/foaf1.rdf> ."""
         res = ntriples.uriquote(safe)
-        self.assert_(res == safe)
+        self.assertTrue(res == safe)
 
     def test_validating_uriquote(self):
         ntriples.validate = True
@@ -79,7 +79,7 @@ class NTTestCase(unittest.TestCase):
             data = f.read()
         p = ntriples.NTriplesParser()
         res = p.parsestring(data)
-        self.assert_(res == None)
+        self.assertTrue(res == None)
 
     def test_w3_ntriple_variants(self):
         uri = "file:///"+os.getcwd()+"/test/nt/test.ntriples"
@@ -89,7 +89,7 @@ class NTTestCase(unittest.TestCase):
         sink = parser.parse(u)
         u.close()
         # ATM we are only really interested in any exceptions thrown
-        self.assert_(sink is not None)
+        self.assertTrue(sink is not None)
 
     def test_bad_line(self):
         data = '''<http://example.org/resource32> 3 <http://example.org/datatype1> .\n'''

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -35,9 +35,9 @@ class ParserTestCase(unittest.TestCase):
 
         subject = URIRef("http://example.org#")
         label = g.value(subject, RDFS.label)
-        self.assertEquals(label, Literal("testing"))
+        self.assertEqual(label, Literal("testing"))
         type = g.value(subject, RDF.type)
-        self.assertEquals(type, RDFS.Class)
+        self.assertEqual(type, RDFS.Class)
 
 
 if __name__ == "__main__":

--- a/test/test_rdf_lists.py
+++ b/test/test_rdf_lists.py
@@ -45,7 +45,7 @@ class OWLCollectionTest(unittest.TestCase):
 class ListTest(unittest.TestCase):
     def testFalseElement(self):
         g=Graph().parse(data=DATA_FALSE_ELEMENT, format='nt')
-        self.assertEquals(len(list(g.items(URIRef('http://example.org/#ThreeMemberList')))), 3)
+        self.assertEqual(len(list(g.items(URIRef('http://example.org/#ThreeMemberList')))), 3)
 
 
 if __name__ == '__main__':

--- a/test/test_rdfxml.py
+++ b/test/test_rdfxml.py
@@ -185,7 +185,7 @@ class ParserTestCase(unittest.TestCase):
                 result = _testNegative(neg, manifest)
                 total += 1
                 num_failed += result
-        self.assertEquals(
+        self.assertEqual(
             num_failed, 0, "Failed: %s of %s." % (num_failed, total))
 
     def testPositive(self):
@@ -210,7 +210,7 @@ class ParserTestCase(unittest.TestCase):
                     results.add((test, RDF.type, RESULT["FailingRun"]))
                 total += 1
                 num_failed += result
-        self.assertEquals(
+        self.assertEqual(
             num_failed, 0, "Failed: %s of %s." % (num_failed, total))
 
 RESULT = Namespace("http://www.w3.org/2002/03owlt/resultsOntology#")

--- a/test/test_seq.py
+++ b/test/test_seq.py
@@ -37,9 +37,9 @@ class SeqTestCase(unittest.TestCase):
 
     def testSeq(self):
         items = self.store.seq(URIRef("http://example.org/Seq"))
-        self.assertEquals(len(items), 6)
-        self.assertEquals(items[-1], URIRef("http://example.org/six"))
-        self.assertEquals(items[2], URIRef("http://example.org/three"))
+        self.assertEqual(len(items), 6)
+        self.assertEqual(items[-1], URIRef("http://example.org/six"))
+        self.assertEqual(items[2], URIRef("http://example.org/three"))
         # just make sure we can serialize
         self.store.serialize()
 

--- a/test/test_slice.py
+++ b/test/test_slice.py
@@ -12,8 +12,8 @@ class GraphSlice(unittest.TestCase):
          all operations return generators over full triples 
         """
 
-        sl=lambda x,y: self.assertEquals(len(list(x)),y)
-        soe=lambda x,y: self.assertEquals(set([a[2] for a in x]),set(y)) # equals objects
+        sl=lambda x,y: self.assertEqual(len(list(x)),y)
+        soe=lambda x,y: self.assertEqual(set([a[2] for a in x]),set(y)) # equals objects
         g=self.graph
          
         # Single terms are all trivial:

--- a/test/test_sparqlupdatestore.py
+++ b/test/test_sparqlupdatestore.py
@@ -58,30 +58,30 @@ class TestSparql11(unittest.TestCase):
         g2 = self.graph.get_context(othergraphuri)
         g2.add((michel, likes, pizza))
 
-        self.assertEquals(3, len(g), 'graph contains 3 triples')
-        self.assertEquals(1, len(g2), 'other graph contains 1 triple')
+        self.assertEqual(3, len(g), 'graph contains 3 triples')
+        self.assertEqual(1, len(g2), 'other graph contains 1 triple')
 
         r = g.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }")
-        self.assertEquals(2, len(list(r)), "two people like pizza")
+        self.assertEqual(2, len(list(r)), "two people like pizza")
 
         r = g.triples((None, likes, pizza))
-        self.assertEquals(2, len(list(r)), "two people like pizza")
+        self.assertEqual(2, len(list(r)), "two people like pizza")
 
         # Test initBindings
         r = g.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }",
                     initBindings={'s': tarek})
-        self.assertEquals(1, len(list(r)), "i was asking only about tarek")
+        self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
         r = g.triples((tarek, likes, pizza))
-        self.assertEquals(1, len(list(r)), "i was asking only about tarek")
+        self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
         r = g.triples((tarek, likes, cheese))
-        self.assertEquals(0, len(list(r)), "tarek doesn't like cheese")
+        self.assertEqual(0, len(list(r)), "tarek doesn't like cheese")
 
         g2.add((tarek, likes, pizza))
         g.remove((tarek, likes, pizza))
         r = g.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }")
-        self.assertEquals(1, len(list(r)), "only bob likes pizza")
+        self.assertEqual(1, len(list(r)), "only bob likes pizza")
 
     def testConjunctiveDefault(self):
         g = self.graph.get_context(graphuri)
@@ -90,7 +90,7 @@ class TestSparql11(unittest.TestCase):
         g2.add((bob, likes, pizza))
         g.add((tarek, hates, cheese))
 
-        self.assertEquals(2, len(g), 'graph contains 2 triples')
+        self.assertEqual(2, len(g), 'graph contains 2 triples')
 
         # the following are actually bad tests as they depend on your endpoint,
         # as pointed out in the sparqlstore.py code:
@@ -102,33 +102,33 @@ class TestSparql11(unittest.TestCase):
         ##
         ## Fuseki/TDB has a flag for specifying that the default graph
         ## is the union of all graphs (tdb:unionDefaultGraph in the Fuseki config).
-        self.assertEquals(3, len(self.graph),
+        self.assertEqual(3, len(self.graph),
             'default union graph should contain three triples but contains:\n'
             '%s' % list(self.graph))
 
         r = self.graph.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }")
-        self.assertEquals(2, len(list(r)), "two people like pizza")
+        self.assertEqual(2, len(list(r)), "two people like pizza")
 
         r = self.graph.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }",
                              initBindings={'s': tarek})
-        self.assertEquals(1, len(list(r)), "i was asking only about tarek")
+        self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
         r = self.graph.triples((tarek, likes, pizza))
-        self.assertEquals(1, len(list(r)), "i was asking only about tarek")
+        self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
         r = self.graph.triples((tarek, likes, cheese))
-        self.assertEquals(0, len(list(r)), "tarek doesn't like cheese")
+        self.assertEqual(0, len(list(r)), "tarek doesn't like cheese")
 
         g2.remove((bob, likes, pizza))
 
         r = self.graph.query("SELECT * WHERE { ?s <urn:likes> <urn:pizza> . }")
-        self.assertEquals(1, len(list(r)), "only tarek likes pizza")
+        self.assertEqual(1, len(list(r)), "only tarek likes pizza")
 
     def testUpdate(self):
         self.graph.update("INSERT DATA { GRAPH <urn:graph> { <urn:michel> <urn:likes> <urn:pizza> . } }")
 
         g = self.graph.get_context(graphuri)
-        self.assertEquals(1, len(g), 'graph contains 1 triples')
+        self.assertEqual(1, len(g), 'graph contains 1 triples')
 
     def testUpdateWithInitNs(self):
         self.graph.update(
@@ -137,7 +137,7 @@ class TestSparql11(unittest.TestCase):
         )
 
         g = self.graph.get_context(graphuri)
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None,None,None))),
             set([(michel,likes,pizza)]),
             'only michel likes pizza'
@@ -154,7 +154,7 @@ class TestSparql11(unittest.TestCase):
         )
 
         g = self.graph.get_context(graphuri)
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None,None,None))),
             set([(michel,likes,pizza)]),
             'only michel likes pizza'
@@ -173,7 +173,7 @@ class TestSparql11(unittest.TestCase):
         )
 
         g = self.graph.get_context(graphuri)
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None,None,None))),
             set([(michel,likes,pizza), (bob,likes,pizza)]),
             'michel and bob like pizza'
@@ -183,7 +183,7 @@ class TestSparql11(unittest.TestCase):
         g = self.graph.get_context(graphuri)
         r1 = "INSERT DATA { <urn:michel> <urn:likes> <urn:pizza> }"
         g.update(r1)
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None,None,None))),
             set([(michel,likes,pizza)]),
             'only michel likes pizza'
@@ -192,7 +192,7 @@ class TestSparql11(unittest.TestCase):
         r2 = "DELETE { <urn:michel> <urn:likes> <urn:pizza> } " + \
              "INSERT { <urn:bob> <urn:likes> <urn:pizza> } WHERE {}"
         g.update(r2)
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None, None, None))),
             set([(bob, likes, pizza)]),
             'only bob likes pizza'
@@ -210,7 +210,7 @@ class TestSparql11(unittest.TestCase):
         values = set()
         for v in g.objects(bob, says):
             values.add(str(v))
-        self.assertEquals(values, set(tricky_strs))
+        self.assertEqual(values, set(tricky_strs))
 
         # Complicated Strings
         r4strings = []
@@ -236,7 +236,7 @@ class TestSparql11(unittest.TestCase):
         values = set()
         for v in g.objects(michel, says):
             values.add(unicode(v))
-        self.assertEquals(values, set([re.sub(ur"\\(.)", ur"\1", re.sub(ur"^'''|'''$|^'|'$|" + ur'^"""|"""$|^"|"$', ur"", s)) for s in r4strings]))
+        self.assertEqual(values, set([re.sub(ur"\\(.)", ur"\1", re.sub(ur"^'''|'''$|^'|'$|" + ur'^"""|"""$|^"|"$', ur"", s)) for s in r4strings]))
 
         # IRI Containing ' or #
         # The fragment identifier must not be misinterpreted as a comment
@@ -249,7 +249,7 @@ class TestSparql11(unittest.TestCase):
         values = set()
         for v in g.objects(michel, hates):
             values.add(unicode(v))
-        self.assertEquals(values, set([u"urn:foo'bar?baz;a=1&b=2#fragment", u"'}"]))
+        self.assertEqual(values, set([u"urn:foo'bar?baz;a=1&b=2#fragment", u"'}"]))
 
         # Comments
         r6 = u"""
@@ -263,7 +263,7 @@ class TestSparql11(unittest.TestCase):
         values = set()
         for v in g.objects(bob, hates):
             values.add(v)
-        self.assertEquals(values, set([bob, michel]))
+        self.assertEqual(values, set([bob, michel]))
 
     def testNamedGraphUpdateWithInitBindings(self):
         g = self.graph.get_context(graphuri)
@@ -273,7 +273,7 @@ class TestSparql11(unittest.TestCase):
                 'b': likes,
                 'c': pizza
             })
-        self.assertEquals(
+        self.assertEqual(
             set(g.triples((None, None, None))),
             set([(michel, likes, pizza)]),
             'only michel likes pizza'
@@ -300,7 +300,7 @@ class TestSparql11(unittest.TestCase):
             Literal('')))
 
         o = tuple(g)[0][2]
-        self.assertEquals(o, Literal(''), repr(o))
+        self.assertEqual(o, Literal(''), repr(o))
 
 from nose import SkipTest
 import urllib2

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -36,4 +36,4 @@ class TestBNodeRepr(unittest.TestCase):
         class MyBNode(BNode):
             pass
         x = MyBNode()
-        self.assert_(repr(x).startswith("MyBNode("))
+        self.assertTrue(repr(x).startswith("MyBNode("))

--- a/test/test_trig.py
+++ b/test/test_trig.py
@@ -29,7 +29,7 @@ class TestTrig(unittest.TestCase):
         self.assertEqual(len(g.get_context('urn:b')),1)
 
         s=g.serialize(format='trig')
-        self.assert_(b('{}') not in s) # no empty graphs!
+        self.assertTrue(b('{}') not in s) # no empty graphs!
 
     def testSameSubject(self):
         g=rdflib.ConjunctiveGraph()
@@ -49,7 +49,7 @@ class TestTrig(unittest.TestCase):
         self.assertEqual(len(re.findall(b("p1"), s)), 1)
         self.assertEqual(len(re.findall(b("p2"), s)), 1)
 
-        self.assert_(b('{}') not in s) # no empty graphs!
+        self.assertTrue(b('{}') not in s) # no empty graphs!
 
     def testRememberNamespace(self):
         g = rdflib.ConjunctiveGraph()
@@ -58,14 +58,14 @@ class TestTrig(unittest.TestCase):
         # prefix for the graph but later serialize() calls would work.
         first_out = g.serialize(format='trig')
         second_out = g.serialize(format='trig')
-        self.assert_(b'@prefix ns1: <http://example.com/> .' in second_out)
-        self.assert_(b'@prefix ns1: <http://example.com/> .' in first_out)
+        self.assertTrue(b'@prefix ns1: <http://example.com/> .' in second_out)
+        self.assertTrue(b'@prefix ns1: <http://example.com/> .' in first_out)
 
     def testGraphQnameSyntax(self):
         g = rdflib.ConjunctiveGraph()
         g.add(TRIPLE + (rdflib.URIRef("http://example.com/graph1"),))
         out = g.serialize(format='trig')
-        self.assert_(b'ns1:graph1 {' in out)
+        self.assertTrue(b'ns1:graph1 {' in out)
 
     def testGraphUriSyntax(self):
         g = rdflib.ConjunctiveGraph()
@@ -73,12 +73,12 @@ class TestTrig(unittest.TestCase):
         # a '<...>' term.
         g.add(TRIPLE + (rdflib.URIRef("http://example.com/foo."),))
         out = g.serialize(format='trig')
-        self.assert_(b'<http://example.com/foo.> {' in out)
+        self.assertTrue(b'<http://example.com/foo.> {' in out)
 
     def testBlankGraphIdentifier(self):
         g = rdflib.ConjunctiveGraph()
         g.add(TRIPLE + (rdflib.BNode(),))
         out = g.serialize(format='trig')
         graph_label_line = out.splitlines()[-4]
-        self.assert_(re.match(br'^_:[a-zA-Z0-9]+ \{', graph_label_line))
+        self.assertTrue(re.match(br'^_:[a-zA-Z0-9]+ \{', graph_label_line))
         

--- a/test/test_trix_parse.py
+++ b/test/test_trix_parse.py
@@ -22,8 +22,8 @@ class TestTrixParse(unittest.TestCase):
         #print list(g.contexts())
         t=sum(map(len, g.contexts()))
 
-        self.assertEquals(t,24)
-        self.assertEquals(len(c),4)
+        self.assertEqual(t,24)
+        self.assertEqual(len(c),4)
         
         #print "Parsed %d triples"%t
 

--- a/test/test_trix_serialize.py
+++ b/test/test_trix_serialize.py
@@ -60,7 +60,7 @@ class TestTrixSerialize(unittest.TestCase):
                 # here I know there is only one anonymous graph,
                 # and that is the default one, but this is not always the case
                 tg = g.default_context
-            self.assert_(q[0:3] in tg)
+            self.assertTrue(q[0:3] in tg)
 
     def test_issue_250(self):
         """
@@ -93,9 +93,9 @@ class TestTrixSerialize(unittest.TestCase):
         graph = ConjunctiveGraph()
         graph.bind(None, "http://defaultnamespace")
         sg = graph.serialize(format='trix').decode('UTF-8')
-        self.assert_(
+        self.assertTrue(
             'xmlns="http://defaultnamespace"' not in sg, sg)
-        self.assert_(
+        self.assertTrue(
             'xmlns="http://www.w3.org/2004/03/trix/trix-1/' in sg, sg)
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -57,15 +57,15 @@ class TestUtilMisc(unittest.TestCase):
     def test_util_list2set(self):
         base = [Literal('foo'), self.x]
         r = util.list2set(base+base)
-        self.assert_(r == base)
+        self.assertTrue(r == base)
 
     def test_util_uniq(self):
         base = ["michel", "hates", "pizza"]
         r = util.uniq(base+base)
-        self.assertEquals(sorted(r), sorted(base))
+        self.assertEqual(sorted(r), sorted(base))
         base = ["michel", "hates", "pizza"]
         r = util.uniq(base+base, strip=True)
-        self.assertEquals(sorted(r), sorted(base))
+        self.assertEqual(sorted(r), sorted(base))
 
     def test_coverage_dodge(self):
         util.test()
@@ -79,32 +79,32 @@ class TestUtilDateTime(unittest.TestCase):
     def test_util_date_time_tisnoneandnotz(self):
         t = None
         res = util.date_time(t, local_time_zone=False)
-        self.assert_(res[4:5] == "-")
+        self.assertTrue(res[4:5] == "-")
 
     def test_util_date_time_tisnonebuttz(self):
         t = None
         res = util.date_time(t, local_time_zone=True)
-        self.assert_(res[4:5] == "-")
+        self.assertTrue(res[4:5] == "-")
 
     def test_util_date_time_tistime(self):
         t = time.time()
         res = util.date_time(t, local_time_zone=False)
-        self.assert_(res[4:5] == "-")
+        self.assertTrue(res[4:5] == "-")
 
     def test_util_date_time_tistimewithtz(self):
         t = time.time()
         res = util.date_time(t, local_time_zone=True)
-        self.assert_(res[4:5] == "-")
+        self.assertTrue(res[4:5] == "-")
 
     def test_util_parse_date_time(self):
         t = time.time()
         res = util.parse_date_time("1970-01-01")
-        self.assert_(res is not t)
+        self.assertTrue(res is not t)
 
     def test_util_parse_date_timewithtz(self):
         t = time.time()
         res = util.parse_date_time("1970-01-01")
-        self.assert_(res is not t)
+        self.assertTrue(res is not t)
 
     def test_util_date_timewithtoutz(self):
         t = time.time()
@@ -114,7 +114,7 @@ class TestUtilDateTime(unittest.TestCase):
             return res
         util.localtime = ablocaltime
         res = util.date_time(t, local_time_zone=True)
-        self.assert_(res is not t)
+        self.assertTrue(res is not t)
 
 class TestUtilTermConvert(unittest.TestCase):
     def setUp(self):
@@ -123,25 +123,25 @@ class TestUtilTermConvert(unittest.TestCase):
 
     def test_util_to_term_sisNone(self):
         s = None
-        self.assertEquals(util.to_term(s), s)
-        self.assertEquals(util.to_term(s, default=""), "")
+        self.assertEqual(util.to_term(s), s)
+        self.assertEqual(util.to_term(s, default=""), "")
 
     def test_util_to_term_sisstr(self):
         s = '"http://example.com"'
         res = util.to_term(s)
-        self.assert_(isinstance(res, Literal))
-        self.assertEquals(str(res), s[1:-1])
+        self.assertTrue(isinstance(res, Literal))
+        self.assertEqual(str(res), s[1:-1])
 
     def test_util_to_term_sisurl(self):
         s = "<http://example.com>"
         res = util.to_term(s)
-        self.assert_(isinstance(res, URIRef))
-        self.assertEquals(str(res), s[1:-1])
+        self.assertTrue(isinstance(res, URIRef))
+        self.assertEqual(str(res), s[1:-1])
 
     def test_util_to_term_sisbnode(self):
         s = '_http%23%4F%4Fexample%33com'
         res = util.to_term(s)
-        self.assert_(isinstance(res, BNode))
+        self.assertTrue(isinstance(res, BNode))
 
     def test_util_to_term_sisunknown(self):
         s = 'http://example.com'
@@ -155,44 +155,44 @@ class TestUtilTermConvert(unittest.TestCase):
         s = None
         default = None
         res = util.from_n3(s, default=default, backend=None)
-        self.assert_(res == default)
+        self.assertTrue(res == default)
 
     def test_util_from_n3_sisnonewithdefault(self):
         s = None
         default = "TestofDefault"
         res = util.from_n3(s, default=default, backend=None)
-        self.assert_(res == default)
+        self.assertTrue(res == default)
     
 
     def test_util_from_n3_expectdefaultbnode(self):
         s = "michel"
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, BNode))
+        self.assertTrue(isinstance(res, BNode))
 
     def test_util_from_n3_expectbnode(self):
         s = "_:michel"
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, BNode))
+        self.assertTrue(isinstance(res, BNode))
 
     def test_util_from_n3_expectliteral(self):
         s = '"michel"'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, Literal))
+        self.assertTrue(isinstance(res, Literal))
 
     def test_util_from_n3_expecturiref(self):
         s = '<http://example.org/schema>'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, URIRef))
+        self.assertTrue(isinstance(res, URIRef))
 
     def test_util_from_n3_expectliteralandlang(self):
         s = '"michel"@fr'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, Literal))
+        self.assertTrue(isinstance(res, Literal))
 
     def test_util_from_n3_expectliteralandlangdtype(self):
         s = '"michel"@fr^^xsd:fr'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(isinstance(res, Literal))
+        self.assertTrue(isinstance(res, Literal))
         self.assertEqual(res, Literal('michel',
                                       datatype=XSD['fr']))
 
@@ -217,18 +217,18 @@ class TestUtilTermConvert(unittest.TestCase):
     def test_util_from_n3_expectliteralmultiline(self):
         s = '"""multi\nline\nstring"""@en'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(res, Literal('multi\nline\nstring', lang='en'))
+        self.assertTrue(res, Literal('multi\nline\nstring', lang='en'))
     
     def test_util_from_n3_expectliteralwithescapedquote(self):
         s = '"\\""'
         res = util.from_n3(s, default=None, backend=None)
-        self.assert_(res, Literal('\\"', lang='en'))
+        self.assertTrue(res, Literal('\\"', lang='en'))
 
     def test_util_from_n3_expectliteralwithtrailingbackslash(self):
         s = '"trailing\\\\"^^<http://www.w3.org/2001/XMLSchema#string>'
         res = util.from_n3(s)
-        self.assert_(res, Literal('trailing\\', datatype=XSD['string']))
-        self.assert_(res.n3(), s)
+        self.assertTrue(res, Literal('trailing\\', datatype=XSD['string']))
+        self.assertTrue(res.n3(), s)
     
     def test_util_from_n3_expectpartialidempotencewithn3(self):
         for n3 in ('<http://ex.com/foo>',
@@ -263,7 +263,7 @@ class TestUtilTermConvert(unittest.TestCase):
                    '"\\""@en',
                    '"""multi\n"line"\nstring"""@en'):
             res, exp = util.from_n3(n3), parse_n3(n3)
-            self.assertEquals(res, exp,
+            self.assertEqual(res, exp,
                 'from_n3(%(n3e)r): %(res)r != parser.notation3: %(exp)r' % {
                         'res': res, 'exp': exp, 'n3e':n3})
         
@@ -272,12 +272,12 @@ class TestUtilTermConvert(unittest.TestCase):
     def test_util_from_n3_expectquotedgraph(self):
         s = '{<http://example.com/schema>}'
         res = util.from_n3(s, default=None, backend="IOMemory")
-        self.assert_(isinstance(res, QuotedGraph))
+        self.assertTrue(isinstance(res, QuotedGraph))
 
     def test_util_from_n3_expectgraph(self):
         s = '[<http://example.com/schema>]'
         res = util.from_n3(s, default=None, backend="IOMemory")
-        self.assert_(isinstance(res, Graph))
+        self.assertTrue(isinstance(res, Graph))
 
 class TestUtilCheckers(unittest.TestCase):
     def setUp(self):
@@ -295,19 +295,19 @@ class TestUtilCheckers(unittest.TestCase):
 
     def test_util_check_context(self):
         res = util.check_context(self.c)
-        self.assert_(res == None)
+        self.assertTrue(res == None)
 
     def test_util_check_subject(self):
         res = util.check_subject(self.s)
-        self.assert_(res == None)
+        self.assertTrue(res == None)
     
     def test_util_check_predicate(self):
         res = util.check_predicate(self.p)
-        self.assert_(res == None)
+        self.assertTrue(res == None)
 
     def test_util_check_object(self):
         res = util.check_object(self.o)
-        self.assert_(res == None)
+        self.assertTrue(res == None)
     
     def test_util_check_statement(self):
         c = "http://example.com"
@@ -324,7 +324,7 @@ class TestUtilCheckers(unittest.TestCase):
                 util.check_statement, 
                     (self.s, self.p, c)) 
         res = util.check_statement((self.s, self.p, self.o))
-        self.assert_(res == None)
+        self.assertTrue(res == None)
     
     def test_util_check_pattern(self):
         c = "http://example.com"
@@ -341,7 +341,7 @@ class TestUtilCheckers(unittest.TestCase):
                 util.check_pattern, 
                     (self.s, self.p, c)) 
         res = util.check_pattern((self.s, self.p, self.o))
-        self.assert_(res == None)
+        self.assertTrue(res == None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
While trying to wade through Travis' logs yesterday, I noticed there's 700+ lines of DeprecationWarnings from the test suite. This makes it fairly difficult to find things, or easily scroll between sections of the log. I updated the warnings to the 2.5+ compatible alternatives, which should make things more readable.