### PR TITLE
Fix for issue #629 - Arithmetic Operations of DateTime in SPARQL

### DIFF
--- a/rdflib/plugins/sparql/datatypes.py
+++ b/rdflib/plugins/sparql/datatypes.py
@@ -11,6 +11,16 @@ XSD_DTs = set(
      XSD.unsignedLong, XSD.unsignedInt, XSD.unsignedShort, XSD.unsignedByte,
      XSD.positiveInteger, XSD.date))
 
+### adding dateTime datatypes
+
+XSD_DateTime_DTs = set(
+    (XSD.dateTime, XSD.date, XSD.time)
+)
+
+XSD_Duration_DTs = set(
+    (XSD.duration, XSD.dayTimeDuration, XSD.yearMonthDuration)
+)
+
 _sub_types = {
     XSD.integer: [
         XSD.nonPositiveInteger, XSD.negativeInteger, XSD.long, XSD.int,

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -765,45 +765,46 @@ def AdditiveExpression(e, ctx):
 
     # handling arithmetic(addition/subtraction) of dateTime, date, time
     # and duration datatypes (if any)
-    if(expr.datatype in XSD_DateTime_DTs or expr.datatype in XSD_Duration_DTs):
+    if hasattr(expr, 'datatype'):
+        if(expr.datatype in XSD_DateTime_DTs or expr.datatype in XSD_Duration_DTs):
 
-        res = dateTimeObjects(expr)
-        dt = expr.datatype
+            res = dateTimeObjects(expr)
+            dt = expr.datatype
 
-        for op, term in zip(e.op, other):
+            for op, term in zip(e.op, other):
 
-            # check if operation is datetime,date,time operation over
-            # another datetime,date,time datatype
-            if dt in XSD_DateTime_DTs and dt == term.datatype and op == '-':
-                # checking if there are more than one datetime operands -
-                # in that case it doesn't make sense for example
-                # ( dateTime1 - dateTime2 - dateTime3 ) is an invalid operation
-                if len(other) > 1:
-                    error_message = "Can't evaluate multiple %r arguments"
-                    raise SPARQLError(error_message, dt.datatype)
-                else:
-                    n = dateTimeObjects(term)
-                    res = calculateDuration(res, n)
-                    return res
+                # check if operation is datetime,date,time operation over
+                # another datetime,date,time datatype
+                if dt in XSD_DateTime_DTs and dt == term.datatype and op == '-':
+                    # checking if there are more than one datetime operands -
+                    # in that case it doesn't make sense for example
+                    # ( dateTime1 - dateTime2 - dateTime3 ) is an invalid operation
+                    if len(other) > 1:
+                        error_message = "Can't evaluate multiple %r arguments"
+                        raise SPARQLError(error_message, dt.datatype)
+                    else:
+                        n = dateTimeObjects(term)
+                        res = calculateDuration(res, n)
+                        return res
 
-            # datetime,date,time +/- duration,dayTimeDuration,yearMonthDuration
-            elif (dt in XSD_DateTime_DTs and term.datatype in XSD_Duration_DTs):
-                n = dateTimeObjects(term)
-                res = calculateFinalDateTime(res, dt, n, term.datatype, op)
-                return res
-
-            # duration,dayTimeDuration,yearMonthDuration + datetime,date,time
-            elif dt in XSD_Duration_DTs and term.datatype in XSD_DateTime_DTs:
-                if op == "+":
+                # datetime,date,time +/- duration,dayTimeDuration,yearMonthDuration
+                elif (dt in XSD_DateTime_DTs and term.datatype in XSD_Duration_DTs):
                     n = dateTimeObjects(term)
                     res = calculateFinalDateTime(res, dt, n, term.datatype, op)
                     return res
 
-            # rest are invalid types
-            else:
-                raise SPARQLError('Invalid DateTime Operations')
+                # duration,dayTimeDuration,yearMonthDuration + datetime,date,time
+                elif dt in XSD_Duration_DTs and term.datatype in XSD_DateTime_DTs:
+                    if op == "+":
+                        n = dateTimeObjects(term)
+                        res = calculateFinalDateTime(res, dt, n, term.datatype, op)
+                        return res
 
-    # handling arithmetic(addition/subtraction) of numeric datatypes (if any)
+                # rest are invalid types
+                else:
+                    raise SPARQLError('Invalid DateTime Operations')
+
+        # handling arithmetic(addition/subtraction) of numeric datatypes (if any)
     else:
         res = numeric(expr)
 

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -23,6 +23,7 @@ import isodate
 
 from rdflib.plugins.sparql.parserutils import CompValue, Expr
 from rdflib.plugins.sparql.datatypes import XSD_DTs, type_promotion
+from rdflib.plugins.sparql.datatypes import XSD_DateTime_DTs, XSD_Duration_DTs
 from rdflib import URIRef, BNode, Variable, Literal, XSD, RDF
 from rdflib.term import Node
 from six import text_type
@@ -762,25 +763,67 @@ def AdditiveExpression(e, ctx):
     if other is None:
         return expr
 
-    res = numeric(expr)
+    # handling arithmetic(addition/subtraction) of dateTime, date, time
+    # and duration datatypes (if any)
+    if(expr.datatype in XSD_DateTime_DTs or expr.datatype in XSD_Duration_DTs):
 
-    dt = expr.datatype
+        res = dateTimeObjects(expr)
+        dt = expr.datatype
 
-    for op, term in zip(e.op, other):
-        n = numeric(term)
-        if isinstance(n, Decimal) and isinstance(res, float):
-            n = float(n)
-        if isinstance(n, float) and isinstance(res, Decimal):
-            res = float(res)
+        for op, term in zip(e.op, other):
 
-        dt = type_promotion(dt, term.datatype)
+            # check if operation is datetime,date,time operation over
+            # another datetime,date,time datatype
+            if dt in XSD_DateTime_DTs and dt == term.datatype and op == '-':
+                # checking if there are more than one datetime operands -
+                # in that case it doesn't make sense for example
+                # ( dateTime1 - dateTime2 - dateTime3 ) is an invalid operation
+                if len(other) > 1:
+                    error_message = "Can't evaluate multiple %r arguments"
+                    raise SPARQLError(error_message, dt.datatype)
+                else:
+                    n = dateTimeObjects(term)
+                    res = calculateDuration(res, n)
+                    return res
 
-        if op == '+':
-            res += n
-        else:
-            res -= n
+            # datetime,date,time +/- duration,dayTimeDuration,yearMonthDuration
+            elif (dt in XSD_DateTime_DTs and term.datatype in XSD_Duration_DTs):
+                n = dateTimeObjects(term)
+                res = calculateFinalDateTime(res, dt, n, term.datatype, op)
+                return res
 
-    return Literal(res, datatype=dt)
+            # duration,dayTimeDuration,yearMonthDuration + datetime,date,time
+            elif dt in XSD_Duration_DTs and term.datatype in XSD_DateTime_DTs:
+                if op == "+":
+                    n = dateTimeObjects(term)
+                    res = calculateFinalDateTime(res, dt, n, term.datatype, op)
+                    return res
+
+            # rest are invalid types
+            else:
+                raise SPARQLError('Invalid DateTime Operations')
+
+    # handling arithmetic(addition/subtraction) of numeric datatypes (if any)
+    else:
+        res = numeric(expr)
+
+        dt = expr.datatype
+
+        for op, term in zip(e.op, other):
+            n = numeric(term)
+            if isinstance(n, Decimal) and isinstance(res, float):
+                n = float(n)
+            if isinstance(n, float) and isinstance(res, Decimal):
+                res = float(res)
+
+            dt = type_promotion(dt, term.datatype)
+
+            if op == '+':
+                res += n
+            else:
+                res -= n
+
+        return Literal(res, datatype=dt)
 
 
 def RelationalExpression(e, ctx):
@@ -980,6 +1023,79 @@ def numeric(expr):
         raise SPARQLTypeError("%r does not have a numeric datatype!" % expr)
 
     return expr.toPython()
+
+
+def dateTimeObjects(expr):
+    """
+    return a dataTime/date/time/duration/dayTimeDuration/yearMonthDuration python objects from a literal
+
+    """
+    return expr.toPython()
+
+
+def isCompatibleDateTimeDatatype(obj1, dt1, obj2, dt2):
+    """
+    returns a boolean indicating if first object is compatible
+    with operation(+/-) over second object.
+
+    """
+    if(dt1 == XSD.date):
+        if(dt2 == XSD.yearMonthDuration):
+            return True
+        elif(dt2 == XSD.dayTimeDuration or dt2 == XSD.Duration):
+            # checking if the dayTimeDuration has no Time Component
+            # else it wont be compatible with Date Literal
+            if("T" in str(obj2)):
+                return False
+            else:
+                return True
+
+    if(dt1 == XSD.time):
+        if(dt2 == XSD.yearMonthDuration):
+            return False
+        elif(dt2 == XSD.dayTimeDuration or dt2 == XSD.Duration):
+            # checking if the dayTimeDuration has no Date Component
+            # (by checking if the format is "PT...." )
+            # else it wont be compatible with Time Literal
+            if("T" == str(obj2)[1]):
+                return True
+            else:
+                return False
+
+    if(dt1 == XSD.dateTime):
+        # compatible with all
+        return True
+
+
+def calculateDuration(obj1, obj2):
+    """
+        returns the duration Literal between two datetime
+
+    """
+    date1 = obj1
+    date2 = obj2
+    difference = date1 - date2
+    return Literal(difference, datatype=XSD.duration)
+
+
+def calculateFinalDateTime(obj1, dt1, obj2, dt2, operation):
+    """
+        Calculates the final dateTime/date/time resultant after addition/
+        subtraction of duration/dayTimeDuration/yearMonthDuration
+    """
+
+    # checking compatibility of datatypes (duration types and date/time/dateTime)
+    if(isCompatibleDateTimeDatatype(obj1, dt1, obj2, dt2)):
+        # proceed
+        if(operation == "-"):
+            ans = obj1 - obj2
+            return Literal(ans, datatype=dt1)
+        else:
+            ans = obj1 + obj2
+            return Literal(ans, datatype=dt1)
+
+    else:
+        raise SPARQLError('Incompatible Data types to DateTime Operations')
 
 
 def EBV(rt):

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -765,8 +765,7 @@ def AdditiveExpression(e, ctx):
 
     # handling arithmetic(addition/subtraction) of dateTime, date, time
     # and duration datatypes (if any)
-    if hasattr(expr, 'datatype'):
-        if(expr.datatype in XSD_DateTime_DTs or expr.datatype in XSD_Duration_DTs):
+    if hasattr(expr, 'datatype') and (expr.datatype in XSD_DateTime_DTs or expr.datatype in XSD_Duration_DTs):
 
             res = dateTimeObjects(expr)
             dt = expr.datatype

--- a/test/test_sparql_datetime.py
+++ b/test/test_sparql_datetime.py
@@ -1,0 +1,219 @@
+from rdflib import Graph, URIRef, Literal, BNode,XSD
+from rdflib.plugins.sparql import prepareQuery
+from rdflib.compare import isomorphic
+import rdflib
+from nose.tools import eq_
+from pprint import pprint
+import io
+
+def test_dateTime_dateTime_subs_issue():
+    """
+        Test for query mentioned in the Issue #629
+        https://github.com/RDFLib/rdflib/issues/629
+
+    """
+
+    data1 = """
+    @prefix : <#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+    :C a rdfs:Class.
+
+    :start a rdf:Property;
+        rdfs:domain :C; 
+        rdfs:range xsd:dateTime.
+
+    :end a rdf:Property;
+        rdfs:domain :C; 
+        rdfs:range xsd:dateTime.
+
+    :c1 a :C;
+        :start "2016-01-01T20:00:00"^^xsd:dateTime;
+        :end "2016-01-02T20:01:00"^^xsd:dateTime.
+
+    :c2 a :C;
+        :start "2016-01-01T20:05:00"^^xsd:dateTime;
+        :end "2016-01-01T20:30:00"^^xsd:dateTime.
+    """
+
+    graph1 = Graph()
+    f = io.StringIO(data1)
+    graph1.parse(f, format='n3')
+
+    result = graph1.query("""
+    SELECT ?c ?duration
+    WHERE {
+        ?c :start ?start;
+            :end ?end.
+        BIND(?end - ?start AS ?duration)
+    }
+    """)
+
+    answer=list(result)
+    answer=sorted(answer)
+    # expected result will be a list of 2 tuples
+    # FirstElement of these tuples will be a node with a path of directory of saved project 
+    # Second Element while represent the actual durations 
+
+    expectedFirstDuration=rdflib.term.Literal('P1DT1M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+    expectedSecondDuration=rdflib.term.Literal('PT25M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+
+
+    eq_(answer[0][1],expectedFirstDuration)
+    eq_(answer[1][1],expectedSecondDuration)
+
+
+def test_dateTime_duration_subs():
+    """
+        Test cases for subtraction operation between dateTime and duration 
+
+    """
+    data = """
+    @prefix : <#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+    """
+    graph = Graph()
+    f = io.StringIO(data)
+    graph.parse(f, format='n3')
+
+    ## 1st Test Case 
+
+    result1 = graph.query("""
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (?d - ?duration AS ?next_year)
+    WHERE {
+        VALUES (?duration ?d) {
+            ("P1Y"^^xsd:yearMonthDuration"2019-05-28T12:14:45Z"^^xsd:dateTime)
+            ("P1Y"^^xsd:yearMonthDuration"2019-05-28"^^xsd:date)
+        }
+    }
+    """)
+    expected=[]
+    expected.append(rdflib.term.Literal('2018-05-28T12:14:45+00:00', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTime')))
+    expected.append(rdflib.term.Literal('2018-05-28', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#date')))
+    
+    eq_(list(result1)[0][0],expected[0])
+    eq_(list(result1)[1][0],expected[1])
+
+    ## 2nd Test Case 
+
+    result2 = graph.query("""
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (?d - ?duration AS ?next_year)
+    WHERE {
+        VALUES (?duration ?d) {
+            ("P3DT1H15M"^^xsd:dayTimeDuration "2000-10-30T11:12:00"^^xsd:dateTime)
+		    ("P3DT1H15M"^^xsd:dayTimeDuration "2000-10-30"^^xsd:date)
+        }
+    }
+    """)
+
+    expected=[]
+    expected.append(rdflib.term.Literal('2000-10-27T09:57:00', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTime')))
+    expected.append(rdflib.term.Literal('2000-10-27', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#date')))
+    
+    eq_(list(result2)[0][0],expected[0])
+    eq_(list(result2)[1][0],expected[1])
+
+
+    
+def test_dateTime_duration_add():
+    """
+        Test cases for addition operation between dateTime and duration 
+
+    """
+    data = """
+    @prefix : <#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+    """
+    graph = Graph()
+    f = io.StringIO(data)
+    graph.parse(f, format='n3')
+
+    ## 1st Test case
+
+    result1 = graph.query("""
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (?d + ?duration AS ?next_year)
+    WHERE {
+        VALUES (?duration ?d) {
+            ("P1Y"^^xsd:yearMonthDuration"2019-05-28T12:14:45Z"^^xsd:dateTime)
+            ("P1Y"^^xsd:yearMonthDuration"2019-05-28"^^xsd:date)
+        }
+    }
+    """)
+
+    # print(list(result1))
+    expected=[]
+    expected.append(rdflib.term.Literal('2020-05-28T12:14:45+00:00', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTime')))
+    expected.append(rdflib.term.Literal('2020-05-28', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#date')))
+    
+    eq_(list(result1)[0][0],expected[0])
+    eq_(list(result1)[1][0],expected[1])
+
+    ## 2nd Test case
+
+    result2 = graph.query("""
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (?d + ?duration AS ?next_year)
+    WHERE {
+        VALUES (?duration ?d) {
+            ("P3DT1H15M"^^xsd:dayTimeDuration "2000-10-30T11:12:00"^^xsd:dateTime)
+            ("P3DT1H15M"^^xsd:dayTimeDuration "2000-10-30"^^xsd:date)
+        }
+    }
+    """)
+
+    # print(list(result2))
+    expected=[]
+    expected.append(rdflib.term.Literal('2000-11-02T12:27:00', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTime')))
+    expected.append(rdflib.term.Literal('2000-11-02', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#date')))
+    
+    eq_(list(result2)[0][0],expected[0])
+    eq_(list(result2)[1][0],expected[1])
+
+def test_dateTime_dateTime_subs():
+    """
+        Test cases for subtraction operation between dateTime and dateTime 
+
+    """
+    data = """
+    @prefix : <#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+    """
+
+    graph = Graph()
+    f = io.StringIO(data)
+    graph.parse(f, format='n3')
+
+    result1 = graph.query("""
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (?l - ?r AS ?duration)
+    WHERE {
+        VALUES (?l ?r) {
+            ("2000-10-30T06:12:00-05:00"^^xsd:dateTime "1999-11-28T09:00:00Z"^^xsd:dateTime)
+            ("2000-10-30"^^xsd:date"1999-11-28"^^xsd:date)
+        }
+    }
+    """)
+
+    expected1=rdflib.term.Literal('P337DT2H12M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+    expected2=rdflib.term.Literal('P337D', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+    
+    eq_(list(result1)[0][0],expected1)
+    eq_(list(result1)[1][0],expected2)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.main(defaultTest=__name__)
+
+    


### PR DESCRIPTION
Added the functionality for performing arithmetic operations of DateTime/Date/Time in SPARQL Queries.

This will fix the issue of #629 which requires handling of the arithmetic operation of `dateTime` variables in the SPARQL query. This fix also extends this operation handling to other similar Date, Time, Duration based variables. These operations are  also discussed in official w3c Sparql work - (https://github.com/w3c/sparql-12/blob/master/SEP/SEP-0002/sep-0002.md) 

This is the list of handled operations : 
```
- xsd:dateTime - xsd:dateTime
- xsd:date - xsd:date
- xsd:time - xsd:time
- xsd:dateTime - (xsd:dayTimeDuration or xsd:yearMonthDuration or xsd:duration)
- xsd:dateTime + (xsd:dayTimeDuration or xsd:yearMonthDuration or xsd:duration)
- xsd:date - (xsd:dayTimeDuration or xsd:yearMonthDuration or xsd:duration)
- xsd:date + (xsd:dayTimeDuration or xsd:yearMonthDuration or xsd:duration)
- xsd:time - (xsd:dayTimeDuration or xsd:duration)
- xsd:time + (xsd:dayTimeDuration or xsd:duration)
```
In this PR, I have added the code to handle these operations in SPARQL queries. I have also added tests for the same operations. (Some test cases were also taken from (https://github.com/kasei/sparql-12/tree/xsd_datetime_duration/tests/xsd_functions)).

Closes #629


