### PR TITLE
Update to import directly from collections.abc

### DIFF
--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import
 import collections
 import itertools
 import datetime
-from collections.abc import Mapping, MutableMapping
-
+try:
+    from collections.abc import Mapping, MutableMapping
+except:
+    from collections import Mapping, MutableMapping
 import isodate
 from six import text_type, iteritems
 

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import collections
 import itertools
 import datetime
-from collections import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 import isodate
 from six import text_type, iteritems

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -7,6 +7,7 @@ try:
     from collections.abc import Mapping, MutableMapping
 except:
     from collections import Mapping, MutableMapping
+    
 import isodate
 from six import text_type, iteritems
 


### PR DESCRIPTION
Error :: "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working from collections import Mapping, MutableMapping."

The query function might break with python 3.8 because of this. Should update this soon to avoid that possibility.