### PR TITLE
IPython tab-completions for ClosedNamespace

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -193,6 +193,14 @@ class ClosedNamespace(object):
     def __repr__(self):
         return "rdf.namespace.ClosedNamespace(%r)" % text_type(self.uri)
 
+    def _ipython_key_completions_(self):
+        # Enables IPython tab completion for getitem, eg. RDF['Pro\t
+        return [key for key in self.__uris]
+
+    def __dir__(self):
+        # Enables IPython tab completion when using dot notation
+        return list(super(ClosedNamespace, self).__dir__()) + self._ipython_key_completions_()
+
 
 class _RDFNamespace(ClosedNamespace):
     """


### PR DESCRIPTION
For a ClosedNamespace all allowed keys are known in advance, so we might as well allow IPython users to discover them via tab-completions: https://ipython.readthedocs.io/en/stable/config/integrating.html 

This change will enable tab-completion for ClosedNamespace objects when using dot notation (`RDF.Pro\t -> RDF.Property`) and for square bracket notation (`RDF['Pro\t -> RDF['Property']`).

This really adds convenience for only a subset of users, so I'd understand if the additional logic is not welcome.