### PR TITLE
Add requests to the tests_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 kwargs = {}
 kwargs['install_requires'] = [ 'six', 'isodate', 'pyparsing']
-kwargs['tests_require'] = ['html5lib', 'networkx', 'nose', 'doctest-ignore-unicode']
+kwargs['tests_require'] = ['html5lib', 'networkx', 'nose', 'doctest-ignore-unicode', 'requests']
 kwargs['test_suite'] = "nose.collector"
 kwargs['extras_require'] = {
     'html': ['html5lib'],


### PR DESCRIPTION
I have introduced a test dependency for `requests` in 0986737fc8170d3cd3a7c95d078fa8f689267355 to test the sparqlstore in relation with pull-request #1022.
I forgot to add it to the tests_requirements.

Fix #1035.