### PR TITLE
Literal total ordering

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1406,6 +1406,7 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
 _NO_TOTAL_ORDER_TYPES = {
     datetime:lambda value:bool(value.tzinfo),
     time:lambda value:bool(value.tzinfo),
+    xml.dom.minidom.Document:lambda value:value.toxml(),
 }
 
 def _castPythonToLiteral(obj):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -812,6 +812,9 @@ class Literal(Identifier):
                     return self.language > other.language
 
             if self.value != None and other.value != None:
+                if dtself in _NO_TOTAL_ORDER_TYPES:
+                    comparator = _NO_TOTAL_ORDER_TYPES[dtself]
+                    return comparator(self.value) > comparator(other.value)
                 return self.value > other.value
 
             if text_type(self) != text_type(other):
@@ -1397,6 +1400,12 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
     _XSD_DECIMAL,
 )
 
+# these are not guranteed to sort because it is not possible
+# to calculate a total order over all valid members of the type
+# the function must partition the type into subtypes that do have total orders
+_NO_TOTAL_ORDER_TYPES = {
+    _XSD_DATETIME:lambda value:bool(value.tzinfo),
+}
 
 def _castPythonToLiteral(obj):
     """

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -812,8 +812,8 @@ class Literal(Identifier):
                     return self.language > other.language
 
             if self.value != None and other.value != None:
-                if dtself in _NO_TOTAL_ORDER_TYPES:
-                    comparator = _NO_TOTAL_ORDER_TYPES[dtself]
+                if type(self.value) in _NO_TOTAL_ORDER_TYPES:
+                    comparator = _NO_TOTAL_ORDER_TYPES[type(self.value)]
                     return comparator(self.value) > comparator(other.value)
                 return self.value > other.value
 
@@ -1362,9 +1362,6 @@ _XSD_DATETIME = URIRef(_XSD_PFX + 'dateTime')
 _XSD_DATE = URIRef(_XSD_PFX + 'date')
 _XSD_TIME = URIRef(_XSD_PFX + 'time')
 
-_XSD_GYEARMONTH = URIRef(_XSD_PFX + 'gYearMonth')
-_XSD_GYEAR = URIRef(_XSD_PFX + 'gYear')
-
 # TODO: duration, gYearMonth, gYear, gMonthDay, gDay, gMonth
 
 _NUMERIC_LITERAL_TYPES = (
@@ -1407,11 +1404,8 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
 # to calculate a total order over all valid members of the type
 # the function must partition the type into subtypes that do have total orders
 _NO_TOTAL_ORDER_TYPES = {
-    _XSD_DATETIME:lambda value:bool(value.tzinfo),
-    #_XSD_DATE:lambda value:bool(value.tzinfo),  # TODO: xsd spec allows tz
-    _XSD_TIME:lambda value:bool(value.tzinfo),
-    #_XSD_GYEARMONTH:lambda value:bool(value.tzinfo),  # TODO: spec allows tz
-    #_XSD_GYEAR:lambda value:bool(value.tzinfo),  # TODO: spec allows tz
+    datetime:lambda value:bool(value.tzinfo),
+    time:lambda value:bool(value.tzinfo),
 }
 
 def _castPythonToLiteral(obj):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1362,6 +1362,9 @@ _XSD_DATETIME = URIRef(_XSD_PFX + 'dateTime')
 _XSD_DATE = URIRef(_XSD_PFX + 'date')
 _XSD_TIME = URIRef(_XSD_PFX + 'time')
 
+_XSD_GYEARMONTH = URIRef(_XSD_PFX + 'gYearMonth')
+_XSD_GYEAR = URIRef(_XSD_PFX + 'gYear')
+
 # TODO: duration, gYearMonth, gYear, gMonthDay, gDay, gMonth
 
 _NUMERIC_LITERAL_TYPES = (
@@ -1405,6 +1408,10 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
 # the function must partition the type into subtypes that do have total orders
 _NO_TOTAL_ORDER_TYPES = {
     _XSD_DATETIME:lambda value:bool(value.tzinfo),
+    #_XSD_DATE:lambda value:bool(value.tzinfo),  # TODO: xsd spec allows tz
+    _XSD_TIME:lambda value:bool(value.tzinfo),
+    #_XSD_GYEARMONTH:lambda value:bool(value.tzinfo),  # TODO: spec allows tz
+    #_XSD_GYEAR:lambda value:bool(value.tzinfo),  # TODO: spec allows tz
 }
 
 def _castPythonToLiteral(obj):

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -55,6 +55,28 @@ class TestLiteral(unittest.TestCase):
         self.assertEqual(lit.value, decoded_b64msg)
         self.assertEqual(str(lit), b64msg)
 
+    def test_total_order(self):
+        types = {
+            XSD.dateTime:('0001-01-01T00:00:00', '0001-01-01T00:00:00Z',
+                          '0001-01-01T00:00:00-00:00'),
+            XSD.date:('0001-01-01', '0001-01-01Z', '0001-01-01-00:00'),
+            XSD.time:('00:00:00', '00:00:00Z', '00:00:00-00:00'),
+            XSD.gYear:('0001', '0001Z', '0001-00:00'),  # interval
+            XSD.gYearMonth:('0001-01', '0001-01Z', '0001-01-00:00'),
+        }
+        literals = [Literal(literal, datatype=type)
+                    for type, literals in types.items()
+                    for literal in literals]
+        try:
+            sorted(literals)
+            orderable = True
+        except TypeError as e:
+            for l in literals:
+                print(repr(l), repr(l.value))
+            print(e)
+            orderable = False
+        self.assertTrue(orderable)
+
 
 class TestValidityFunctions(unittest.TestCase):
 


### PR DESCRIPTION
This pull request provides basic infrastructure for sorting Literals by value where the underlying native type has no total ordering. This provides a more consistent solution to issues like: https://github.com/RDFLib/rdflib/issues/648, https://github.com/RDFLib/rdflib/issues/630, and https://github.com/RDFLib/rdflib/issues/613, where workarounds are implemented in the serializer. This leads to massively increased code complexity in the serializers to compensate for the fact that Literal does not support a total ordering because some of the underlying python types do not.

The two types that currently cause issues are datetime and time, but the proposed solution is easily extensible. If other types are found to have this issue the solution is to add an entry to _NO_TOTAL_ORDER_TYPES that includes a function that partitions the type into subtypes that do have total orders.

This pull request also adds test to ensure that types with known issues sort as expected.