### PR TITLE
Compare Nones with is or is not

### DIFF
--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -191,7 +191,7 @@ class Collection(object):
         container = self.uri
         while True:
             rest = self.graph.value(container, RDF.rest)
-            if rest == None or rest == RDF.nil:
+            if rest is None or rest == RDF.nil:
                 return container
             else:
                 container = rest

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -366,7 +366,7 @@ def _traverseAgg(e, visitor=lambda n, v: None):
 
     elif isinstance(e, CompValue):
         for k, val in e.items():
-            if val != None:
+            if val is not None:
                 res.append(_traverseAgg(val, visitor))
 
     return visitor(e, res)
@@ -618,10 +618,10 @@ def translate(q):
 
     if q.limitoffset:
         offset = 0
-        if q.limitoffset.offset != None:
+        if q.limitoffset.offset is not None:
             offset = q.limitoffset.offset.toPython()
 
-        if q.limitoffset.limit != None:
+        if q.limitoffset.limit is not None:
             M = CompValue('Slice', p=M, start=offset,
                           length=q.limitoffset.limit.toPython())
         else:

--- a/rdflib/plugins/sparql/datatypes.py
+++ b/rdflib/plugins/sparql/datatypes.py
@@ -44,7 +44,7 @@ _typePromotionMap = {
 
 
 def type_promotion(t1, t2):
-    if t2 == None:
+    if t2 is None:
         return t1
     t1 = _super_types.get(t1, t1)
     t2 = _super_types.get(t2, t2)

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -840,7 +840,7 @@ def RelationalExpression(e, ctx):
 
     if isinstance(expr, Literal) and isinstance(other, Literal):
 
-        if expr.datatype != None and expr.datatype not in XSD_DTs and other.datatype != None and other.datatype not in XSD_DTs:
+        if expr.datatype is not None and expr.datatype not in XSD_DTs and other.datatype is not None and other.datatype not in XSD_DTs:
             # in SPARQL for non-XSD DT Literals we can only do =,!=
             if op not in ('=', '!='):
                 raise SPARQLError(

--- a/rdflib/plugins/sparql/results/rdfresults.py
+++ b/rdflib/plugins/sparql/results/rdfresults.py
@@ -55,7 +55,7 @@ class RDFResult(Result):
                 self.bindings.append(sol)
         elif type_ == 'ASK':
             self.askAnswer = askAnswer.value
-            if askAnswer.value == None:
+            if askAnswer.value is None:
                 raise Exception('Malformed boolean in ask answer!')
         elif type_ == 'CONSTRUCT':
             self.graph = g

--- a/rdflib/plugins/sparql/results/txtresults.py
+++ b/rdflib/plugins/sparql/results/txtresults.py
@@ -4,7 +4,7 @@ from rdflib.query import ResultSerializer
 
 
 def _termString(t, namespace_manager):
-    if t == None:
+    if t is None:
         return "-"
     if namespace_manager:
         if isinstance(t, URIRef):

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -146,7 +146,7 @@ class ResultRow(tuple):
             return default
 
     def asdict(self):
-        return dict((v, self[v]) for v in self.labels if self[v] != None)
+        return dict((v, self[v]) for v in self.labels if self[v] is not None)
 
 
 class Result(object):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -535,7 +535,7 @@ class Literal(Identifier):
         if lang == '':
             lang = None  # no empty lang-tags in RDF
 
-        normalize = normalize if normalize != None else rdflib.NORMALIZE_LITERALS
+        normalize = normalize if normalize is not None else rdflib.NORMALIZE_LITERALS
 
         if lang is not None and datatype is not None:
             raise TypeError(
@@ -608,7 +608,7 @@ class Literal(Identifier):
 
         """
 
-        if self.value != None:
+        if self.value is not None:
             return Literal(self.value, datatype=self.datatype, lang=self.language)
         else:
             return self
@@ -659,7 +659,7 @@ class Literal(Identifier):
         Is the Literal "True"
         This is used for if statements, bool(literal), etc.
         """
-        if self.value != None:
+        if self.value is not None:
             return bool(self.value)
         return len(self) != 0
 
@@ -1009,7 +1009,7 @@ class Literal(Identifier):
 
             if self.datatype in _NUMERIC_LITERAL_TYPES  \
                     and other.datatype in _NUMERIC_LITERAL_TYPES:
-                if self.value != None and other.value != None:
+                if self.value is not None and other.value is not None:
                     return self.value == other.value
                 else:
                     if text_type.__eq__(self, other):
@@ -1037,7 +1037,7 @@ class Literal(Identifier):
             # lexical form first?  comparing two ints is far quicker -
             # maybe there are counter examples
 
-            if self.value != None and other.value != None:
+            if self.value is not None and other.value is not None:
 
                 if self.datatype in (_RDF_XMLLITERAL, _RDF_HTMLLITERAL):
                     return _isEqualXMLNode(self.value, other.value)
@@ -1550,7 +1550,7 @@ def bind(datatype, pythontype, constructor=None, lexicalizer=None):
         logger.warning("datatype '%s' was already bound. Rebinding." %
                        datatype)
 
-    if constructor == None:
+    if constructor is None:
         constructor = pythontype
     _toPythonMapping[datatype] = constructor
     _PythonToXSD.append((pythontype, (lexicalizer, datatype)))


### PR DESCRIPTION
Using `is` and `is not` instead of `==` and `!=` for `None` comparisons - https://realpython.com/python-is-identity-vs-equality/

I think normally we don't want to use the `==` and `!=`? Not sure if it will pass Travis checks.