### PR TITLE
quick fix for Link header handling for json-ld

### DIFF
--- a/rdflib/tools/rdf2dot.py
+++ b/rdflib/tools/rdf2dot.py
@@ -15,7 +15,7 @@ import rdflib
 import rdflib.extras.cmdlineutils
 
 import sys
-import cgi
+import html as cgi
 import collections
 
 from rdflib import XSD
@@ -103,9 +103,14 @@ def rdf2dot(g, stream, opts={}):
                 return l
 
         try:
-            return g.namespace_manager.compute_qname(x)[2]
+            l = g.namespace_manager.compute_qname(x)[2]
+            if l:
+                return l
         except:
-            return x
+            if x:
+                return x
+        #dot throws up a little with empty <B>
+        return " "
 
     def formatliteral(l, g):
         v = cgi.escape(l)

--- a/rdflib/tools/rdf2dot.py
+++ b/rdflib/tools/rdf2dot.py
@@ -15,7 +15,7 @@ import rdflib
 import rdflib.extras.cmdlineutils
 
 import sys
-import html as cgi
+import cgi
 import collections
 
 from rdflib import XSD
@@ -103,14 +103,9 @@ def rdf2dot(g, stream, opts={}):
                 return l
 
         try:
-            l = g.namespace_manager.compute_qname(x)[2]
-            if l:
-                return l
+            return g.namespace_manager.compute_qname(x)[2]
         except:
-            if x:
-                return x
-        #dot throws up a little with empty <B>
-        return " "
+            return x
 
     def formatliteral(l, g):
         v = cgi.escape(l)


### PR DESCRIPTION
Fixes https://github.com/RDFLib/rdflib-jsonld/issues/85

## Proposed Changes

  - Add support for handling Link header responses

PR is a minimal implementation to get rdflib-jsonld to work with schema.org remote context reference.

TBD:
- Can multiple Link headers returned (e.g. to reference different content types)?
- Do other RDF formats leverage the Link header in HTTP response is specific to JSON-LD?
