### PR TITLE
Adds escaped single quote to literal parser

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -1585,9 +1585,9 @@ class SinkParser:
                     raise BadSyntax(
                         self._thisDoc, startline, argstr, i,
                         "unterminated string literal (2)")
-                k = 'abfrtvn\\"'.find(ch)
+                k = 'abfrtvn\\"\''.find(ch)
                 if k >= 0:
-                    uch = '\a\b\f\r\t\v\n\\"'[k]
+                    uch = '\a\b\f\r\t\v\n\\"\''[k]
                     ustr = ustr + uch
                     j = j + 1
                 elif ch == "u":


### PR DESCRIPTION
Addresses issue #732.  Literals with double quotes ("....") include an escaped interior quote ("...\"..."), but literals with single quotes ('...\'...') currently produce a parsing error.  This adds a single quote to the escaped character list
