### PR TITLE
ClosedNamespace KeyError -> AttributeError

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -169,7 +169,7 @@ class ClosedNamespace(object):
     def term(self, name):
         uri = self.__uris.get(name)
         if uri is None:
-            raise KeyError(
+            raise AttributeError(
                 "term '{}' not in namespace '{}'".format(name, self.uri)
             )
         else:


### PR DESCRIPTION
The current implementation of ClosedNamespace raises a KeyError via `__getattr__` which breaks hasattr. This patch fixes it by raising an AttributeError instead.