### PR TITLE
make namespace module flake8-compliant, change exceptions in that mod…

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -120,7 +120,7 @@ class Namespace(text_type):
             return self.term(name)
 
     def __repr__(self):
-        return "Namespace(%s)" % text_type.__repr__(self)
+        return "Namespace(%r)" % text_type(self)
 
 
 class URIPattern(text_type):
@@ -150,7 +150,7 @@ class URIPattern(text_type):
         return URIRef(text_type.format(self, *args, **kwargs))
 
     def __repr__(self):
-        return "URIPattern(%r)" % text_type.__repr__(self)
+        return "URIPattern(%r)" % text_type(self)
 
 
 class ClosedNamespace(object):
@@ -185,10 +185,10 @@ class ClosedNamespace(object):
             return self.term(name)
 
     def __str__(self):
-        return str(self.uri)
+        return text_type(self.uri)
 
     def __repr__(self):
-        return """rdf.namespace.ClosedNamespace('%s')""" % str(self.uri)
+        return "rdf.namespace.ClosedNamespace(%r)" % text_type(self.uri)
 
 
 class _RDFNamespace(ClosedNamespace):

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,7 +8,7 @@ This test runner uses Nose for test discovery and running. It uses the argument
 spec of Nose, but with some options pre-set. To begin with, make sure you have
 Nose installed, e.g.:
 
-    $ sudo easy_install nose
+    $ pip nose doctest-ignore-unicode
 
 For daily test runs, use:
 


### PR DESCRIPTION
- Updates Exceptions raised in this module to specific ones so possible to catch them without a "except Exception" catch-all in application code that uses this library
- Some formatting updates to make this module [flake8](http://flake8.pycqa.org/en/latest/) compliant! 
- Mention `doctest-ignore-unicode` dependency in run_tests.py docs for running tests, update it to suggest using pip (without sudo - use virtualenv!)

I Opted to use built in exception types that seemed most appropriate, ideally we should define our own custom error hierarchy, but for now this seems a good start.