### PR TITLE
improve hash efficiency by directly using str/unicode hash

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -200,10 +200,11 @@ class Identifier(Node, text_type):  # allow Identifiers to be Nodes in the Graph
             return True
         return self == other
 
-    def __hash__(self):
-        t = type(self)
-        fqn = t.__module__ + '.' + t.__name__
-        return hash(fqn) ^ hash(text_type(self))
+    # use parent's hash for efficiency reasons
+    # clashes of 'foo', URIRef('foo') and Literal('foo') are typically so rare
+    # that they don't justify additional overhead. Notice that even in case of
+    # clash __eq__ is still the fallback and very quick in those cases.
+    __hash__ = text_type.__hash__
 
 
 class URIRef(Identifier):
@@ -924,7 +925,8 @@ class Literal(Identifier):
         -- 6.5.1 Literal Equality (RDF: Concepts and Abstract Syntax)
 
         """
-        res = super(Literal, self).__hash__()
+        # don't use super()... for efficiency reasons, see Identifier.__hash__
+        res = text_type.__hash__(self)
         if self.language:
             res ^= hash(self.language.lower())
         if self.datatype:


### PR DESCRIPTION
During investigation of a performance issue in my graph pattern learner, i noticed (sadly not for the first time) that rdflib spends massive amounts of time when hashing Identifiers. For example below you can see how about 34 % of the execution time of a minimal example are spent in `Identifier.__hash__`:
![screen shot 2017-05-25 at 22 43 27](https://cloud.githubusercontent.com/assets/464192/26470033/7b9a5910-419c-11e7-84bc-3fe051c4c207.png)

This change makes hashing about 25 % more efficient for URIRefs, 15 % for Literals.

After this change (nothing else changed) for my code (using various sets, dicts, ...) this means a speedup of ~4:
![screen shot 2017-05-25 at 22 44 59](https://cloud.githubusercontent.com/assets/464192/26470032/7b787f34-419c-11e7-8219-31e94872076b.png)

Before, hashing performed several string concatenations to get the fqn, then hash that and XOR with str/unicode hash. It did this to avoid potential hash collisions between 'foo', URIRef('foo'), Literal('foo').

However, those scenarios can be considered corner cases. Testing the new hashing version in worst-case collision scenarios, it actually performs very close to the old behavior, but clearly outperforms it in more normal ones.

Test code for ipython:
```
from rdflib import URIRef, Literal

def test():
    # worst case collisions
    s = set()
    for i in range(100000):
        _s = u'foo:%d' % i
        s.add(_s)
        s.add(URIRef(_s))
        s.add(Literal(_s))
    assert len(s) == 300000

%timeit test()

"more natural ones:"
%timeit set(URIRef('asldkfjlsadkfsaldfj:%d' % i) for i in range(100000))
%timeit set(Literal('asldkfjlsadkfsaldfj%d' % i) for i in range(100000))
```

Results:

Old:
1 loop, best of 3: 940 ms per loop
1 loop, best of 3: 334 ms per loop
1 loop, best of 3: 610 ms per loop

New:
1 loop, best of 3: 945 ms per loop
1 loop, best of 3: 250 ms per loop
1 loop, best of 3: 515 ms per loop