### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ exist). New Namespaces can also be defined:
 
 ```python
 
-dbpedia=Namespace('http://dbpedia.org/ontology/')
+dbpedia=rdflib.Namespace('http://dbpedia.org/ontology/')
 
 abstracts=list(x for x in g.objects(semweb, dbpedia['abstract']) if x.language=='en')
 ```


### PR DESCRIPTION
fixes a missing reference to `rdflib` when using `Namespace()` in the *getting started* section.