### PR TITLE
collections migration update and backwards comparability. 

### DIFF
--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -154,3 +154,10 @@ def decodeUnicodeEscape(s):
         s = _unicodeExpand(s)  # hmm - string escape doesn't do unicode escaping
 
     return s
+
+
+# Migration to abc in Python 3.8
+try:
+    from collections.abc import Mapping, MutableMapping
+except:
+    from collections import Mapping, MutableMapping

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -6,8 +6,8 @@ import datetime
 
 import isodate
 from six import text_type, iteritems
-from rdflib.compat import Mapping, MutableMapping
 
+from rdflib.compat import Mapping, MutableMapping
 from rdflib.namespace import NamespaceManager
 from rdflib import Variable, BNode, Graph, ConjunctiveGraph, URIRef, Literal
 from rdflib.term import Node

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 import collections
 import itertools
 import datetime
-from collections import Mapping, MutableMapping
 
 import isodate
 from six import text_type, iteritems
+from rdflib.compat import Mapping, MutableMapping
 
 from rdflib.namespace import NamespaceManager
 from rdflib import Variable, BNode, Graph, ConjunctiveGraph, URIRef, Literal


### PR DESCRIPTION
Backwards comparability placed into rdflib/compat.py as per request. 

Previous correction suggestion at #950. Created a proper fork for a more detailed change. 

Error :: "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working from collections import Mapping, MutableMapping."

The query function might break with python 3.8 because of this. Should update this soon to avoid that possibility.