### PR TITLE
add a NTSerializer sub-class for nt11

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -176,6 +176,10 @@ register(
     'nt', Serializer,
     'rdflib.plugins.serializers.nt', 'NTSerializer')
 register(
+    'nt11', Serializer,
+    'rdflib.plugins.serializers.nt', 'NT11Serializer')
+
+register(
     'pretty-xml', Serializer,
     'rdflib.plugins.serializers.rdfxml', 'PrettyXMLSerializer')
 register(
@@ -214,6 +218,9 @@ register(
     'rdflib.plugins.parsers.nt', 'NTParser')
 register(
     'nt', Parser,
+    'rdflib.plugins.parsers.nt', 'NTParser')
+register(
+    'nt11', Parser,
     'rdflib.plugins.parsers.nt', 'NTParser')
 register(
     'application/n-quads', Parser,

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -33,6 +33,17 @@ class NTSerializer(Serializer):
         stream.write(b("\n"))
 
 
+class NT11Serializer(NTSerializer):
+    """
+    Serializes RDF graphs to RDF 1.1 NTriples format.
+
+    Exactly like nt - only utf8 encoded.
+    """
+
+    def __init__(self, store):
+        Serializer.__init__(self, store) # default to utf-8
+
+
 def _nt_row(triple):
     if isinstance(triple[2], Literal):
         return u"%s %s %s .\n" % (


### PR DESCRIPTION
NTriples in RDF1.1 are utf8 encoded.
This is backwards compatible, but you can have nicer output if you
know the consumer will support nt11/utf-8

Fixes #695