### PR TITLE
Register additional serializer plugins for SPARQL mime types.

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -271,13 +271,22 @@ register(
     'xml', ResultSerializer,
     'rdflib.plugins.sparql.results.xmlresults', 'XMLResultSerializer')
 register(
+    'application/sparql-results+xml', ResultSerializer,
+    'rdflib.plugins.sparql.results.xmlresults', 'XMLResultSerializer')
+register(
     'txt', ResultSerializer,
     'rdflib.plugins.sparql.results.txtresults', 'TXTResultSerializer')
 register(
     'json', ResultSerializer,
     'rdflib.plugins.sparql.results.jsonresults', 'JSONResultSerializer')
 register(
+    'application/sparql-results+json', ResultSerializer,
+    'rdflib.plugins.sparql.results.jsonresults', 'JSONResultSerializer')
+register(
     'csv', ResultSerializer,
+    'rdflib.plugins.sparql.results.csvresults', 'CSVResultSerializer')
+register(
+    'text/csv', ResultSerializer,
     'rdflib.plugins.sparql.results.csvresults', 'CSVResultSerializer')
 
 register(


### PR DESCRIPTION
This mirrors the similar parser registrations below in the same file.
With this commit, an Accept header can be used directly to serialize a
response, making putting up a SPARQL compatible endpoint trivial.