### PR TITLE
Add requirement for requests to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 from setuptools import setup, find_packages
 
 kwargs = {}
-kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing']
+kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing', 'requests']
 kwargs['tests_require'] = ['html5lib', 'networkx']
 kwargs['test_suite'] = "nose.collector"
 kwargs['extras_require'] = {'html': ['html5lib']}

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import re
 from setuptools import setup, find_packages
 
 kwargs = {}
-kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing', 'requests']
+kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing']
 kwargs['tests_require'] = ['html5lib', 'networkx']
 kwargs['test_suite'] = "nose.collector"
-kwargs['extras_require'] = {'html': ['html5lib']}
+kwargs['extras_require'] = {'html': ['html5lib'], 'sparql': ['requests']}
 
 def find_version(filename):
     _version_re = re.compile(r'__version__ = "(.*)"')


### PR DESCRIPTION
The requests package is required by the sparql plugin at several places.

The current issue is reproducible with:

In a new virtualenv

```
$ pip install git+https://github.com/RDFLib/rdflib@master
$ python3
>>> import rdflib
>>> graph = rdflib.Graph()
>>> graph.query("select * {?s ?p ?o}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/natanael/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/graph.py", line 1073, in query
    result = plugin.get(result, query.Result)
  File "/home/natanael/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/plugin.py", line 107, in get
    return p.getClass()
  File "/home/me/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/plugin.py", line 69, in getClass
    module = __import__(self.module_path, globals(), locals(), [""])
  File "/home/me/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/plugins/sparql/__init__.py", line 37, in <module>
    from .processor import prepareQuery, processUpdate
  File "/home/me/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/plugins/sparql/processor.py", line 18, in <module>
    from rdflib.plugins.sparql.evaluate import evalQuery
  File "/home/me/.virtualenvs/rdflib-try/lib/python3.7/site-packages/rdflib/plugins/sparql/evaluate.py", line 20, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
>>>
```