### PR TITLE
made UNION faster by not preventing duplicates

### DIFF
--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -112,13 +112,10 @@ def evalJoin(ctx, join):
 
 
 def evalUnion(ctx, union):
-    res = set()
     for x in evalPart(ctx, union.p1):
-        res.add(x)
         yield x
     for x in evalPart(ctx, union.p2):
-        if x not in res:
-            yield x
+        yield x
 
 
 def evalMinus(ctx, minus):


### PR DESCRIPTION
The current implementation of evalUnion is designed to prevent duplicate results, so if a mapping is a result of both parts of the UNION, it is return only once.

However, the specification [1] states that the cardinality of each mapping is the *sum* of its cardinality in each part of the UNION.

Not only does it make the SPARQL implementation more compliant, but it also makes it faster (50% gain in one of my queries using several UNIONs).

[1] https://www.w3.org/TR/sparql11-query/#defn_algUnion