### PR TITLE
setup.py: Make the license field use an SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     maintainer="RDFLib Team",
     maintainer_email="rdflib-dev@google.com",
     url="https://github.com/RDFLib/rdflib",
-    license="https://raw.github.com/RDFLib/rdflib/master/LICENSE",
+    license="BSD-3-Clause",
     platforms=["any"],
     classifiers=[
             "Programming Language :: Python",


### PR DESCRIPTION
According to [1] this should rather be the license name than a link to the
LICENSE file, so use the SPDX identifier "BSD-3-Clause".

[1] https://docs.python.org/2/distutils/setupscript.html#additional-meta-data