### PR TITLE
Remove previous prefix when calling bind

### DIFF
--- a/rdflib/plugins/memory.py
+++ b/rdflib/plugins/memory.py
@@ -158,6 +158,9 @@ class Memory(Store):
 
     def bind(self, prefix, namespace):
         self.__prefix[namespace] = prefix
+        bound_prefix = self.__prefix.get(namespace)
+        if bound_prefix is not None:
+            self.__namespace.delete(bound_prefix)
         self.__namespace[prefix] = namespace
 
     def namespace(self, prefix):
@@ -238,6 +241,9 @@ class IOMemory(Store):
 
     def bind(self, prefix, namespace):
         self.__prefix[namespace] = prefix
+        bound_prefix = self.__prefix.get(namespace)
+        if bound_prefix is not None:
+            self.__namespace.delete(bound_prefix)
         self.__namespace[prefix] = namespace
 
     def namespace(self, prefix):

--- a/rdflib/plugins/sleepycat.py
+++ b/rdflib/plugins/sleepycat.py
@@ -436,7 +436,7 @@ class Sleepycat(Store):
         prefix = prefix.encode("utf-8")
         namespace = namespace.encode("utf-8")
         bound_prefix = self.__prefix.get(namespace)
-        if bound_prefix:
+        if bound_prefix is not None:
             self.__namespace.delete(bound_prefix)
         self.__prefix[namespace] = prefix
         self.__namespace[prefix] = namespace


### PR DESCRIPTION
In Memory store plugin, bind() adds the new binding to the dicts but
doesn't remove any old one. The Sleepycat store does better, but misses
when the prefix is empty (as often happens in turtle files). This fix
applies the Sleepycat solution modified to delete re-bound empty
prefixes too