### PR TITLE
Fix blank node label to not contain '_:' during parsing

### DIFF
--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -224,7 +224,7 @@ PNAME_LN = PNAME_NS + Param('localname', PN_LOCAL.leaveWhitespace())
 # [142] BLANK_NODE_LABEL ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
 BLANK_NODE_LABEL = Regex(u'_:[0-9%s](?:[\\.%s]*[%s])?' % (
     PN_CHARS_U_re, PN_CHARS_re, PN_CHARS_re), flags=re.U)
-BLANK_NODE_LABEL.setParseAction(lambda x: rdflib.BNode(x[0]))
+BLANK_NODE_LABEL.setParseAction(lambda x: rdflib.BNode(x[0][2:]))
 
 
 # [166] VARNAME ::= ( PN_CHARS_U | [0-9] ) ( PN_CHARS_U | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -1,4 +1,4 @@
-from rdflib import Graph, URIRef, Literal
+from rdflib import Graph, URIRef, Literal, BNode
 from rdflib.plugins.sparql import prepareQuery
 from rdflib.compare import isomorphic
 
@@ -77,6 +77,35 @@ def test_complex_sparql_construct():
       <urn:id> [ a <urn:Identifier>; <urn:has-value> ?id].
     }'''
     g.query(q)
+
+
+def test_sparql_update_with_bnode():
+    """
+    Test if the blank node is inserted correctly.
+    """
+    graph = Graph()
+    graph.update(
+        "INSERT DATA { _:blankA <urn:type> <urn:Blank> }")
+    for t in graph.triples((None, None, None)):
+        assert isinstance(t[0], BNode)
+        eq_(t[1].n3(), "<urn:type>")
+        eq_(t[2].n3(), "<urn:Blank>")
+
+
+def test_sparql_update_with_bnode_serialize_parse():
+    """
+    Test if the blank node is inserted correctly, can be serialized and parsed.
+    """
+    graph = Graph()
+    graph.update(
+        "INSERT DATA { _:blankA <urn:type> <urn:Blank> }")
+    string = graph.serialize(format='ntriples').decode('utf-8')
+    raised = False
+    try:
+        Graph().parse(data=string, format="ntriples")
+    except Exception as e:
+        raised = True
+    assert not raised
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When parsing a query, e.g.:

```
PREFIX ex: <http://example.org/>
INSERT DATA { GRAPH ex: { _:blankA a ex:Bla }}
```

The generated `BNode` would be `BNode("_:blankA")` serializing this blank node with `BNode("_:blankA").n3()` results in `_:_:blankA` which the parser can not understand.