### PR TITLE
Add possibility to set authority and basepath to skolemize graph

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1218,21 +1218,21 @@ class Graph(Node):
         for t in self.triples((None, None, None)):
             target.add(func(t))
 
-    def skolemize(self, new_graph=None, bnode=None):
+    def skolemize(self, new_graph=None, bnode=None, authority=None, basepath=None):
         def do_skolemize(bnode, t):
             (s, p, o) = t
             if s == bnode:
-                s = s.skolemize()
+                s = s.skolemize(authority=authority, basepath=basepath)
             if o == bnode:
-                o = o.skolemize()
+                o = o.skolemize(authority=authority, basepath=basepath)
             return (s, p, o)
 
         def do_skolemize2(t):
             (s, p, o) = t
             if isinstance(s, BNode):
-                s = s.skolemize()
+                s = s.skolemize(authority=authority, basepath=basepath)
             if isinstance(o, BNode):
-                o = o.skolemize()
+                o = o.skolemize(authority=authority, basepath=basepath)
             return (s, p, o)
 
         retval = Graph() if new_graph is None else new_graph

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -420,13 +420,17 @@ class BNode(Identifier):
             clsName = self.__class__.__name__
         return """%s('%s')""" % (clsName, str(self))
 
-    def skolemize(self, authority="http://rdlib.net/"):
+    def skolemize(self, authority=None, basepath=None):
         """ Create a URIRef "skolem" representation of the BNode, in accordance
         with http://www.w3.org/TR/rdf11-concepts/#section-skolemization
 
         .. versionadded:: 4.0
         """
-        skolem = "%s%s" % (rdflib_skolem_genid, text_type(self))
+        if authority is None:
+            authority = "http://rdlib.net/"
+        if basepath is None:
+            basepath = rdflib_skolem_genid
+        skolem = "%s%s" % (basepath, text_type(self))
         return URIRef(urljoin(authority, skolem))
 
 


### PR DESCRIPTION
When calling `Graph.skolemize()` it is not possible to set the authority, while the parameter exists on the `BNode.skolemize(authority)` method.

With this contribution it is possible to set the `authority` also when calling `skolemize()` on a graph.
Further an additional optional parameter `basepath` is added to allow the configuration of the path which is perpended to the generated ID.