### PR TITLE
Fix for Issue #543 

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -694,6 +694,9 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
+    def unbind(self,prefix):
+        self.store.unbind(prefix)
+
     def bind(self, prefix, namespace, override=True, replace=False):
         """bind a given namespace to the prefix
 

--- a/rdflib/plugins/memory.py
+++ b/rdflib/plugins/memory.py
@@ -155,6 +155,8 @@ class Memory(Store):
     def bind(self, prefix, namespace):
         self.__prefix[namespace] = prefix
         self.__namespace[prefix] = namespace
+    def unbind(self, prefix):
+        del self.__namespace[prefix]
 
     def namespace(self, prefix):
         return self.__namespace.get(prefix, None)


### PR DESCRIPTION
We added a unbind function which can be called in same way in which we call bind function. We pass the prefix that need to be unbind. The example can be given as:- 

from rdflib import Graph, Namespace
g = Graph()
g.namespace_manager.bind('abc', Namespace('http://xmlns.com/foaf/0.1'))
print('--- namespaces before unbinding ----')
for ns in g.namespaces():
    print('%s:%s' % (ns))
print
g.namespace_manager.unbind('abc')
print("\n\n")
print('--- namespaces after unbinding ----')
for ns in g.namespaces():
    print('%s:%s' % (ns))
print