### PR TITLE
Fixed the return type of parse function of ConjunctiveGraph (Issue #939)

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1538,15 +1538,25 @@ class ConjunctiveGraph(Graph):
             data=data,
             format=format,
         )
+        
 
         g_id = publicID and publicID or source.getPublicId()
         if not isinstance(g_id, Node):
             g_id = URIRef(g_id)
-
-        context = Graph(store=self.store, identifier=g_id)
-        context.remove((None, None, None))  # hmm ?
-        context.parse(source, publicID=publicID, format=format, **args)
-        return context
+            
+        if format is None:
+            format = source.content_type
+        if format is None:
+            # raise Exception("Could not determine format for %r. You can" + \
+            # "expicitly specify one with the format argument." % source)
+            format = "application/rdf+xml"
+        parser = plugin.get(format, Parser)()
+        try:
+            parser.parse(source, self, **args)
+        finally:
+            if source.auto_close:
+                source.close()
+        return self
 
     def __reduce__(self):
         return ConjunctiveGraph, (self.store, self.identifier)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1064,6 +1064,7 @@ class Graph(Node):
             data=data,
             format=format,
         )
+        
         if format is None:
             format = source.content_type
         if format is None:
@@ -1344,6 +1345,7 @@ class ConjunctiveGraph(Graph):
         assert self.store.context_aware, (
             "ConjunctiveGraph must be backed by" " a context aware store."
         )
+        
         self.context_aware = True
         self.default_union = True  # Conjunctive!
         self.default_context = Graph(
@@ -1508,6 +1510,9 @@ class ConjunctiveGraph(Graph):
             context_id = "#context"
         return URIRef(context_id, base=uri)
 
+    # def identifier(self,id):
+    #     self._identifier=id
+    
     def parse(
         self,
         source=None,
@@ -1539,11 +1544,14 @@ class ConjunctiveGraph(Graph):
             format=format,
         )
         
-
+        # print(source.getPublicId(),publicID)
+        
         g_id = publicID and publicID or source.getPublicId()
         if not isinstance(g_id, Node):
             g_id = URIRef(g_id)
             
+        super(ConjunctiveGraph, self).__init__(store=self.store,identifier=g_id)
+        self.remove((None,None,None))
         if format is None:
             format = source.content_type
         if format is None:
@@ -1557,6 +1565,12 @@ class ConjunctiveGraph(Graph):
             if source.auto_close:
                 source.close()
         return self
+
+        # context = Graph(store=self.store, identifier=g_id)
+        # context.remove((None, None, None))  # hmm ?
+        # context.parse(source, publicID=publicID, format=format, **args)
+        # print(type(context))
+        # return context
 
     def __reduce__(self):
         return ConjunctiveGraph, (self.store, self.identifier)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1551,7 +1551,7 @@ class ConjunctiveGraph(Graph):
             g_id = URIRef(g_id)
             
         super(ConjunctiveGraph, self).__init__(store=self.store,identifier=g_id)
-        self.remove((None,None,None))
+        super(ConjunctiveGraph,self).remove((None,None,None))
         if format is None:
             format = source.content_type
         if format is None:
@@ -1566,11 +1566,6 @@ class ConjunctiveGraph(Graph):
                 source.close()
         return self
 
-        # context = Graph(store=self.store, identifier=g_id)
-        # context.remove((None, None, None))  # hmm ?
-        # context.parse(source, publicID=publicID, format=format, **args)
-        # print(type(context))
-        # return context
 
     def __reduce__(self):
         return ConjunctiveGraph, (self.store, self.identifier)


### PR DESCRIPTION
Instead of creating a new graph and parsing changes in that (therefore changing the graph type), the parsing is done in the graph itself and a self is returned. (Similar code as parse function of class Graph).