### PR TITLE
Correct support for container membership properties (RDF._1).

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -224,11 +224,17 @@ class _RDFNamespace(ClosedNamespace):
         )
 
     def term(self, name):
-        try:
-            i = int(name)
-            return URIRef("%s_%s" % (self.uri, i))
-        except ValueError:
-            return super(_RDFNamespace, self).term(name)
+        # Container membership properties
+        if name.startswith('_'):
+            try:
+                i = int(name[1:])
+            except ValueError:
+                pass
+            else:
+                if i > 0:
+                    return URIRef("%s_%s" % (self.uri, i))
+
+        return super(_RDFNamespace, self).term(name)
 
 
 RDF = _RDFNamespace()

--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -64,7 +64,7 @@ class BagID(URIRef):
 
     def next_li(self):
         self.li += 1
-        return RDFNS[self.li]
+        return RDFNS['_%s' % self.li]
 
 
 class ElementHandler(object):
@@ -89,7 +89,7 @@ class ElementHandler(object):
 
     def next_li(self):
         self.li += 1
-        return RDFNS[self.li]
+        return RDFNS['_%s' % self.li]
 
 
 class RDFXMLHandler(handler.ContentHandler):


### PR DESCRIPTION
Right now, rdflib supports accessing them only thru `getattr(RDF, '1')` - because `RDF.1` is invalid Python.

The RDF spec references them as `rdf:_1`, so it looks like a good idea to allow `RDF._1` (which is valid Python).

Also, the RDF spec allows only numbers greater than 0.