### PR TITLE
Add SERVICE clause to documentation

### DIFF
--- a/docs/intro_to_sparql.rst
+++ b/docs/intro_to_sparql.rst
@@ -71,6 +71,35 @@ Variables can also be pre-bound, using ``initBindings`` kwarg can be
 used to pass in a ``dict`` of initial bindings, this is particularly
 useful for prepared queries, as described below.
 
+Query a Remote Service
+^^^^^^^^^^^^^^^^^^^^^^
+
+The SERVICE keyword of SPARQL 1.1 can send a query to a remote SPARQL endpoint.
+
+.. code-block:: python
+
+    import rdflib
+
+    g = rdflib.Graph()
+    qres = g.query('''
+    SELECT ?s
+    WHERE {
+      SERVICE <http://dbpedia.org/sparql> {
+        ?s <http://purl.org/linguistics/gold/hypernym> <http://dbpedia.org/resource/Leveller> .
+      }
+    } LIMIT 3''')
+    for row in qres:
+        print(row.s)
+
+This example sends a query to `DBPedia
+<https://dbpedia.org/>`_'s SPARQL endpoint service so that it can run the query and then send back the result:
+
+.. code-block:: text
+
+    http://dbpedia.org/resource/Elizabeth_Lilburne
+    http://dbpedia.org/resource/Thomas_Prince_(Leveller)
+    http://dbpedia.org/resource/John_Lilburne
+
 Prepared Queries
 ^^^^^^^^^^^^^^^^
 

--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -277,7 +277,7 @@ def evalPart(ctx, part):
 def evalServiceQuery(ctx, part):
     res = {}
     match = re.match('^service <(.*)>[ \n]*{(.*)}[ \n]*$',
-                     part.get('service_string', ''), re.DOTALL)
+                     part.get('service_string', ''), re.DOTALL | re.I)
 
     if match:
         service_url = match.group(1)

--- a/test/test_sparql_service.py
+++ b/test/test_sparql_service.py
@@ -99,6 +99,7 @@ def test_service_with_implicit_select_and_prefix():
     for r in results:
         assert len(r) == 3
 
+
 def test_service_with_implicit_select_and_base():
     g = Graph()
     q = '''base <http://example.org/>
@@ -114,6 +115,20 @@ def test_service_with_implicit_select_and_base():
 
     for r in results:
         assert len(r) == 3
+
+
+def test_service_with_implicit_select_and_allcaps():
+    g = Graph()
+    q = '''SELECT ?s
+    WHERE
+    {
+      SERVICE <http://dbpedia.org/sparql>
+      {
+        ?s <http://purl.org/linguistics/gold/hypernym> <http://dbpedia.org/resource/Leveller> .
+      }
+    } LIMIT 3'''
+    results = g.query(q)
+    assert len(results) == 3
 
 
 #def test_with_fixture(httpserver):


### PR DESCRIPTION
Address #996.

Also, make it so a user can put "SERVICE" (all caps) in a SPARQL query by adding a `re.I` flag to the matcher in `evalServiceQuery`. The all-caps style is used in the example added to the documentation.

Thank you for labeling #996 as a good first issue! Let me know how I can improve this PR / if it satisfies guidelines for contribution, etc.