### PR TITLE
Fix Issue #948 prefixed names does not allow escaping in turtle 1.1

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -833,25 +833,43 @@ def is_ncname(name):
     return 0
 
 
-def split_uri(uri, split_start=SPLIT_START_CATEGORIES):
-    if uri.startswith(XMLNS):
-        return (XMLNS, uri.split(XMLNS)[1])
-    length = len(uri)
-    for i in range(0, length):
-        c = uri[-i - 1]
-        if not category(c) in NAME_CATEGORIES:
-            if c in ALLOWED_NAME_CHARS:
-                continue
-            for j in range(-1 - i, length):
-                if category(uri[j]) in split_start or uri[j] == "_":
-                    # _ prevents early split, roundtrip not generate
-                    ns = uri[:j]
-                    if not ns:
-                        break
-                    ln = uri[j:]
-                    return (ns, ln)
-            break
-    raise ValueError("Can't split '{}'".format(uri))
+def split_uri(uri, split_start=SPLIT_START_CATEGORIES,FLAG=0,NSP=''):
+    if FLAG==0:
+        if uri.startswith(XMLNS):
+            return (XMLNS, uri.split(XMLNS)[1])
+        length = len(uri)
+        for i in range(0, length):
+            c = uri[-i - 1]
+            if not category(c) in NAME_CATEGORIES:
+                if c in ALLOWED_NAME_CHARS:
+                    continue
+                for j in range(-1 - i, length):
+                    if category(uri[j]) in split_start or uri[j] == "_":
+                        # _ prevents early split, roundtrip not generate
+                        ns = uri[:j]
+                        if not ns:
+                            break
+                        ln = uri[j:]
+                    
+                        return (ns, ln)
+                break
+            
+        raise ValueError("Can't split '{}'".format(uri))
+    else:
+        for i in NSP.keys():
+            w = str(uri).split(NSP[i])
+            if(len(w)==2):
+                sp=['_','~','.','-','!','$','&','\'','(',')','*','+',',',';','=','/','?','#','@','%' ]
+                l = w[len(w)-1]
+                w1=""
+                for j in l:
+                    if(j in sp):
+                        w1=w1+'\\'+j
+                    else:
+                        w1=w1+j
+                local=w1
+                prefix=i
+                return(prefix, local)
 
 
 def insert_trie(trie, value):  # aka get_subtrie_or_insert

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -283,11 +283,43 @@ class TurtleSerializer(RecursiveSerializer):
             if pfx is not None:
                 parts = (pfx, uri, "")
             else:
+                gh = self.namespaces
+                if(len(gh)==0):
+                    return None
                 # nothing worked
-                return None
+                #return None
+        flag=0
+        if parts==None:
+            gh = self.namespaces
 
-        prefix, namespace, local = parts
+            for i in gh.keys():
+                g = gh[i]
+                try:
+                    parts = self.store.compute_qname(g, generate=gen_prefix)
+                    prefix,namespace,local = parts
+                    n = str(namespace)
+                    w = str(uri).split(n)
+                    if(len(w)==2):
+                        flag=1
+                        sp = ['%','&','*','#','?',':','!','.','$','_','-','+','=',',','(',')','~']
+                        l = w[len(w)-1]
+                        w1=""
+                        for i in l:
+                            if(i in sp):
+                                w1=w1+'\\'+i
+                            else:
+                                w1=w1+i
+                        local=w1
+                        prefix = self.addNamespace(prefix, namespace)
+                        return u'%s:%s' % (prefix, local)
 
+                except:
+                    continue
+                
+                
+        if flag!=1:
+            prefix, namespace, local = parts
+    
         # QName cannot end with .
         if local.endswith("."):
             return None

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -9,7 +9,7 @@ from functools import cmp_to_key
 from rdflib.term import BNode, Literal, URIRef
 from rdflib.exceptions import Error
 from rdflib.serializer import Serializer
-from rdflib.namespace import RDF, RDFS
+from rdflib.namespace import RDF, RDFS, split_uri
 
 __all__ = ["RecursiveSerializer", "TurtleSerializer"]
 
@@ -122,7 +122,10 @@ class RecursiveSerializer(Serializer):
                         self.addNamespace(prefix, ns)
             else:
                 for prefix, ns in self.store.namespaces():
-                    self.addNamespace(prefix, ns)
+                    self.addNamespace(prefix, ns)            
+        else:
+            for prefix, ns in self.store.namespaces():
+                self.addNamespace(prefix, ns) 
 
     def buildPredicateHash(self, subject):
         """
@@ -291,32 +294,8 @@ class TurtleSerializer(RecursiveSerializer):
         flag=0
         if parts==None:
             gh = self.namespaces
-
-            for i in gh.keys():
-                g = gh[i]
-                try:
-                    parts = self.store.compute_qname(g, generate=gen_prefix)
-                    prefix,namespace,local = parts
-                    n = str(namespace)
-                    w = str(uri).split(n)
-                    if(len(w)==2):
-                        flag=1
-                        sp = ['%','&','*','#','?',':','!','.','$','_','-','+','=',',','(',')','~']
-                        l = w[len(w)-1]
-                        w1=""
-                        for i in l:
-                            if(i in sp):
-                                w1=w1+'\\'+i
-                            else:
-                                w1=w1+i
-                        local=w1
-                        prefix = self.addNamespace(prefix, namespace)
-                        return u'%s:%s' % (prefix, local)
-
-                except:
-                    continue
-                
-                
+            prefix,local=split_uri(uri,FLAG=1,NSP=gh)
+            return u'%s:%s' % (prefix, local)
         if flag!=1:
             prefix, namespace, local = parts
     

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -123,9 +123,7 @@ class RecursiveSerializer(Serializer):
             else:
                 for prefix, ns in self.store.namespaces():
                     self.addNamespace(prefix, ns)            
-        else:
-            for prefix, ns in self.store.namespaces():
-                self.addNamespace(prefix, ns) 
+        
 
     def buildPredicateHash(self, subject):
         """


### PR DESCRIPTION
We have provided the solution for issue #948 . In this we have allowed objects to have special characters with forward slash to make it a valid one.