### PR TITLE
make SPARQLConnector work with DBpedia

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -286,6 +286,9 @@ register(
 register(
     'application/sparql-results+xml', ResultParser,
     'rdflib.plugins.sparql.results.xmlresults', 'XMLResultParser')
+register(
+    'application/sparql-results+xml; charset=UTF-8', ResultParser,
+    'rdflib.plugins.sparql.results.xmlresults', 'XMLResultParser')
 
 register(
     'application/rdf+xml', ResultParser,

--- a/test/test_sparqlstore.py
+++ b/test/test_sparqlstore.py
@@ -3,9 +3,8 @@ from six.moves.urllib.request import urlopen
 import os
 import unittest
 from nose import SkipTest
+from requests import HTTPError
 
-if os.getenv("TRAVIS"):
-    raise SkipTest("Doesn't work in travis")
 
 try:
     assert len(urlopen("http://dbpedia.org/sparql").read()) > 0
@@ -51,7 +50,7 @@ class SPARQLStoreDBPediaTestCase(unittest.TestCase):
             { ?s a xyzzy:Concept ; xyzzy:prefLabel ?label . } LIMIT 10
         """
         self.assertRaises(
-            SPARQLWrapper.Wrapper.QueryBadFormed,
+            HTTPError,
             self.graph.query,
             query)
 


### PR DESCRIPTION
i think this was a leftover from #744 

DBpedia seems to answer with `application/sparql-results+xml; charset=UTF-8` header, which wasn't registered in plugins...

also unskips an old test on travis tha otherwise failed locally due to now unresolved SPARQLWrapper exception ref