### PR TITLE
Add more ASCII chars as specified for bnode labels

### DIFF
--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -37,7 +37,7 @@ r_wspace = re.compile(r'[ \t]*')
 r_wspaces = re.compile(r'[ \t]+')
 r_tail = re.compile(r'[ \t]*\.[ \t]*(#.*)?')
 r_uriref = re.compile(uriref)
-r_nodeid = re.compile(r'_:([A-Za-z0-9_:]([-A-Za-z0-9_:\.]*[-A-Za-z0-9_:])*)')
+r_nodeid = re.compile(r'_:([A-Za-z0-9_:]([-A-Za-z0-9_:\.]*[-A-Za-z0-9_:])?)')
 r_literal = re.compile(literal + litinfo)
 
 bufsiz = 2048

--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -37,7 +37,7 @@ r_wspace = re.compile(r'[ \t]*')
 r_wspaces = re.compile(r'[ \t]+')
 r_tail = re.compile(r'[ \t]*\.[ \t]*(#.*)?')
 r_uriref = re.compile(uriref)
-r_nodeid = re.compile(r'_:([A-Za-z0-9]*)')
+r_nodeid = re.compile(r'_:([A-Za-z0-9_:]([-A-Za-z0-9_:\.]*[-A-Za-z0-9_:])*)')
 r_literal = re.compile(literal + litinfo)
 
 bufsiz = 2048

--- a/test/nt/bnode-01.nt
+++ b/test/nt/bnode-01.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> _:_1_.a .
+_:_1_.a  <http://example/p> <http://example/o> .


### PR DESCRIPTION
Add the missing ASCII characters that are specified in https://www.w3.org/TR/n-triples/#grammar-production-BLANK_NODE_LABEL to the `r_nodeid` regex in the ntriples parser.

```
[141s] BLANK_NODE_LABEL ::= '_:' (PN_CHARS_U |  [0-9]) ((PN_CHARS |  '.')* PN_CHARS)?
[158s] PN_CHARS_U ::= PN_CHARS_BASE |  '_' |  ':'
[160s] PN_CHARS ::= PN_CHARS_U |  '-' |  [0-9] |  #x00B7 |  [#x0300-#x036F] |  [#x203F-#x2040]
```

Fix #888 . Fix #835 .
Close #874 .
In contrast to #874 this provides a test.
