### PR TITLE
Autodetect parse() format

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -10,6 +10,7 @@ assert Literal  # avoid warning
 from rdflib.namespace import Namespace  # required for doctests
 
 assert Namespace  # avoid warning
+import rdflib.util  # avoid circular dependency
 
 
 __doc__ = """\
@@ -1075,12 +1076,12 @@ class Graph(Node):
         assumed_xml = False
         if format is None:
             try:
-                from rdflib.util import guess_format  # local import avoids circular dependency
-                format = guess_format(source.file.name)
-            finally:
-                if format is None:
-                    format = "application/rdf+xml"
-                    assumed_xml = True
+                format = rdflib.util.guess_format(source.file.name)
+            except (AttributeError, TypeError):
+                pass
+            if format is None:
+                format = "application/rdf+xml"
+                assumed_xml = True
         parser = plugin.get(format, Parser)()
         try:
             parser.parse(source, self, **args)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1072,10 +1072,10 @@ class Graph(Node):
             format = source.content_type
         assumed_xml = False
         if format is None:
-            try:
+            if (hasattr(source, "file")
+                    and getattr(source.file, "name", None)
+                    and isinstance(source.file.name, str)):
                 format = rdflib.util.guess_format(source.file.name)
-            except (AttributeError, TypeError):
-                pass
             if format is None:
                 format = "application/rdf+xml"
                 assumed_xml = True

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1071,9 +1071,12 @@ class Graph(Node):
         if format is None:
             format = source.content_type
         if format is None:
-            # raise Exception("Could not determine format for %r. You can" + \
-            # "expicitly specify one with the format argument." % source)
-            format = "application/rdf+xml"
+            try:
+                from rdflib.util import guess_format  # local import avoids circular dependency
+                format = guess_format(source.file.name)
+            finally:
+                if format is None:
+                    format = "application/rdf+xml"
         parser = plugin.get(format, Parser)()
         try:
             parser.parse(source, self, **args)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1090,7 +1090,7 @@ class Graph(Node):
                 logger.warning(
                     "Could not guess format for %r, so assumed xml."
                     " You can explicitly specify format using the format argument." % source)
-                raise saxpe
+            raise saxpe
         finally:
             if source.auto_close:
                 source.close()

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -46,8 +46,7 @@ from rdflib.exceptions import ContextTypeError
 from rdflib.exceptions import ObjectTypeError
 from rdflib.exceptions import PredicateTypeError
 from rdflib.exceptions import SubjectTypeError
-from rdflib.graph import Graph
-from rdflib.graph import QuotedGraph
+import rdflib.graph as graph  # avoid circular dependency
 from rdflib.namespace import Namespace
 from rdflib.namespace import NamespaceManager
 from rdflib.term import BNode
@@ -146,7 +145,7 @@ def from_n3(s, default=None, backend=None, nsm=None):
         >>> from rdflib import RDFS
         >>> from_n3('rdfs:label') == RDFS['label']
         True
-        >>> nsm = NamespaceManager(Graph())
+        >>> nsm = NamespaceManager(graph.Graph())
         >>> nsm.bind('dbpedia', 'http://dbpedia.org/resource/')
         >>> berlin = URIRef('http://dbpedia.org/resource/Berlin')
         >>> from_n3('dbpedia:Berlin', nsm=nsm) == berlin
@@ -192,16 +191,16 @@ def from_n3(s, default=None, backend=None, nsm=None):
         return Literal(int(s))
     elif s.startswith('{'):
         identifier = from_n3(s[1:-1])
-        return QuotedGraph(backend, identifier)
+        return graph.QuotedGraph(backend, identifier)
     elif s.startswith('['):
         identifier = from_n3(s[1:-1])
-        return Graph(backend, identifier)
+        return graph.Graph(backend, identifier)
     elif s.startswith("_:"):
         return BNode(s[2:])
     elif ':' in s:
         if nsm is None:
             # instantiate default NamespaceManager and rely on its defaults
-            nsm = NamespaceManager(Graph())
+            nsm = NamespaceManager(graph.Graph())
         prefix, last_part = s.split(':', 1)
         ns = dict(nsm.namespaces())[prefix]
         return Namespace(ns)[last_part]

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -46,7 +46,7 @@ from rdflib.exceptions import ContextTypeError
 from rdflib.exceptions import ObjectTypeError
 from rdflib.exceptions import PredicateTypeError
 from rdflib.exceptions import SubjectTypeError
-import rdflib.graph as graph  # avoid circular dependency
+import rdflib.graph  # avoid circular dependency
 from rdflib.namespace import Namespace
 from rdflib.namespace import NamespaceManager
 from rdflib.term import BNode
@@ -145,7 +145,7 @@ def from_n3(s, default=None, backend=None, nsm=None):
         >>> from rdflib import RDFS
         >>> from_n3('rdfs:label') == RDFS['label']
         True
-        >>> nsm = NamespaceManager(graph.Graph())
+        >>> nsm = NamespaceManager(rdflib.graph.Graph())
         >>> nsm.bind('dbpedia', 'http://dbpedia.org/resource/')
         >>> berlin = URIRef('http://dbpedia.org/resource/Berlin')
         >>> from_n3('dbpedia:Berlin', nsm=nsm) == berlin
@@ -191,16 +191,16 @@ def from_n3(s, default=None, backend=None, nsm=None):
         return Literal(int(s))
     elif s.startswith('{'):
         identifier = from_n3(s[1:-1])
-        return graph.QuotedGraph(backend, identifier)
+        return rdflib.graph.QuotedGraph(backend, identifier)
     elif s.startswith('['):
         identifier = from_n3(s[1:-1])
-        return graph.Graph(backend, identifier)
+        return rdflib.graph.Graph(backend, identifier)
     elif s.startswith("_:"):
         return BNode(s[2:])
     elif ':' in s:
         if nsm is None:
             # instantiate default NamespaceManager and rely on its defaults
-            nsm = NamespaceManager(graph.Graph())
+            nsm = NamespaceManager(rdflib.graph.Graph())
         prefix, last_part = s.split(':', 1)
         ns = dict(nsm.namespaces())[prefix]
         return Namespace(ns)[last_part]

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -1,6 +1,11 @@
 import unittest
+from pathlib import Path
+from shutil import copyfile
+from tempfile import TemporaryDirectory
 
-from rdflib import Graph
+from xml.sax import SAXParseException
+
+from rdflib import Graph, logger as graph_logger
 
 
 class FileParserGuessFormatTest(unittest.TestCase):
@@ -11,6 +16,16 @@ class FileParserGuessFormatTest(unittest.TestCase):
     def test_n3(self):
         g = Graph()
         self.assertIsInstance(g.parse("test/n3/example-lots_of_graphs.n3"), Graph)
+
+    def test_warning(self):
+        g = Graph()
+        with TemporaryDirectory() as tmpdirname:
+            newpath = Path(tmpdirname).joinpath("no_file_ext")
+            copyfile("test/w3c/turtle/IRI_subject.ttl", newpath)
+            with self.assertLogs(graph_logger, "WARNING") as log_cm:
+                with self.assertRaises(SAXParseException):
+                    g.parse(str(newpath))
+            self.assertTrue(any("Could not guess format" in msg for msg in log_cm.output))
 
 
 if __name__ == '__main__':

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -1,0 +1,17 @@
+import unittest
+
+from rdflib import Graph
+
+
+class FileParserGuessFormatTest(unittest.TestCase):
+    def test_ttl(self):
+        g = Graph()
+        self.assertIsInstance(g.parse("test/w3c/turtle/IRI_subject.ttl"), Graph)
+
+    def test_n3(self):
+        g = Graph()
+        self.assertIsInstance(g.parse("test/n3/example-lots_of_graphs.n3"), Graph)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -21,7 +21,7 @@ class FileParserGuessFormatTest(unittest.TestCase):
         g = Graph()
         with TemporaryDirectory() as tmpdirname:
             newpath = Path(tmpdirname).joinpath("no_file_ext")
-            copyfile("test/w3c/turtle/IRI_subject.ttl", newpath)
+            copyfile("test/w3c/turtle/IRI_subject.ttl", str(newpath))
             with self.assertLogs(graph_logger, "WARNING") as log_cm:
                 with self.assertRaises(SAXParseException):
                     g.parse(str(newpath))


### PR DESCRIPTION
Addresses #981

* Use `rdflib.util.guess_format` to guess and try to apply format based on file extension
* Log warning if assumed XML(not guessed from file extension) and cannot parse
* Add tests

Close #981