### PR TITLE
CONSTRUCT resolve with initBindings fixes #1001

### DIFF
--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -173,7 +173,10 @@ class FrozenBindings(FrozenDict):
         if not type(key) in (BNode, Variable):
             return key
 
-        return self._d[key]
+        if key not in self._d:
+            return self.ctx.initBindings[key]
+        else:
+            return self._d[key]
 
     def project(self, vars):
         return FrozenBindings(

--- a/test/test_sparql_construct_bindings.py
+++ b/test/test_sparql_construct_bindings.py
@@ -3,6 +3,7 @@ from rdflib.plugins.sparql import prepareQuery
 from rdflib.compare import isomorphic
 
 import unittest
+from nose.tools import eq_
 
 class TestConstructInitBindings(unittest.TestCase):
 
@@ -36,4 +37,4 @@ class TestConstructInitBindings(unittest.TestCase):
           'c': Literal('C')
         })
 
-        self.assertCountEqual(list(results), expected)
+        eq_(sorted(results, key=lambda x: str(x[1])), expected)

--- a/test/test_sparql_construct_bindings.py
+++ b/test/test_sparql_construct_bindings.py
@@ -1,0 +1,39 @@
+from rdflib import Graph, URIRef, Literal, BNode
+from rdflib.plugins.sparql import prepareQuery
+from rdflib.compare import isomorphic
+
+import unittest
+
+class TestConstructInitBindings(unittest.TestCase):
+
+    def test_construct_init_bindings(self):
+        """
+        This is issue https://github.com/RDFLib/rdflib/issues/1001
+        """
+
+        g1 = Graph()
+        
+        q_str = ("""
+        PREFIX : <urn:ns1:>
+        CONSTRUCT {
+          ?uri :prop1 ?val1;
+               :prop2 ?c .
+        }
+        WHERE {
+          bind(uri(concat("urn:ns1:", ?a)) as ?uri)
+          bind(?b as ?val1)
+        }
+        """)
+        q_prepared = prepareQuery(q_str)
+
+        expected = [
+            (URIRef('urn:ns1:A'),URIRef('urn:ns1:prop1'), Literal('B')),
+            (URIRef('urn:ns1:A'),URIRef('urn:ns1:prop2'), Literal('C'))
+        ]
+        results = g1.query(q_prepared, initBindings={
+          'a': Literal('A'),
+          'b': Literal('B'),
+          'c': Literal('C')
+        })
+
+        self.assertCountEqual(list(results), expected)


### PR DESCRIPTION
Addresses https://github.com/RDFLib/rdflib/issues/1001 by defaulting to initBindings from the context during template substitution.