### PR TITLE
More aliases for common formats

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -167,6 +167,9 @@ register(
     'turtle', Serializer,
     'rdflib.plugins.serializers.turtle', 'TurtleSerializer')
 register(
+    'ttl', Serializer,
+    'rdflib.plugins.serializers.turtle', 'TurtleSerializer')
+register(
     'trig', Serializer,
     'rdflib.plugins.serializers.trig', 'TrigSerializer')
 register(
@@ -212,6 +215,9 @@ register(
     'rdflib.plugins.parsers.notation3', 'TurtleParser')
 register(
     'turtle', Parser,
+    'rdflib.plugins.parsers.notation3', 'TurtleParser')
+register(
+    'ttl', Parser,
     'rdflib.plugins.parsers.notation3', 'TurtleParser')
 register(
     'application/n-triples', Parser,

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -176,6 +176,9 @@ register(
     'application/n-triples', Serializer,
     'rdflib.plugins.serializers.nt', 'NTSerializer')
 register(
+    'ntriples', Serializer,
+    'rdflib.plugins.serializers.nt', 'NTSerializer')
+register(
     'nt', Serializer,
     'rdflib.plugins.serializers.nt', 'NTSerializer')
 register(
@@ -221,6 +224,9 @@ register(
     'rdflib.plugins.parsers.notation3', 'TurtleParser')
 register(
     'application/n-triples', Parser,
+    'rdflib.plugins.parsers.nt', 'NTParser')
+register(
+    'ntriples', Parser,
     'rdflib.plugins.parsers.nt', 'NTParser')
 register(
     'nt', Parser,

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -195,10 +195,10 @@ register(
     'application/trix', Serializer,
     'rdflib.plugins.serializers.trix', 'TriXSerializer')
 register(
-    "application/n-quads", Serializer,
+    'application/n-quads', Serializer,
     'rdflib.plugins.serializers.nquads', 'NQuadsSerializer')
 register(
-    "nquads", Serializer,
+    'nquads', Serializer,
     'rdflib.plugins.serializers.nquads', 'NQuadsSerializer')
 
 register(


### PR DESCRIPTION
`format='ttl'` and `'ntriples'` has bitten me too often, especially considering that `'turtle'` and `'nt'` work