### PR TITLE
fixed URIRef including native unicode characters

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -50,6 +50,7 @@ import xml.dom.minidom
 from datetime import date, time, datetime, timedelta
 from re import sub, compile
 from collections import defaultdict
+from unicodedata import category
 
 from isodate import parse_time, parse_date, parse_datetime, Duration, parse_duration, duration_isoformat
 
@@ -73,10 +74,11 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    for c in _invalid_uri_chars:
-        if c in uri:
-            return False
-    return True
+    """
+    Verify invalid chars other than Unicode Letter (Category: Lx)
+    Ref: https://www.unicode.org/reports/tr44/#General_Category
+    """
+    return all(map(lambda c: category(c).startswith('L') or not c in _invalid_uri_chars, uri))
 
 
 _lang_tag_regex = compile('^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$')

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -74,7 +74,7 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    return all(map(lambda c: category(c).startswith('L') or not c in _invalid_uri_chars, uri))
+    return all(map(lambda c: ord(c) > 256 or not c in _invalid_uri_chars, uri))
 
 
 _lang_tag_regex = compile('^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$')

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -74,10 +74,6 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    """
-    Verify invalid chars other than Unicode Letter (Category: Lx)
-    Ref: https://www.unicode.org/reports/tr44/#General_Category
-    """
     return all(map(lambda c: category(c).startswith('L') or not c in _invalid_uri_chars, uri))
 
 

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -156,7 +156,9 @@ def from_n3(s, default=None, backend=None, nsm=None):
     if not s:
         return default
     if s.startswith('<'):
-        return URIRef(s[1:-1])
+        # Hack: this should correctly handle strings with either native unicode
+        # characters, or \u1234 unicode escapes.
+        return URIRef(s[1:-1].encode("raw-unicode-escape").decode("unicode-escape"))
     elif s.startswith('"'):
         if s.startswith('"""'):
             quotes = '"""'

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -236,8 +236,8 @@ class TestUtilTermConvert(unittest.TestCase):
     def test_util_from_n3_expectpartialidempotencewithn3(self):
         for n3 in ('<http://ex.com/foo>',
                    '"foo"@de',
-                   '<http://ex.com/漢字>',
-                   '<http://ex.com/a#あ>',
+                   u'<http://ex.com/漢字>',
+                   u'<http://ex.com/a#あ>',
                    # '"\\""', # exception as '\\"' --> '"' by orig parser as well
                    '"""multi\n"line"\nstring"""@en'):
             self.assertEqual(util.from_n3(n3).n3(), n3,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 import time
 from rdflib.graph import Graph

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -236,6 +236,8 @@ class TestUtilTermConvert(unittest.TestCase):
     def test_util_from_n3_expectpartialidempotencewithn3(self):
         for n3 in ('<http://ex.com/foo>',
                    '"foo"@de',
+                   '<http://ex.com/漢字>',
+                   '<http://ex.com/a#あ>',
                    # '"\\""', # exception as '\\"' --> '"' by orig parser as well
                    '"""multi\n"line"\nstring"""@en'):
             self.assertEqual(util.from_n3(n3).n3(), n3,


### PR DESCRIPTION
URIRef should be able to include native unicode like <http://ja.dbpedia.org/resource/日本> equal to <http://ja.dbpedia.org/resource/\\u65e5\\u672c>.
Adding the code as same as line 185-187.