### PR TITLE
Add a  __dir__ attribute to a closed namespace

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -214,7 +214,9 @@ class ClosedNamespace(object):
     def __repr__(self):
         return "rdf.namespace.ClosedNamespace(%r)" % str(self.uri)
 
-
+    def __dir__(self):
+        return list(self._ClosedNamespace__uris)
+    
 class _RDFNamespace(ClosedNamespace):
     """
     Closed namespace for RDF terms

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -217,6 +217,9 @@ class ClosedNamespace(object):
     def __dir__(self):
         return list(self._ClosedNamespace__uris)
     
+    def _ipython_key_completions_(self):
+        return dir(self)
+    
 class _RDFNamespace(ClosedNamespace):
     """
     Closed namespace for RDF terms


### PR DESCRIPTION
## Proposed Changes

  - This change is introduced for improved affordance when working with rdflib in interactive settings like IPython. 
  - The __dir__ attribute gives attribute completion.
  - Use the mangled attribute from the closed namespace object to give better interactive completion.

Closes #918