### PR TITLE
Missing check in __init__.py prevents rdflib to be usable in QGIS plugin

### DIFF
--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 _interactive_mode = False
 try:
     import __main__
-    if not hasattr(__main__, '__file__') and sys.stderr.isatty():
+    if not hasattr(__main__, '__file__') and sys.stdout!=None and sys.stderr.isatty():
         # show log messages in interactive mode
         _interactive_mode = True
         logger.setLevel(logging.INFO)


### PR DESCRIPTION
When using rdflib inside our QGIS Plugin (https://plugins.qgis.org) SPARQLUnicorn (https://github.com/sparqlunicorn/sparqlunicornGoesGIS) sys.stdout is not defined when executing the Plugin in Windows.
This causes our plugin to crash.
By adding a simple check if sys.stdout is None rdflib is working perfectly when used in QGIS.

I would appreciate if you could include this very simple check.

Thank you!