### PR TITLE
issue_771_add_key_error_if_spaces

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -708,8 +708,9 @@ class NamespaceManager(object):
         # When documenting explain that override only applies in what cases
         if prefix is None:
             prefix = ""
-        if (len(prefix.split(" ")) > 1):
-            raise KeyError("\'" + prefix + "\' does not look like a valid prefix as it has spaces, change it into correct format")
+        elif " " in prefix:
+            raise KeyError("Prefixes may not contain spaces.")
+            
         bound_namespace = self.store.namespace(prefix)
         # Check if the bound_namespace contains a URI
         # and if so convert it into a URIRef for comparison

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -708,6 +708,8 @@ class NamespaceManager(object):
         # When documenting explain that override only applies in what cases
         if prefix is None:
             prefix = ""
+        if (len(prefix.split(" ")) > 1):
+            raise KeyError("\'" + prefix + "\' does not look like a valid prefix as it has spaces, change it into correct format")
         bound_namespace = self.store.namespace(prefix)
         # Check if the bound_namespace contains a URI
         # and if so convert it into a URIRef for comparison


### PR DESCRIPTION
Hello, 
Here is my contribution for issue #771 . I raise a key error if prefix have spaces in it. The changes are done is  /rdflib/NamespaceManger.bind.  Please let me know if error message need to be change or if we need to raise only warning instead of error message.