### PR TITLE
Allows RDF terms introduced by JSON-LD 1.1

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -220,7 +220,10 @@ class _RDFNamespace(ClosedNamespace):
                 "nil",
 
                 # Added in RDF 1.1
-                "XMLLiteral", "HTML", "langString"]
+                "XMLLiteral", "HTML", "langString",
+            
+                # Added in JSON-LD 1.1
+                "JSON", "CompoundLiteral", "language", "direction"]
         )
 
     def term(self, name):


### PR DESCRIPTION
[JSON-LD 1.1 introduces some RDF terms](https://www.w3.org/TR/json-ld11/#relationship-to-rdf), some of them being in a "work in progress" state.

It might still be convenient to allow them to be used with the `RDF.*` syntax now.