### PR TITLE
Suppress warning for not using custom encoding.

### DIFF
--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -22,7 +22,7 @@ class NQuadsSerializer(Serializer):
     def serialize(self, stream, base=None, encoding=None, **args):
         if base is not None:
             warnings.warn("NQuadsSerializer does not support base.")
-        if encoding is not None:
+        if encoding is not None and encoding.lower() != self.encoding.lower():
             warnings.warn("NQuadsSerializer does not use custom encoding.")
         encoding = self.encoding
         for context in self.store.contexts():

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -25,7 +25,7 @@ class NTSerializer(Serializer):
     def serialize(self, stream, base=None, encoding=None, **args):
         if base is not None:
             warnings.warn("NTSerializer does not support base.")
-        if encoding is not None:
+        if encoding is not None and encoding.lower() != self.encoding.lower():
             warnings.warn("NTSerializer does not use custom encoding.")
         encoding = self.encoding
         for triple in self.store:


### PR DESCRIPTION
Suppress the warning "NQuadsSerializer/NTSerializer does not use custom encoding." in the case that the `encoding` argument (custom encoding) is set to the same value as the default encoding (`self.encoding`).

This is especially relevant, if one is selecting the NQuadsSerializer/NTSerializer for serializing query results, since it is setting `utf-8` as `encoding`: https://github.com/RDFLib/rdflib/blob/0469adb01a4dc3dd7b153496ad5e1c0f09a66465/rdflib/query.py#L203-L230