### PR TITLE
fixing non recognition of @base declaration when parsing turtle files

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -1187,7 +1187,7 @@ class SinkParser:
                     if pfx == "_":  # Magic prefix 2001/05/30, can be changed
                         res.append(self.anonymousNode(ln))
                         return j
-                    if not self.turtle and pfx == "":
+                    if pfx == "":
                         ns = join(self._baseURI or "", "#")
                     else:
                         self.BadSyntax(argstr, i,

--- a/test/test_turtle_base.py
+++ b/test/test_turtle_base.py
@@ -1,0 +1,108 @@
+import os
+from rdflib.graph import Graph
+from rdflib.term import URIRef
+
+turtle = """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@base <http://example.org/schemas/vehicles>.
+
+:MotorVehicle a rdfs:Class.
+
+:PassengerVehicle a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+
+:Truck a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+    
+:Van a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+
+:MiniVan a rdfs:Class;
+   rdfs:subClassOf :Van;
+   rdfs:subClassOf :PassengerVehicle.
+
+:Person a rdfs:Class.
+
+xsd:integer a rdfs:Datatype.
+
+:registeredTo a rdf:Property;
+   rdfs:domain :MotorVehicle;
+   rdfs:range  :Person.
+    
+:rearSeatLegRoom a rdf:Property;
+   rdfs:domain :MotorVehicle;
+   rdfs:range xsd:integer.
+
+:driver a rdf:Property;
+   rdfs:domain :MotorVehicle.
+
+:primaryDriver a rdf:Property;
+   rdfs:subPropertyOf :driver.
+"""
+
+turtle_without_base = """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+:MotorVehicle a rdfs:Class.
+
+:PassengerVehicle a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+
+:Truck a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+    
+:Van a rdfs:Class;
+   rdfs:subClassOf :MotorVehicle.
+
+:MiniVan a rdfs:Class;
+   rdfs:subClassOf :Van;
+   rdfs:subClassOf :PassengerVehicle.
+
+:Person a rdfs:Class.
+
+xsd:integer a rdfs:Datatype.
+
+:registeredTo a rdf:Property;
+   rdfs:domain :MotorVehicle;
+   rdfs:range  :Person.
+    
+:rearSeatLegRoom a rdf:Property;
+   rdfs:domain :MotorVehicle;
+   rdfs:range xsd:integer.
+
+:driver a rdf:Property;
+   rdfs:domain :MotorVehicle.
+
+:primaryDriver a rdf:Property;
+   rdfs:subPropertyOf :driver.
+"""
+
+
+def test_base():
+    """Test parsing turtle file with @base"""
+    g = Graph()
+    g.parse(data=turtle, format='turtle')
+    print(len(g))
+    target_predicate = URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+    target_object = URIRef("http://www.w3.org/2000/01/rdf-schema#Class")
+    subjects = list(g.subjects(predicate=target_predicate, object=target_object))
+    assert len(subjects)
+    for subject in subjects:
+        assert "http://example.org/schemas/vehicles" in subject.toPython()
+
+
+def test_without_base():
+    """Test parsing turtle file without @base"""
+    g = Graph()
+    g.parse(data=turtle_without_base, format='turtle')
+    print(len(g))
+    target_predicate = URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+    target_object = URIRef("http://www.w3.org/2000/01/rdf-schema#Class")
+    subjects = list(g.subjects(predicate=target_predicate, object=target_object))
+    assert len(subjects)
+    current_dir = os.getcwd()
+    for subject in subjects:
+        assert current_dir in subject.toPython()
+    


### PR DESCRIPTION
Hi,

When attempting to import some example turtle [file](https://www.w3.org/2007/02/turtle/primer/#example19) with RDFLib, the following code

`from rdflib import Graph`
` `
`g = Graph()`
`g.parse("test.ttl", format="turtle")`

returns a BadSyntax exception, because it does not take into account of the following line of the test.ttl file:

`@base <http://example.org/schemas/vehicles>`

After digging into the matter, it seems that the bug originates from the Turtle/Notation3 parser, more especially rdflib/plugins/parsers/notation3.py, line 1186, in uri_ref2.

I created some test file to reproduce the bug, and then fixed it by the present pull request.

My correction does not seem to break existing nose tests.

Please consider my pull request to mitigate said issue