### PR TITLE
fixedIssue837

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -615,20 +615,45 @@ class Graph(Node):
         self.remove((subject, predicate, None))
         self.add((subject, predicate, object_))
 
-    def subjects(self, predicate=None, object=None):
+    def subjects(self, predicate=None, object=None, uniqueLimit =-1):
         """A generator of subjects with the given predicate and object"""
+        if (uniqueLimit != -1):
+            uniqueSub = dict()
         for s, p, o in self.triples((None, predicate, object)):
-            yield s
+            if(uniqueLimit==-1):
+                yield s
+            elif(len(uniqueSub)<uniqueLimit and s not in uniqueSub):
+                uniqueSub[s]=True
+                yield s
+            elif(s not in uniqueSub):
+                yield s
 
-    def predicates(self, subject=None, object=None):
+    def predicates(self, subject=None, object=None, uniqueLimit =-1):
         """A generator of predicates with the given subject and object"""
+        if (uniqueLimit != -1):
+            uniquePred = dict()
         for s, p, o in self.triples((subject, None, object)):
-            yield p
+            if(uniqueLimit==-1):
+                yield p
+            elif(len(uniquePred)<uniqueLimit and p not in uniquePred):
+                uniquePred[p]=True
+                yield p
+            elif(p not in uniquePred):
+                yield p
 
-    def objects(self, subject=None, predicate=None):
+    def objects(self, subject=None, predicate=None, uniqueLimit=-1):
         """A generator of objects with the given subject and predicate"""
+        if (uniqueLimit != -1):
+            uniqueObj = dict()
         for s, p, o in self.triples((subject, predicate, None)):
-            yield o
+            if(uniqueLimit==-1):
+                yield o
+            elif(len(uniqueObj)<uniqueLimit and o not in uniqueObj):
+                uniqueObj[o]=True
+                yield o
+            elif(o not in uniqueObj):
+                yield o
+
 
     def subject_predicates(self, object=None):
         """A generator of (subject, predicate) tuples for the given object"""

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -76,6 +76,56 @@ class GraphTestCase(unittest.TestCase):
         self.graph.remove((bob, hates, pizza))
         self.graph.remove((bob, hates, michel))  # gasp!
 
+
+    #Issue 837
+    def testSubjectsPredicatesObjects(self):
+        graph = self.graph
+        tarek = self.tarek
+        michel = self.michel
+        bob = self.bob
+        likes = self.likes
+        hates = self.hates
+        pizza = self.pizza
+        cheese = self.cheese
+
+        graph.add((tarek, likes, pizza))
+        graph.add((tarek, likes, cheese))
+        graph.add((tarek, hates, pizza))
+        graph.add((tarek, hates, cheese))
+
+        graph.add((michel, likes, pizza))
+        graph.add((michel, likes, cheese))
+        graph.add((michel, hates, pizza))
+        graph.add((michel, hates, cheese))
+        
+        graph.add((bob, likes, cheese))
+        graph.add((bob, likes, pizza))
+        graph.add((bob, hates, pizza))
+        graph.add((bob, hates, cheese))
+
+        self.assertEqual(len(list(self.graph.subjects())), 12)
+        self.assertEqual(len(list(self.graph.predicates())), 12)
+        self.assertEqual(len(list(self.graph.objects())), 12)
+
+        self.assertEqual(len(list(self.graph.subjects(uniqueLimit=0))), 12)
+        self.assertEqual(len(list(self.graph.predicates(uniqueLimit=0))), 12)
+        self.assertEqual(len(list(self.graph.objects(uniqueLimit=0))), 12)
+
+        self.assertEqual(len(list(self.graph.subjects(uniqueLimit=15))), 3)
+        self.assertEqual(len(list(self.graph.predicates(uniqueLimit=15))), 2)
+        self.assertEqual(len(list(self.graph.objects(uniqueLimit=15))), 2)
+
+        self.assertEqual(len(list(self.graph.subjects(uniqueLimit=1))), 9)
+        self.assertEqual(len(list(self.graph.subjects(uniqueLimit=2))), 6)
+        self.assertEqual(len(list(self.graph.predicates(uniqueLimit=1))), 7)
+        self.assertEqual(len(list(self.graph.objects(uniqueLimit=1))), 7)
+
+
+
+
+
+
+
     def testAdd(self):
         self.addStuff()
 


### PR DESCRIPTION
Fixed for #837 , made necessary changes in `subjects`, `predicates` and `objects` API.
For the memory issue, I introduced a variable `uniqueLimit`, this can be customised by the user in accordance with how much memory he can deal with. By default it is -1 i.e. no memory will be used and all values will be returned.
The case where uniqueLimit <  uniqueValues is also handled. 
Added tests for all 3 APIs in ./rdflib/test_graph.py. Following are the details for the testcases :
1. Where the unqiueLimit=0 or uniqueLimit=-1(default)
2. Where  uniqueLimit > uniqueValues
3. Where  uniqueLimit <  uniqueValues

Please suggest changes if any. 