### PR TITLE
Accept header should use a q parameter

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -101,7 +101,7 @@ class URLInputSource(InputSource):
             myheaders['Accept'] = 'text/plain, */*;q=0.1'
         elif format == 'json-ld':
             myheaders['Accept'] = (
-                'application/ld+json, application/json;p=0.9, */*;q=0.1')
+                'application/ld+json, application/json;q=0.9, */*;q=0.1')
         else:
             myheaders['Accept'] = (
                 'application/rdf+xml,text/rdf+n3;q=0.9,' +


### PR DESCRIPTION
[RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.3.2) defines the HTTP Accept header to use a `q` parameter. The use of a `p` parameter in the code appears to be a typo and probably would not be understood by a conforming HTTP server.