### PR TITLE
Remove SPARQLWrapper dependency

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -323,11 +323,31 @@ register(
     'xml', ResultParser,
     'rdflib.plugins.sparql.results.xmlresults', 'XMLResultParser')
 register(
+    'application/sparql-results+xml', ResultParser,
+    'rdflib.plugins.sparql.results.xmlresults', 'XMLResultParser')
+
+register(
+    'application/rdf+xml', ResultParser,
+    'rdflib.plugins.sparql.results.graph', 'GraphResultParser')
+
+
+register(
     'json', ResultParser,
     'rdflib.plugins.sparql.results.jsonresults', 'JSONResultParser')
+register(
+    'application/sparql-results+json', ResultParser,
+    'rdflib.plugins.sparql.results.jsonresults', 'JSONResultParser')
+
 register(
     'csv', ResultParser,
     'rdflib.plugins.sparql.results.csvresults', 'CSVResultParser')
 register(
+    'text/csv', ResultParser,
+    'rdflib.plugins.sparql.results.csvresults', 'CSVResultParser')
+
+register(
     'tsv', ResultParser,
+    'rdflib.plugins.sparql.results.tsvresults', 'TSVResultParser')
+register(
+    'text/tab-separated-values', ResultParser,
     'rdflib.plugins.sparql.results.tsvresults', 'TSVResultParser')

--- a/rdflib/plugins/sparql/results/csvresults.py
+++ b/rdflib/plugins/sparql/results/csvresults.py
@@ -21,7 +21,7 @@ class CSVResultParser(ResultParser):
     def __init__(self):
         self.delim = ","
 
-    def parse(self, source):
+    def parse(self, source, content_type=None):
 
         r = Result('SELECT')
 

--- a/rdflib/plugins/sparql/results/graph.py
+++ b/rdflib/plugins/sparql/results/graph.py
@@ -1,0 +1,18 @@
+from rdflib import Graph
+
+from rdflib.query import (
+    Result,
+    ResultParser,
+    ResultSerializer,
+    ResultException
+)
+
+class GraphResultParser(ResultParser):
+
+    def parse(self, source, content_type):
+
+        res = Result('CONSTRUCT') # hmm - or describe?type_)
+        res.graph = Graph()
+        res.graph.parse(source, format=content_type)
+
+        return res

--- a/rdflib/plugins/sparql/results/jsonresults.py
+++ b/rdflib/plugins/sparql/results/jsonresults.py
@@ -21,7 +21,7 @@ Authors: Drew Perttula, Gunnar Aastrand Grimnes
 
 class JSONResultParser(ResultParser):
 
-    def parse(self, source):
+    def parse(self, source, content_type=None):
         inp = source.read()
         if isinstance(inp, binary_type):
             inp = inp.decode('utf-8')

--- a/rdflib/plugins/sparql/results/tsvresults.py
+++ b/rdflib/plugins/sparql/results/tsvresults.py
@@ -47,7 +47,7 @@ HEADER.parseWithTabs()
 
 
 class TSVResultParser(ResultParser):
-    def parse(self, source):
+    def parse(self, source, content_type=None):
 
         if isinstance(source.read(0), binary_type):
             # if reading from source returns bytes do utf-8 decoding

--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -37,25 +37,18 @@ Authors: Drew Perttula, Gunnar Aastrand Grimnes
 
 class XMLResultParser(ResultParser):
 
-    def parse(self, source):
+    def parse(self, source, content_type=None):
         return XMLResult(source)
 
 
 class XMLResult(Result):
-    def __init__(self, source):
+    def __init__(self, source, content_type=None):
 
-        xmlstring = source.read()
-
-        if isinstance(xmlstring, text_type):
-            xmlstring = xmlstring.encode('utf-8')
         try:
             parser = etree.XMLParser(huge_tree=True)
-            tree = etree.parse(BytesIO(xmlstring), parser)
+            tree = etree.parse(source, parser)
         except TypeError:
-            tree = etree.fromstring(xmlstring)
-        except Exception as e:
-            log.exception("Error parsing XML results: %s"%xmlstring)
-            raise e
+            tree = etree.parse(source)
 
         boolean = tree.find(RESULTS_NS_ET + 'boolean')
         results = tree.find(RESULTS_NS_ET + 'results')
@@ -65,18 +58,11 @@ class XMLResult(Result):
         elif results is not None:
             type_ = 'SELECT'
         else:
-            g = Graph()
-            try:
-                g.parse(data=xmlstring)
-                if len(g) == 0:
-                    raise
-                type_ = 'CONSTRUCT'
-
-            except:
-                raise ResultException(
-                    "No RDF Graph, result-bindings or boolean answer found!")
+            raise ResultException(
+                "No RDF result-bindings or boolean answer found!")
 
         Result.__init__(self, type_)
+
         if type_ == 'SELECT':
             self.bindings = []
             for result in results:
@@ -90,10 +76,11 @@ class XMLResult(Result):
                          './%shead/%svariable' % (
                              RESULTS_NS_ET, RESULTS_NS_ET))]
 
-        elif type_ == 'ASK':
+        else:
             self.askAnswer = boolean.text.lower().strip() == "true"
-        elif type_ == 'CONSTRUCT':
-            self.graph = g
+
+
+
 
 
 def parseTerm(element):

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -635,8 +635,7 @@ class SPARQLUpdateStore(SPARQLStore):
 
         self.debug = DEBUG
         assert isinstance(query, string_types)
-        self.setNamespaceBindings(initNs)
-        query = self.injectPrefixes(query)
+        query = self._inject_prefixes(query, initNs)
 
         if self._is_contextual(queryGraph):
             query = self._insert_named_graph(query, queryGraph)

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -13,66 +13,19 @@ ORDERBY = 'ORDER BY'
 
 import re
 import collections
-import warnings
-import contextlib
 
-try:
-    from SPARQLWrapper import SPARQLWrapper, XML, JSON, POST, GET, URLENCODED, POSTDIRECTLY
-except ImportError:
-    raise Exception(
-        "SPARQLWrapper not found! SPARQL Store will not work." +
-        "Install with 'pip install SPARQLWrapper'")
+from .sparqlwrapper import SPARQLWrapper
 
 from rdflib.plugins.stores.regexmatching import NATIVE_REGEX
 
 from rdflib.store import Store
-from rdflib.query import Result
 from rdflib import Variable, BNode
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.term import Node
 
 from six import string_types
 
-class NSSPARQLWrapper(SPARQLWrapper):
-    nsBindings = {}
-
-    def setNamespaceBindings(self, bindings):
-        """
-        A shortcut for setting namespace bindings that will be added
-        to the prolog of the query
-
-        @param bindings: A dictionary of prefixs to URIs
-        """
-        self.nsBindings.update(bindings)
-
-    def setQuery(self, query):
-        """
-        Set the SPARQL query text. Note: no check is done on the
-        validity of the query (syntax or otherwise) by this module,
-        except for testing the query type (SELECT, ASK, etc).
-
-        Syntax and validity checking is done by the SPARQL service itself.
-
-        @param query: query text
-        @type query: string
-        @bug: #2320024
-        """
-        self.queryType = self._parseQueryType(query)
-        self.queryString = self.injectPrefixes(query)
-
-    def injectPrefixes(self, query):
-        prefixes = list(self.nsBindings.items())
-        if not prefixes:
-            return query
-        return '\n'.join([
-            '\n'.join(['PREFIX %s: <%s>' % (k, v) for k, v in prefixes]),
-            '',  # separate prefixes from query with an empty line
-            query
-        ])
-
-
 BNODE_IDENT_PATTERN = re.compile('(?P<label>_\:[^\s]+)')
-
 
 def _node_to_sparql(node):
     if isinstance(node, BNode):
@@ -83,8 +36,7 @@ def _node_to_sparql(node):
     return node.n3()
 
 
-
-class SPARQLStore(NSSPARQLWrapper, Store):
+class SPARQLStore(SPARQLWrapper, Store):
     """
     An RDFLib store around a SPARQL endpoint
 
@@ -129,22 +81,18 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                  endpoint=None,
                  sparql11=True, context_aware=True,
                  node_to_sparql=_node_to_sparql,
-                 default_query_method=GET,
-                 returnFormat=XML,
+                 returnFormat='xml',
                  **sparqlwrapper_kwargs):
         """
         """
         super(SPARQLStore, self).__init__(
             endpoint, returnFormat=returnFormat, **sparqlwrapper_kwargs)
-        self.returnFormat = returnFormat
-        self.setUseKeepAlive()
+
         self.node_to_sparql = node_to_sparql
         self.nsBindings = {}
         self.sparql11 = sparql11
         self.context_aware = context_aware
         self.graph_aware = context_aware
-        self._timeout = None
-        self.query_method = default_query_method
         self._queries = 0
 
     # Database Management Methods
@@ -160,15 +108,6 @@ class SPARQLStore(NSSPARQLWrapper, Store):
             raise Exception("Cannot create a SPARQL Endpoint")
 
         self.query_endpoint = configuration
-
-    def __set_query_endpoint(self, queryEndpoint):
-        super(SPARQLStore, self).__init__(queryEndpoint, returnFormat=self.returnFormat)
-        self.endpoint = queryEndpoint
-
-    def __get_query_endpoint(self):
-        return self.endpoint
-
-    query_endpoint = property(__get_query_endpoint, __set_query_endpoint)
 
     def destroy(self, configuration):
         raise TypeError('The SPARQL store is read only')
@@ -192,7 +131,20 @@ class SPARQLStore(NSSPARQLWrapper, Store):
     def _query(self, *args, **kwargs):
         self._queries += 1
 
-        return super(SPARQLStore, self)._query(*args, **kwargs)
+        return super(SPARQLStore, self).query(*args, **kwargs)
+
+    def _inject_prefixes(self, query, extra_bindings):
+        bindings = list(self.nsBindings.items()) + list(extra_bindings.items())
+        if not bindings:
+            return query
+        return '\n'.join([
+            '\n'.join(['PREFIX %s: <%s>' % (k, v) for k, v in bindings]),
+            '',  # separate ns_bindings from query with an empty line
+            query
+        ])
+
+    def _preprocess_query(self, query):
+        return self._inject_prefixes(query)
 
     def query(self, query,
               initNs={},
@@ -201,7 +153,9 @@ class SPARQLStore(NSSPARQLWrapper, Store):
               DEBUG=False):
         self.debug = DEBUG
         assert isinstance(query, string_types)
-        self.setNamespaceBindings(initNs)
+
+        query = self._inject_prefixes(query, initNs)
+
         if initBindings:
             if not self.sparql11:
                 raise Exception(
@@ -213,16 +167,8 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                 % (" ".join("?" + str(x) for x in v),
                    " ".join(self.node_to_sparql(initBindings[x]) for x in v))
 
-        self.resetQuery()
-        self.setMethod(self.query_method)
-        if self._is_contextual(queryGraph):
-            self.addParameter("default-graph-uri", queryGraph)
-        self.timeout = self._timeout
-        self.setQuery(query)
-
-        with contextlib.closing(SPARQLWrapper.query(self).response) as res:
-            return Result.parse(res, format=self.returnFormat)
-
+        return self._query(query,
+                           default_graph=queryGraph if self._is_contextual(queryGraph) else None)
 
     def triples(self, spo, context=None):
         """
@@ -307,14 +253,9 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         except (ValueError, TypeError, AttributeError):
             pass
 
-        self.resetQuery()
-        if self._is_contextual(context):
-            self.addParameter("default-graph-uri", context.identifier)
-        self.timeout = self._timeout
-        self.setQuery(query)
 
-        with contextlib.closing(SPARQLWrapper.query(self).response) as res:
-            result = Result.parse(res, format=self.returnFormat)
+        result = self._query(query,
+                             default_graph=context.identifier if self._is_contextual(context) else None)
 
         if vars:
             for row in result:
@@ -341,14 +282,10 @@ class SPARQLStore(NSSPARQLWrapper, Store):
                 "For performance reasons, this is not" +
                 "supported for sparql1.0 endpoints")
         else:
-            self.resetQuery()
             q = "SELECT (count(*) as ?c) WHERE {?s ?p ?o .}"
-            if self._is_contextual(context):
-                self.addParameter("default-graph-uri", context.identifier)
-            self.setQuery(q)
 
-            with contextlib.closing(SPARQLWrapper.query(self).response) as res:
-                result = Result.parse(res, format=self.returnFormat)
+            result = self._query(q,
+                                 default_graph=context.identifier if self._is_contextual(context) else None)
 
             return int(next(iter(result)).c)
 
@@ -366,7 +303,6 @@ class SPARQLStore(NSSPARQLWrapper, Store):
         Please note that some SPARQL endpoints are not able to find empty named
         graphs.
         """
-        self.resetQuery()
 
         if triple:
             nts = self.node_to_sparql
@@ -374,12 +310,11 @@ class SPARQLStore(NSSPARQLWrapper, Store):
             params = (nts(s if s else Variable('s')),
                       nts(p if p else Variable('p')),
                       nts(o if o else Variable('o')))
-            self.setQuery('SELECT ?name WHERE { GRAPH ?name { %s %s %s }}' % params)
+            q = 'SELECT ?name WHERE { GRAPH ?name { %s %s %s }}' % params
         else:
-            self.setQuery('SELECT ?name WHERE { GRAPH ?name {} }')
+            q = 'SELECT ?name WHERE { GRAPH ?name {} }'
 
-        with contextlib.closing(SPARQLWrapper.query(self).response) as res:
-            result = Result.parse(res, format=self.returnFormat)
+        result = self._query(q)
 
         return ( row.name for row in result )
 
@@ -507,7 +442,7 @@ class SPARQLUpdateStore(SPARQLStore):
             queryEndpoint,
             sparql11,
             context_aware,
-            updateEndpoint=update_endpoint,
+            update_endpoint=update_endpoint,
             **kwds
         )
 
@@ -550,31 +485,19 @@ class SPARQLUpdateStore(SPARQLStore):
             raise Exception("Cannot create a SPARQL Endpoint")
 
         if isinstance(configuration, tuple):
-            self.endpoint = configuration[0]
+            self.query_endpoint = configuration[0]
             if len(configuration) > 1:
-                self.updateEndpoint = configuration[1]
+                self.update_endpoint = configuration[1]
         else:
-            self.endpoint = configuration
+            self.query_endpoint = configuration
 
-        if not self.updateEndpoint:
-            self.updateEndpoint = self.endpoint
+        if not self.update_endpoint:
+            self.update_endpoint = self.endpoint
 
     def _transaction(self):
         if self._edits is None:
             self._edits = []
         return self._edits
-
-    def __set_update_endpoint(self, update_endpoint):
-        self.updateEndpoint = update_endpoint
-
-    def __get_update_endpoint(self):
-        return self.updateEndpoint
-
-    update_endpoint = property(
-        __get_update_endpoint,
-        __set_update_endpoint,
-        doc='the HTTP URL for the Update endpoint, typically '
-            'something like http://server/dataset/update')
 
     # Transactional interfaces
     def commit(self):
@@ -584,7 +507,7 @@ class SPARQLUpdateStore(SPARQLStore):
             and reads can degenerate to the original call-per-triple situation that originally existed.
         """
         if self._edits and len(self._edits) > 0:
-            self._do_update('\n;\n'.join(self._edits))
+            self._update('\n;\n'.join(self._edits))
             self._edits = None
 
     def rollback(self):
@@ -593,7 +516,7 @@ class SPARQLUpdateStore(SPARQLStore):
     def add(self, spo, context=None, quoted=False):
         """ Add a triple to the store of triples. """
 
-        if not self.endpoint:
+        if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
 
         assert not quoted
@@ -612,7 +535,7 @@ class SPARQLUpdateStore(SPARQLStore):
 
     def addN(self, quads):
         """ Add a list of quads to the store. """
-        if not self.endpoint:
+        if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
 
         contexts = collections.defaultdict(list)
@@ -634,7 +557,7 @@ class SPARQLUpdateStore(SPARQLStore):
 
     def remove(self, spo, context):
         """ Remove a triple from the store """
-        if not self.endpoint:
+        if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
 
         (subject, predicate, obj) = spo
@@ -659,23 +582,13 @@ class SPARQLUpdateStore(SPARQLStore):
     def setTimeout(self, timeout):
         self._timeout = int(timeout)
 
-    def _do_update(self, update):
+    def _update(self, update):
 
         self._updates += 1
 
-        self.resetQuery()
-        self.setQuery(update)
-        self.setMethod(POST)
-        self.timeout = self._timeout
-        self.setRequestMethod(URLENCODED if self.postAsEncoded else POSTDIRECTLY)
+        SPARQLWrapper.update(self, update)
 
-        result = SPARQLWrapper.query(self)
 
-        # we must read (and discard) the whole response
-        # otherwise the network socket buffer will at some point be "full"
-        # and we will block
-        with contextlib.closing(result.response) as res:
-            res.read()
 
     def update(self, query,
                initNs={},
@@ -714,7 +627,7 @@ class SPARQLUpdateStore(SPARQLStore):
               uncommon situations and produce invalid output.
 
         """
-        if not self.endpoint:
+        if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
 
         self.debug = DEBUG
@@ -803,6 +716,12 @@ class SPARQLUpdateStore(SPARQLStore):
         elif graph.identifier != DATASET_DEFAULT_GRAPH_ID:
             self.update(
                 "CREATE GRAPH %s" % self.node_to_sparql(graph.identifier))
+
+    def close(self, commit_pending_transaction=False):
+
+        if commit_pending_transaction: self.commit()
+
+        super(SPARQLStore, self).close()
 
     def remove_graph(self, graph):
         if not self.graph_aware:

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -352,6 +352,9 @@ class SPARQLStore(SPARQLWrapper, Store):
         else:
             return graph.identifier != DATASET_DEFAULT_GRAPH_ID
 
+    def close(self, commit_pending_transaction=None):
+        SPARQLWrapper.close(self)
+
 
 class SPARQLUpdateStore(SPARQLStore):
     """A store using SPARQL queries for reading and SPARQL Update for changes.

--- a/rdflib/plugins/stores/sparqlwrapper.py
+++ b/rdflib/plugins/stores/sparqlwrapper.py
@@ -22,12 +22,16 @@ class SPARQLWrapper(object):
     this class deals with nitty gritty details of talking to a SPARQL server
     """
 
-    def __init__(self, query_endpoint=None, update_endpoint=None, returnFormat='xml', method='GET', timeout=None):
+    def __init__(self, query_endpoint=None, update_endpoint=None, returnFormat='xml', method='GET', **kwargs):
+
+        """
+        Any additional keyword arguments will be passed to requests, and can be used to setup timesouts, basic auth, etc.
+        """
 
         self.returnFormat = returnFormat
         self.query_endpoint = query_endpoint
         self.update_endpoint = update_endpoint
-        self.timeout = timeout
+        self.kwargs = kwargs
         self.method = method
 
         # it is recommended to have one session object per thread/process. This assures that is the case.
@@ -50,7 +54,6 @@ class SPARQLWrapper(object):
     @method.setter
     def method(self, method):
         if method not in ('GET', 'POST'):
-            print 'cake'
             raise SPARQLWrapperException('Method must be "GET" or "POST"')
 
         self._method = method
@@ -66,13 +69,17 @@ class SPARQLWrapper(object):
 
         headers = { 'Accept': _response_mime_types[self.returnFormat] }
 
-        args = dict(url=self.query_endpoint,
-                    headers=headers,
-                    timeout=self.timeout)
+        args = dict(self.kwargs)
+        args.update(url=self.query_endpoint)
 
+        # merge params/headers dicts
+        args.setdefault('params', {})
+
+        args.setdefault('headers', {})
+        args['headers'].update(headers)
 
         if self.method == 'GET':
-            args['params'] = params
+            args['params'].update(params)
         elif self.method == 'POST':
             args['data'] = params
         else:
@@ -81,6 +88,7 @@ class SPARQLWrapper(object):
         res = self.session.request(self.method, **args)
 
         res.raise_for_status()
+
         return Result.parse(BytesIO(res.content), content_type=res.headers['Content-type'])
 
     def update(self, update, default_graph=None):
@@ -93,16 +101,22 @@ class SPARQLWrapper(object):
 
         headers = { 'Accept': _response_mime_types[self.returnFormat] }
 
-        res = self.session.post(self.update_endpoint,
-                            params=params,
-                            data=update.encode('utf-8'),
-                            headers=headers,
-                            timeout=self.timeout)
+        args = dict(self.kwargs)
+
+        args.update(url=self.update_endpoint,
+                    data=update.encode('utf-8'))
+
+        # merge params/headers dicts
+        args.setdefault('params', {})
+        args['params'].update(params)
+        args.setdefault('headers', {})
+        args['headers'].update(headers)
+
+        res = self.session.post(**args)
 
 
         res.raise_for_status()
 
 
     def close(self):
-        pass
-        #self.session.close()
+        self.session.close()

--- a/rdflib/plugins/stores/sparqlwrapper.py
+++ b/rdflib/plugins/stores/sparqlwrapper.py
@@ -1,0 +1,108 @@
+import logging
+import threading
+import requests
+
+import os
+
+from io import BytesIO
+
+from rdflib.query import Result
+
+log = logging.getLogger(__name__)
+
+class SPARQLWrapperException(Exception): pass
+
+_response_mime_types = {
+    'xml': 'application/sparql-results+xml, application/rdf+xml',
+}
+
+class SPARQLWrapper(object):
+
+    """
+    this class deals with nitty gritty details of talking to a SPARQL server
+    """
+
+    def __init__(self, query_endpoint=None, update_endpoint=None, returnFormat='xml', method='GET', timeout=None):
+
+        self.returnFormat = returnFormat
+        self.query_endpoint = query_endpoint
+        self.update_endpoint = update_endpoint
+        self.timeout = timeout
+        self.method = method
+
+        # it is recommended to have one session object per thread/process. This assures that is the case.
+        # https://github.com/kennethreitz/requests/issues/1871
+
+        self._session = threading.local()
+
+
+    @property
+    def session(self):
+        k = 'session_%d'%os.getpid()
+        self._session.__dict__.setdefault(k, requests.Session())
+        log.debug('Session %s %s', os.getpid(), id(self._session.__dict__[k]))
+        return self._session.__dict__[k]
+
+    @property
+    def method(self):
+        return self._method
+
+    @method.setter
+    def method(self, method):
+        if method not in ('GET', 'POST'):
+            print 'cake'
+            raise SPARQLWrapperException('Method must be "GET" or "POST"')
+
+        self._method = method
+
+
+    def query(self, query, default_graph=None):
+
+        if not self.query_endpoint:
+            raise SPARQLWrapperException("Query endpoint not set!")
+
+        params = { 'query': query }
+        if default_graph: params["default-graph-uri"] = default_graph
+
+        headers = { 'Accept': _response_mime_types[self.returnFormat] }
+
+        args = dict(url=self.query_endpoint,
+                    headers=headers,
+                    timeout=self.timeout)
+
+
+        if self.method == 'GET':
+            args['params'] = params
+        elif self.method == 'POST':
+            args['data'] = params
+        else:
+            raise SPARQLWrapperException("Unknown method %s"%self.method)
+
+        res = self.session.request(self.method, **args)
+
+        res.raise_for_status()
+        return Result.parse(BytesIO(res.content), content_type=res.headers['Content-type'])
+
+    def update(self, update, default_graph=None):
+        if not self.update_endpoint:
+            raise SPARQLWrapperException("Query endpoint not set!")
+
+        params = { }
+
+        if default_graph: params["using-graph-uri"] = default_graph
+
+        headers = { 'Accept': _response_mime_types[self.returnFormat] }
+
+        res = self.session.post(self.update_endpoint,
+                            params=params,
+                            data=update.encode('utf-8'),
+                            headers=headers,
+                            timeout=self.timeout)
+
+
+        res.raise_for_status()
+
+
+    def close(self):
+        pass
+        #self.session.close()

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -195,10 +195,11 @@ class Result(object):
         _get_bindings, _set_bindings, doc="a list of variable bindings as dicts")
 
     @staticmethod
-    def parse(source, format='xml', **kwargs):
+    def parse(source=None, format=None, content_type=None, **kwargs):
         from rdflib import plugin
-        parser = plugin.get(format, ResultParser)()
-        return parser.parse(source, **kwargs)
+        parser = plugin.get(format or content_type or 'xml', ResultParser)()
+
+        return parser.parse(source, content_type=content_type, **kwargs)
 
     def serialize(
             self, destination=None, encoding="utf-8", format='xml', **args):

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ from setuptools import setup, find_packages
 
 kwargs = {}
 kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing']
-kwargs['tests_require'] = ['html5lib', 'networkx', 'SPARQLWrapper']
+kwargs['tests_require'] = ['html5lib', 'networkx']
 kwargs['test_suite'] = "nose.collector"
-kwargs['extras_require'] = {'sparql': ['SPARQLWrapper'], 'html': ['html5lib']}
+kwargs['extras_require'] = {'html': ['html5lib']}
 
 def find_version(filename):
     _version_re = re.compile(r'__version__ = "(.*)"')


### PR DESCRIPTION
Replace it with "SPARQLWrapper-Lite", which is based on the `requests` library. 

This gains us lots of nice modern HTTP library features, such as keepalive, connection pooling, and by exposing the `kwargs` to be sent to requests, we can do http basic auth etc. easily. 

SPARQLWrapper also has lots of legacy code from supporting various old RDF stores from the days before the SPARQL Protocol was a thing. The new code only supports [SPARQL 1.1 Protocol](https://www.w3.org/TR/sparql11-protocol/) standard, and can therefore be much shorter!

This is not quite done - PR for testing + feedback! (but I run this in production, so it's also not completely pre-beta :) )