### PR TITLE
BNode context dicts for NT and N-Quads parsers

### DIFF
--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -40,7 +40,7 @@ __all__ = ["NQuadsParser"]
 
 
 class NQuadsParser(NTriplesParser):
-    def parse(self, inputsource, sink, **kwargs):
+    def parse(self, inputsource, sink, bnode_context=None, **kwargs):
         """Parse f as an N-Triples file."""
         assert sink.store.context_aware, (
             "NQuadsParser must be given" " a context aware store."
@@ -61,27 +61,27 @@ class NQuadsParser(NTriplesParser):
             if self.line is None:
                 break
             try:
-                self.parseline()
+                self.parseline(bnode_context)
             except ParseError as msg:
                 raise ParseError("Invalid line (%s):\n%r" % (msg, __line))
 
         return self.sink
 
-    def parseline(self):
+    def parseline(self, bnode_context=None):
         self.eat(r_wspace)
         if (not self.line) or self.line.startswith(("#")):
             return  # The line is empty or a comment
 
-        subject = self.subject()
+        subject = self.subject(bnode_context)
         self.eat(r_wspace)
 
         predicate = self.predicate()
         self.eat(r_wspace)
 
-        obj = self.object()
+        obj = self.object(bnode_context)
         self.eat(r_wspace)
 
-        context = self.uriref() or self.nodeid() or self.sink.identifier
+        context = self.uriref() or self.nodeid(bnode_context) or self.sink.identifier
         self.eat(r_tail)
 
         if self.line:

--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -41,7 +41,17 @@ __all__ = ["NQuadsParser"]
 
 class NQuadsParser(NTriplesParser):
     def parse(self, inputsource, sink, bnode_context=None, **kwargs):
-        """Parse f as an N-Triples file."""
+        """
+        Parse inputsource as an N-Quads file.
+
+        :type inputsource: `rdflib.parser.InputSource`
+        :param inputsource: the source of N-Quads-formatted data
+        :type sink: `rdflib.graph.Graph`
+        :param sink: where to send parsed triples
+        :type bnode_context: `dict`, optional
+        :param bnode_context: a dict mapping blank node identifiers to `~rdflib.term.BNode` instances.
+                              See `.NTriplesParser.parse`
+        """
         assert sink.store.context_aware, (
             "NQuadsParser must be given" " a context aware store."
         )

--- a/rdflib/plugins/parsers/nt.py
+++ b/rdflib/plugins/parsers/nt.py
@@ -17,9 +17,6 @@ class NTParser(Parser):
 
     See http://www.w3.org/TR/rdf-testcases/#ntriples"""
 
-    def __init__(self):
-        super(NTParser, self).__init__()
-
     def parse(self, source, sink, **kwargs):
         '''
         Parse the NT format

--- a/rdflib/plugins/parsers/nt.py
+++ b/rdflib/plugins/parsers/nt.py
@@ -20,8 +20,17 @@ class NTParser(Parser):
     def __init__(self):
         super(NTParser, self).__init__()
 
-    def parse(self, source, sink, baseURI=None):
+    def parse(self, source, sink, **kwargs):
+        '''
+        Parse the NT format
+
+        :type source: `rdflib.parser.InputSource`
+        :param source: the source of NT-formatted data
+        :type sink: `rdflib.graph.Graph`
+        :param sink: where to send parsed triples
+        :param kwargs: Additional arguments to pass to `.NTriplesParser.parse`
+        '''
         f = source.getByteStream()  # TODO getCharacterStream?
         parser = NTriplesParser(NTSink(sink))
-        parser.parse(f)
+        parser.parse(f, **kwargs)
         f.close()

--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -142,10 +142,13 @@ class NTriplesParser(object):
         """
         Parse f as an N-Triples file.
 
+        :type f: :term:`file object`
         :param f: the N-Triples source
+        :type bnode_context: `dict`, optional
         :param bnode_context: a dict mapping blank node identifiers (e.g., ``a`` in ``_:a``)
-                              to `.BNode` instances. An empty dict can be passed in to
-                              define a distinct context for a given call to `parse`.
+                              to `~rdflib.term.BNode` instances. An empty dict can be
+                              passed in to define a distinct context for a given call to
+                              `parse`.
         """
         if not hasattr(f, "read"):
             raise ParseError("Item to parse must be a file-like object.")

--- a/test/nquads.rdflib/bnode_context.nquads
+++ b/test/nquads.rdflib/bnode_context.nquads
@@ -1,0 +1,3 @@
+_:bnode1 <http://xmlns.com/foaf/0.1/Friend> "Michele" _:blah .
+_:bnode2 <http://xmlns.com/foaf/0.1/Friend> "Kevin" _:bluh .
+

--- a/test/nquads.rdflib/bnode_context_obj_bnodes.nquads
+++ b/test/nquads.rdflib/bnode_context_obj_bnodes.nquads
@@ -1,0 +1,3 @@
+_:bnode1 <http://xmlns.com/foaf/0.1/Friend> "Michele" <http://example.org/alice/foaf2.rdf> .
+<http://example.org/Kevin> <http://xmlns.com/foaf/0.1/Friend> _:bnode2 <http://example.org/alice/foaf3.rdf> .
+

--- a/test/test_nquads.py
+++ b/test/test_nquads.py
@@ -67,5 +67,69 @@ class NQuadsParserTest(unittest.TestCase):
         )
 
 
+class BnodeContextTest(unittest.TestCase):
+    def setUp(self):
+        self.data = open("test/nquads.rdflib/bnode_context.nquads", "rb")
+        self.data_obnodes = open("test/nquads.rdflib/bnode_context_obj_bnodes.nquads", "rb")
+
+    def tearDown(self):
+        self.data.close()
+
+    def test_parse_shared_bnode_context(self):
+        bnode_ctx = dict()
+        g = ConjunctiveGraph()
+        h = ConjunctiveGraph()
+        g.parse(self.data, format="nquads", bnode_context=bnode_ctx)
+        self.data.seek(0)
+        h.parse(self.data, format="nquads", bnode_context=bnode_ctx)
+        self.assertEqual(set(h.subjects()), set(g.subjects()))
+
+    def test_parse_shared_bnode_context_same_graph(self):
+        bnode_ctx = dict()
+        g = ConjunctiveGraph()
+        g.parse(self.data_obnodes, format="nquads", bnode_context=bnode_ctx)
+        o1 = set(g.objects())
+        self.data_obnodes.seek(0)
+        g.parse(self.data_obnodes, format="nquads", bnode_context=bnode_ctx)
+        o2 = set(g.objects())
+        self.assertEqual(o1, o2)
+
+    def test_parse_distinct_bnode_context(self):
+        g = ConjunctiveGraph()
+        g.parse(self.data, format="nquads", bnode_context=dict())
+        s1 = set(g.subjects())
+        self.data.seek(0)
+        g.parse(self.data, format="nquads", bnode_context=dict())
+        s2 = set(g.subjects())
+        self.assertNotEqual(set(), s2 - s1)
+
+    def test_parse_distinct_bnode_contexts_between_graphs(self):
+        g = ConjunctiveGraph()
+        h = ConjunctiveGraph()
+        g.parse(self.data, format="nquads")
+        s1 = set(g.subjects())
+        self.data.seek(0)
+        h.parse(self.data, format="nquads")
+        s2 = set(h.subjects())
+        self.assertNotEqual(s1, s2)
+
+    def test_parse_distinct_bnode_contexts_named_graphs(self):
+        g = ConjunctiveGraph()
+        h = ConjunctiveGraph()
+        g.parse(self.data, format="nquads")
+        self.data.seek(0)
+        h.parse(self.data, format="nquads")
+        self.assertNotEqual(set(h.contexts()), set(g.contexts()))
+
+    def test_parse_shared_bnode_contexts_named_graphs(self):
+        bnode_ctx = dict()
+        g = ConjunctiveGraph()
+        h = ConjunctiveGraph()
+        g.parse(self.data, format="nquads", bnode_context=bnode_ctx)
+        self.data.seek(0)
+        h.parse(self.data, format="nquads", bnode_context=bnode_ctx)
+        self.assertEqual(set(h.contexts()), set(g.contexts()))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -188,6 +188,22 @@ class BNodeContextTestCase(unittest.TestCase):
 
         self.assertEqual(len(my_sink.subs), 1)
 
+    def test_bnode_shared_across_instances_with_parse_option(self):
+        my_sink = FakeSink()
+        bnode_ctx = dict()
+
+        p = ntriples.NTriplesParser(my_sink)
+        p.parsestring('''
+        _:0 <http://purl.obolibrary.org/obo/RO_0002350> <http://www.gbif.org/species/0000001> .
+        ''', bnode_context=bnode_ctx)
+
+        q = ntriples.NTriplesParser(my_sink)
+        q.parsestring('''
+        _:0 <http://purl.obolibrary.org/obo/RO_0002350> <http://www.gbif.org/species/0000002> .
+        ''', bnode_context=bnode_ctx)
+
+        self.assertEqual(len(my_sink.subs), 1)
+
 
 class FakeSink(object):
     def __init__(self):


### PR DESCRIPTION
Address remainder #980. Also add similar behavior for N-Quads.