### PR TITLE
Added DateTime arithmetic operations for Literals - Extension of #629

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -699,7 +699,7 @@ class Literal(Identifier):
         >>> a= Literal('2006-07-01T20:52:00',datatype=XSD.dateTime)
         >>> b= Literal('2006-11-01T12:50:00',datatype=XSD.dateTime)
         >>> (b-a)
-        rdflib.term.Literal('-P122DT15H58M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+        rdflib.term.Literal('P122DT15H58M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
         
         """
         # if no val is supplied, return this Literal

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -687,6 +687,32 @@ class Literal(Identifier):
 
             return Literal(s, self.language, datatype=new_datatype)
 
+    def __sub__(self, val):
+        """
+        Handling dateTime/date/time based operations in Literals
+        >>> from rdflib.namespace import XSD
+        >>> a= Literal('2006-01-01T20:50:00',datatype=XSD.dateTime)
+        >>> b= Literal('2006-02-01T20:50:00',datatype=XSD.dateTime)
+        >>> (b-a)
+        rdflib.term.Literal('P31D', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+        >>> from rdflib.namespace import XSD
+        >>> a= Literal('2006-07-01T20:52:00',datatype=XSD.dateTime)
+        >>> b= Literal('2006-11-01T12:50:00',datatype=XSD.dateTime)
+        >>> (b-a)
+        rdflib.term.Literal('-P122DT15H58M', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#duration'))
+        
+        """
+        # if no val is supplied, return this Literal
+        if val is None:
+            return self
+
+        # if self and val both are datetime based
+        if hasattr(self, 'datatype') and self.datatype in (_XSD_DATETIME, _XSD_DATE, _XSD_TIME) and val.datatype==self.datatype:
+            date1=self.toPython();
+            date2=val.toPython();
+            difference=date1-date2;   
+            return Literal(difference, datatype=_XSD_DURATION)
+
     def __bool__(self):
         """
         Is the Literal "True"

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -1,7 +1,7 @@
 import unittest
 
 import rdflib  # needed for eval(repr(...)) below
-from rdflib.term import Literal, URIRef, _XSD_DOUBLE, bind, _XSD_BOOLEAN
+from rdflib.term import Literal, URIRef, _XSD_DOUBLE, bind, _XSD_BOOLEAN, _XSD_DATETIME, _XSD_DURATION, _XSD_DATE
 
 
 def uformat(s):
@@ -127,6 +127,35 @@ class TestParseBoolean(unittest.TestCase):
         self.assertRaises(DeprecationWarning)
         self.assertFalse(test_value.value)
 
+class TestLiteralDateTimeOperatons(unittest.TestCase):
+    """extends the issue OF #629 - Handling datetime substraction operations in Literals as a datetime """
+    def testDateTimeSub(self):
+        a= Literal('2006-01-01T20:50:00',datatype=_XSD_DATETIME)
+        b= Literal('2006-02-01T20:50:00',datatype=_XSD_DATETIME)
+        result=(b-a)
+        expected=Literal('P31D',datatype=_XSD_DURATION);
+        self.assertTrue(result,expected)
+
+    def testDateTimeSub2(self):
+        a= Literal('2006-01-02T20:50:00',datatype=_XSD_DATETIME)
+        b= Literal('2006-05-01T20:50:00',datatype=_XSD_DATETIME)
+        result=(b-a)
+        expected=Literal('P119D',datatype=_XSD_DURATION)
+        self.assertTrue(result,expected)
+
+    def testDateTimeSub3(self):
+        a= Literal('2006-07-01T20:52:00',datatype=_XSD_DATE)
+        b= Literal('2006-11-01T12:50:00',datatype=_XSD_DATE)
+        result=(b-a)
+        expected=Literal('-P122DT15H58M',datatype=_XSD_DURATION)
+        self.assertTrue(result,expected)
+
+    def testDateTimeSub3(self):
+        a= Literal('2006-08-01',datatype=_XSD_DATE)
+        b= Literal('2006-11-01',datatype=_XSD_DATE)
+        result=(b-a)
+        expected=Literal('P92D',datatype=_XSD_DURATION)
+        self.assertTrue(result,expected)
 
 class TestBindings(unittest.TestCase):
     def testBinding(self):


### PR DESCRIPTION
This PR adds some additional set of operations - dateTime / date / time subtraction to the Literals of RDFLib. This is an extension to the #629 issue of adding these operations to Literals in addition to the SPARQL queries.