### PR TITLE
Total order patch patch

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -811,10 +811,10 @@ class Literal(Identifier):
                 else:
                     return self.language > other.language
 
-            if self.value != None and other.value != None:
-                if type(self.value) in _NO_TOTAL_ORDER_TYPES:
-                    comparator = _NO_TOTAL_ORDER_TYPES[type(self.value)]
-                    return comparator(self.value) > comparator(other.value)
+            if self.value is not None and other.value is not None:
+                if type(self.value) in _TOTAL_ORDER_CASTERS:
+                    caster = _TOTAL_ORDER_CASTERS[type(self.value)]
+                    return caster(self.value) > caster(other.value)
                 return self.value > other.value
 
             if text_type(self) != text_type(other):
@@ -1400,13 +1400,21 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
     _XSD_DECIMAL,
 )
 
-# these are not guranteed to sort because it is not possible
-# to calculate a total order over all valid members of the type
-# the function must partition the type into subtypes that do have total orders
-_NO_TOTAL_ORDER_TYPES = {
-    datetime:lambda value:bool(value.tzinfo),
-    time:lambda value:bool(value.tzinfo),
-    xml.dom.minidom.Document:lambda value:value.toxml(),
+# the following types need special treatment for reasonable sorting because
+# certain instances can't be compared to each other. We treat this by
+# partitioning and then sorting within those partitions.
+_TOTAL_ORDER_CASTERS = {
+    datetime: lambda value: (
+        # naive vs. aware
+        value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None,
+        value
+    ),
+    time: lambda value: (
+        # naive vs. aware
+        value.tzinfo is not None and value.tzinfo.utcoffset(None) is not None,
+        value
+    ),
+    xml.dom.minidom.Document: lambda value: value.toxml(),
 }
 
 def _castPythonToLiteral(obj):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -757,31 +757,31 @@ class Literal(Identifier):
         This tries to implement this:
         http://www.w3.org/TR/sparql11-query/#modOrderBy
 
-        In short, Literals with compatible data-types are orderd in value space,
-        i.e.
+        In short, Literals with compatible data-types are ordered in value
+        space, i.e.
         >>> from rdflib import XSD
 
-        >>> Literal(1)>Literal(2) # int/int
+        >>> Literal(1) > Literal(2) # int/int
         False
-        >>> Literal(2.0)>Literal(1) # double/int
+        >>> Literal(2.0) > Literal(1) # double/int
         True
         >>> from decimal import Decimal
         >>> Literal(Decimal("3.3")) > Literal(2.0) # decimal/double
         True
         >>> Literal(Decimal("3.3")) < Literal(4.0) # decimal/double
         True
-        >>> Literal('b')>Literal('a') # plain lit/plain lit
+        >>> Literal('b') > Literal('a') # plain lit/plain lit
         True
-        >>> Literal('b')>Literal('a', datatype=XSD.string) # plain lit/xsd:string
+        >>> Literal('b') > Literal('a', datatype=XSD.string) # plain lit/xsd:str
         True
 
         Incompatible datatype mismatches ordered by DT
 
-        >>> Literal(1)>Literal("2") # int>string
+        >>> Literal(1) > Literal("2") # int>string
         False
 
         Langtagged literals by lang tag
-        >>> Literal("a", lang="en")>Literal("a", lang="fr")
+        >>> Literal("a", lang="en") > Literal("a", lang="fr")
         False
         """
         if other is None:

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -2,8 +2,9 @@
 some more specific Literal tests are in test_literal.py
 """
 
-import unittest
 import base64
+import unittest
+import random
 
 from rdflib.term import URIRef, BNode, Literal, _is_valid_unicode
 from rdflib.graph import QuotedGraph, Graph
@@ -57,16 +58,37 @@ class TestLiteral(unittest.TestCase):
 
     def test_total_order(self):
         types = {
-            XSD.dateTime:('0001-01-01T00:00:00', '0001-01-01T00:00:00Z',
-                          '0001-01-01T00:00:00-00:00'),
-            XSD.date:('0001-01-01', '0001-01-01Z', '0001-01-01-00:00'),
-            XSD.time:('00:00:00', '00:00:00Z', '00:00:00-00:00'),
-            XSD.gYear:('0001', '0001Z', '0001-00:00'),  # interval
-            XSD.gYearMonth:('0001-01', '0001-01Z', '0001-01-00:00'),
+            XSD.dateTime: (
+                '2001-01-01T00:00:00',
+                '2001-01-01T00:00:00Z',
+                '2001-01-01T00:00:00-00:00'
+            ),
+            XSD.date: (
+                '2001-01-01',
+                '2001-01-01Z',
+                '2001-01-01-00:00'
+            ),
+            XSD.time: (
+                '00:00:00',
+                '00:00:00Z',
+                '00:00:00-00:00'
+            ),
+            XSD.gYear: (
+                 '2001',
+                 '2001Z',
+                 '2001-00:00'
+            ),  # interval
+            XSD.gYearMonth: (
+                '2001-01',
+                '2001-01Z',
+                '2001-01-00:00'
+            ),
         }
-        literals = [Literal(literal, datatype=type)
-                    for type, literals in types.items()
-                    for literal in literals]
+        literals = [
+            Literal(literal, datatype=t)
+            for t, literals in types.items()
+            for literal in literals
+        ]
         try:
             sorted(literals)
             orderable = True
@@ -76,6 +98,34 @@ class TestLiteral(unittest.TestCase):
             print(e)
             orderable = False
         self.assertTrue(orderable)
+
+        # also make sure that within a datetime things are still ordered:
+        l1 = [
+            Literal(l, datatype=XSD.dateTime)
+            for l in [
+                '2001-01-01T00:00:00',
+                '2001-01-01T01:00:00',
+                '2001-01-01T01:00:01',
+                '2001-01-02T01:00:01',
+                '2001-01-01T00:00:00Z',
+                '2001-01-01T00:00:00-00:00',
+                '2001-01-01T01:00:00Z',
+                '2001-01-01T01:00:00-00:00',
+                '2001-01-01T00:00:00-01:30',
+                '2001-01-01T01:00:00-01:30',
+                '2001-01-02T01:00:01Z',
+                '2001-01-02T01:00:01-00:00',
+                '2001-01-02T01:00:01-01:30'
+            ]
+        ]
+        l2 = l1.copy()
+        random.shuffle(l2)
+        for d in l1:
+            print(d)
+        print()
+        for d in sorted(l2):
+            print(d)
+        self.assertListEqual(l1, sorted(l2))
 
 
 class TestValidityFunctions(unittest.TestCase):

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -118,13 +118,8 @@ class TestLiteral(unittest.TestCase):
                 '2001-01-02T01:00:01-01:30'
             ]
         ]
-        l2 = l1.copy()
+        l2 = list(l1)
         random.shuffle(l2)
-        for d in l1:
-            print(d)
-        print()
-        for d in sorted(l2):
-            print(d)
         self.assertListEqual(l1, sorted(l2))
 
 


### PR DESCRIPTION
fixes possible problems introduced by #793 which caused datetime objects only to be sorted by existance of tzinfo.

Solution here is to cast to a tuple (naive/aware, value) and relying on sort / comparison of tuples to be lazy