### PR TITLE
Support added for parsing RDF* Graphs

### DIFF
--- a/examples/rdf_star2.py
+++ b/examples/rdf_star2.py
@@ -1,0 +1,118 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+"""
+To test for Rdf* graphs with multiple star statements (embedded triples) present in subject/object or both
+"""
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s2 rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:name ;
+    rdf:object "Bob" .
+
+    _:s2 foaf:relatedTo _:s .
+
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?name ?age WHERE {
+    ?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . 
+
+    ?y foaf:name ?name .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:name ;
+    rdf:object ?name .
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    <<ex:bob foaf:age 23>> foaf:relatedTo <<ex:bob foaf:name "Bob">> ;
+    dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?name ?age WHERE 
+    { <<?x foaf:age ?age>> foaf:relatedTo <<?y foaf:name ?name>> .}
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    print("Result on Rdf Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    print("Result on Rdf* Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_1.py
+++ b/examples/rdf_star_1.py
@@ -1,0 +1,116 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+"""
+For graphs with multiple rdf reification statements i.e. multiple Embedded triples
+"""
+
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?src WHERE {
+    {?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . }
+    UNION {
+    ?x ex:influencedBy ?y .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ?y ;
+    dct:source ?src .}
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    <<ex:bob foaf:age 23>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    { <<?x foaf:age ?age>> dct:source ?src . }
+    UNION
+    { <<?x ex:influencedBy ?y>> dct:source ?src . }
+    }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    print("Result on Rdf Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    print("Result on Rdf* Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_object.py
+++ b/examples/rdf_star_object.py
@@ -1,0 +1,120 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+"""
+To test for Rdf* graphs with embedded Triples as the object rather than subject
+equivalent to
+Reification of the object, rather than subject.
+"""
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    ex:PeopleInfo dct:isSourceOf _:s ;
+        ex:hasURL <http://example.com/crawlers#c1> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?src WHERE {
+    {?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age .
+    ex:PeopleInfo dct:isSourceOf ?r ;
+    ex:hasURL ?src .}
+    UNION {
+    ?x ex:influencedBy ?y .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ?y ;
+    dct:source ?src .}
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    ex:PeopleInfo dct:isSourceOf <<ex:bob foaf:age 23>> ;
+        ex:hasURL <http://example.com/crawlers#c1> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    {
+    ex:PeopleInfo dct:isSourceOf <<?x foaf:age ?age>> ;
+    ex:hasURL ?src . }
+    UNION
+    { <<?x ex:influencedBy ?y>> dct:source ?src . }
+    }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    print("Result on Rdf Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    print("Result on Rdf* Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    # test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_recursive.py
+++ b/examples/rdf_star_recursive.py
@@ -1,0 +1,124 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+"""
+An Rdf Star Graph with Recursively Embedded Triples of the form 
+                        <<?s1 ?p1 <<?s2 ?p2 ?o2>> >> ?p ?o .
+along with simple embedded triples.
+"""
+
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:knows _:s2 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:knows ;
+    rdf:object _:s2 .
+
+    _:s2 rdf:type rdf:Statement ;
+    rdf:subject ex:alice ;
+    rdf:predicate foaf:name ;
+    rdf:object "Alice" .
+
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/bob.html> .
+
+    _:s2 dct:source <http://example.net/alice.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?srcX ?srcY WHERE {
+    ?x foaf:knows ?r2 .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:knows ;
+    rdf:object ?r2 ;
+    dct:source ?srcX . 
+
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?y ;
+    rdf:predicate foaf:name ;
+    rdf:object ?name ;
+    dct:source ?srcY
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    <<ex:bob foaf:knows <<ex:alice foaf:name "Alice">>>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/bob.html> .
+
+    <<ex:alice foaf:name "Alice">> dct:source <http://example.net/alice.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?srcX ?srcY WHERE 
+    { <<ex:bob foaf:knows <<?y foaf:name ?name>>>> dct:source ?srcX . 
+    <<?y foaf:name ?name>> dct:source ?srcY .}
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    print("Result on Rdf Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    print("Result on Rdf* Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_simple.py
+++ b/examples/rdf_star_simple.py
@@ -1,0 +1,86 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+
+"""
+A very basic Rdf Star graph with only 1 embedded triple as Subject.
+"""
+
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+    foaf:age 23 .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s1 dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    ?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    <<ex:bob foaf:age 23>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE { <<?x foaf:age ?age>> dct:source ?src . }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    print("Result on Rdf Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    print("Result on Rdf* Graph:")
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()


### PR DESCRIPTION
Support added for parsing RDF* graphs: 
PR for Issue 955 (https://github.com/RDFLib/rdflib/issues/955) 
Changes:
- Additional code added in parser of RDF (TTL) graphs, i.e. notation3.py, to change any embedded triples in Star format to traditional reification statements.
- Tested for graphs with multiple embedded statements and examples added to test for RDF* embedded triples present as subject, object, both subject and object as well as recursively embedded triples.