### PR TITLE
Set update endpoint similar to query endpoint for sparqlstore if only one is given

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -493,8 +493,8 @@ class SPARQLUpdateStore(SPARQLStore):
     def open(self, configuration, create=False):
         """
         sets the endpoint URLs for this SPARQLStore
-        :param configuration: either a tuple of (queryEndpoint, update_endpoint),
-            or a string with the query endpoint
+        :param configuration: either a tuple of (query_endpoint, update_endpoint),
+            or a string with the endpoint which is configured as query and update endpoint
         :param create: if True an exception is thrown.
         """
 
@@ -507,9 +507,7 @@ class SPARQLUpdateStore(SPARQLStore):
                 self.update_endpoint = configuration[1]
         else:
             self.query_endpoint = configuration
-
-        if not self.update_endpoint:
-            self.update_endpoint = self.endpoint
+            self.update_endpoint = configuration
 
     def _transaction(self):
         if self._edits is None:


### PR DESCRIPTION
If only one endpoint is specified when a `SPARQLUpdateStore` is configured, the same endpoint should be used for query and update. The `self.endpoint` which was the fallback seems not to be set anywhere.