### PR TITLE
Add HTTP accept header for turtle

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -98,7 +98,7 @@ class URLInputSource(InputSource):
         elif format == 'n3':
             myheaders['Accept'] = 'text/n3, */*;q=0.1'
         elif format == 'turtle':
-            myheaders['Accept'] = 'text/turtle, */*;q=0.1'
+            myheaders['Accept'] = 'text/turtle,application/x-turtle, */*;q=0.1'
         elif format == 'nt':
             myheaders['Accept'] = 'text/plain, */*;q=0.1'
         elif format == 'json-ld':

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -97,6 +97,8 @@ class URLInputSource(InputSource):
             myheaders['Accept'] = 'application/rdf+xml, */*;q=0.1'
         elif format == 'n3':
             myheaders['Accept'] = 'text/n3, */*;q=0.1'
+        elif format == 'turtle':
+            myheaders['Accept'] = 'text/turtle, */*;q=0.1'
         elif format == 'nt':
             myheaders['Accept'] = 'text/plain, */*;q=0.1'
         elif format == 'json-ld':


### PR DESCRIPTION
Loading a turtle file from a remote source now sends the turtle mime type `text/turtle`.
I've also added the old `application/x-turtle` which is used by some old implementations.