### PR TITLE
Add test for having clause with expression (Var != Iri)

### DIFF
--- a/test/test_having.py
+++ b/test/test_having.py
@@ -2,8 +2,10 @@ import sys
 import unittest
 from rdflib import Graph
 
+
 class GraphTestCase(unittest.TestCase):
     g = Graph()
+    
     def setUp(self):
         data = """
         <urn:a> <urn:p> 1 .

--- a/test/test_having.py
+++ b/test/test_having.py
@@ -1,0 +1,43 @@
+import sys
+import unittest
+from rdflib import Graph
+
+class GraphTestCase(unittest.TestCase):
+    g = Graph()
+    def setUp(self):
+        data = """
+        <urn:a> <urn:p> 1 .
+        <urn:b> <urn:p> 3 .
+        <urn:c> <urn:q> 1 .
+        """
+
+        self.g.parse(data=data, format="turtle")
+
+    def testGroupBy(self):
+        query = ("SELECT ?p ?o "
+                 "WHERE { ?s ?p ?o } "
+                 "GROUP BY ?p")
+        qres = self.g.query(query)
+
+        self.assertEqual(2, len(qres))
+
+    def testHavingAggregateEqLiteral(self):
+
+        query = ("SELECT ?p (avg(?o) as ?a) "
+                 "WHERE { ?s ?p ?o } "
+                 "GROUP BY ?p HAVING (avg(?o) = 2 )")
+        qres = self.g.query(query)
+
+        self.assertEqual(1, len(qres))
+
+    def testHavingPrimaryExpressionVarNeqIri(self):
+        query = ("SELECT ?p ?o"
+                 "WHERE { ?s ?p ?o } "
+                 "GROUP BY ?p HAVING (?p != <urn:foo> )")
+        qres = self.g.query(query)
+
+        self.assertEqual(2, len(qres))
+
+
+if __name__ == '__main__':
+    unittest.main(argv=sys.argv[:1])

--- a/test/test_having.py
+++ b/test/test_having.py
@@ -16,7 +16,7 @@ class GraphTestCase(unittest.TestCase):
         self.g.parse(data=data, format="turtle")
 
     def testGroupBy(self):
-        query = ("SELECT ?p ?o "
+        query = ("SELECT ?p"
                  "WHERE { ?s ?p ?o } "
                  "GROUP BY ?p")
         qres = self.g.query(query)
@@ -33,7 +33,7 @@ class GraphTestCase(unittest.TestCase):
         self.assertEqual(1, len(qres))
 
     def testHavingPrimaryExpressionVarNeqIri(self):
-        query = ("SELECT ?p ?o "
+        query = ("SELECT ?p "
                  "WHERE { ?s ?p ?o } "
                  "GROUP BY ?p HAVING (?p != <urn:foo> )")
         qres = self.g.query(query)

--- a/test/test_having.py
+++ b/test/test_having.py
@@ -31,7 +31,7 @@ class GraphTestCase(unittest.TestCase):
         self.assertEqual(1, len(qres))
 
     def testHavingPrimaryExpressionVarNeqIri(self):
-        query = ("SELECT ?p ?o"
+        query = ("SELECT ?p ?o "
                  "WHERE { ?s ?p ?o } "
                  "GROUP BY ?p HAVING (?p != <urn:foo> )")
         qres = self.g.query(query)


### PR DESCRIPTION
This pull request adds three test cases for a group by (`testGroupBy`) and two group by with having clauses (`testHavingAggregateEqLiteral` and `testHavingPrimaryExpressionVarNeqIri`).
The having clause that compares an aggregate with a literal works correctly (`testHavingAggregateEqLiteral`), while the comparison of a variable with an iri does not work correctly (`testHavingPrimaryExpressionVarNeqIri`).

I expect the having clause in `testHavingPrimaryExpressionVarNeqIri` to be true in all cases and thus to produce two results, just as the `testGroupBy` does.

Test for issue #936.