### PR TITLE
fix property paths bug: issue #715

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -361,7 +361,7 @@ class MulPath(Path):
                     for s2, o2 in _bwd(None, s, seen):
                         yield s2, o
 
-        def _fwdbwd():
+        def _all_fwd_paths():
             if self.zero:
                 seen1 = set()
                 # According to the spec, ALL nodes are possible solutions
@@ -377,15 +377,17 @@ class MulPath(Path):
                         seen1.add(o)
                         yield o, o
 
+            seen = set()
             for s, o in evalPath(graph, (None, self.path, None)):
                 if not self.more:
                     yield s, o
                 else:
-                    seen = set()
-                    f = list(_fwd(s, None, seen))  # cache or recompute?
-                    for s3, o3 in _bwd(None, o, seen):
-                        for s2, o2 in f:
-                            yield s3, o2  # ?
+                    if s not in seen:
+                        seen.add(s)
+                        f = list(_fwd(s, None, set()))
+                        for s1, o1 in f:
+                            assert s1 == s
+                            yield(s1, o1)
 
         done = set()  # the spec does by defn. not allow duplicates
         if subj:
@@ -399,7 +401,7 @@ class MulPath(Path):
                     done.add(x)
                     yield x
         else:
-            for x in _fwdbwd():
+            for x in _all_fwd_paths():
                 if x not in done:
                     done.add(x)
                     yield x

--- a/test/test_issue715.py
+++ b/test/test_issue715.py
@@ -1,0 +1,29 @@
+"""
+Issue 715 - path query chaining issue
+Some incorrect matches were found when using oneOrMore ('+') and
+zeroOrMore ('*') property paths and specifying neither the
+subject or the object.
+"""
+
+from rdflib import URIRef, Graph
+
+
+def test_issue_715():
+    g = Graph()
+    a, b, x, y, z = [URIRef(s) for s in "abxyz"]
+    isa = URIRef('isa')
+    g.add((a, isa, x))
+    g.add((a, isa, y))
+    g.add((b, isa, x))
+    l1 = list(g.query('SELECT ?child ?parent WHERE {?child <isa> ?parent .}'))
+    l2 = list(g.query('SELECT ?child ?parent WHERE {?child <isa>+ ?parent .}'))
+    assert len(l1) == len(l2)
+    assert set(l1) == set(l2)
+    l3 = list(g.query('SELECT ?child ?parent WHERE {?child <isa>* ?parent .}'))
+    assert len(l3) == 7
+    assert set(l3) == set(l1).union({(URIRef(n), URIRef(n)) for
+                                     n in (a, b, x, y)})
+    g.add((y, isa, z))
+    l4 = list(g.query('SELECT ?child ?parent WHERE {?child <isa>* ?parent .}'))
+    assert len(l4) == 10
+    assert (a, z) in l4


### PR DESCRIPTION
As mentioned in #715, when trying to match an arbitrary length property path
between two variables, e.g. "?a rdfs:subClassOf+ ?b", some bad solutions were
returned. I tried to fix this while changing as little as possible the logic of
the property paths implementation.