### PR TITLE
Fix for Issue #543 (Namespace unbind required) including trie  and other modification 

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -694,7 +694,10 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
-    def unbind(self,prefix):
+    def unbind(self, prefix):
+        for ns in self.namespaces():
+            if (ns[0] == prefix):
+                del self.__trie[str(ns[1])]
         self.store.unbind(prefix)
 
     def bind(self, prefix, namespace, override=True, replace=False):

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -694,6 +694,9 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
+    def unbind(self,prefix):
+        self.store.unbind(prefix)
+
     def bind(self, prefix, namespace, override=True, replace=False):
         """bind a given namespace to the prefix
 

--- a/rdflib/plugins/memory.py
+++ b/rdflib/plugins/memory.py
@@ -155,7 +155,10 @@ class Memory(Store):
     def bind(self, prefix, namespace):
         self.__prefix[namespace] = prefix
         self.__namespace[prefix] = namespace
+
     def unbind(self, prefix):
+        temp_prefix = {x: y for x, y in self.__prefix.items() if y != prefix}
+        self.__prefix = temp_prefix
         del self.__namespace[prefix]
 
     def namespace(self, prefix):

--- a/rdflib/plugins/memory.py
+++ b/rdflib/plugins/memory.py
@@ -155,6 +155,8 @@ class Memory(Store):
     def bind(self, prefix, namespace):
         self.__prefix[namespace] = prefix
         self.__namespace[prefix] = namespace
+    def unbind(self, prefix):
+        del self.__namespace[prefix]
 
     def namespace(self, prefix):
         return self.__namespace.get(prefix, None)


### PR DESCRIPTION
For Issue #543  ,We added a unbind function which can be called in same way in which we call bind function. We pass the prefix that need to be unbind. In this PR we also take care of Trie and other cases in both rdflib/namespace.py  and  rdflib/plugins/memory.py .

The example can be given as:-

from rdflib import Graph, Namespace
g = Graph()
g.namespace_manager.bind('abc', Namespace('http://abc.com/xyz/0.1'))
print('--- namespaces before unbinding ----')
for ns in g.namespaces():
print('%s:%s' % (ns))
print
g.namespace_manager.unbind('abc')
print("\n\n")
print('--- namespaces after unbinding ----')
for ns in g.namespaces():
print('%s:%s' % (ns))
print