### PR TITLE
remove import side-effects

### DIFF
--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -83,39 +83,6 @@ __all__ = [
     "util",
 ]
 
-import sys
-
-import logging
-
-logger = logging.getLogger(__name__)
-_interactive_mode = False
-try:
-    import __main__
-
-    if (
-        not hasattr(__main__, "__file__")
-        and sys.stdout is not None
-        and sys.stderr.isatty()
-    ):
-        # show log messages in interactive mode
-        _interactive_mode = True
-        logger.setLevel(logging.INFO)
-        logger.addHandler(logging.StreamHandler())
-    del __main__
-except ImportError:
-    # Main already imported from elsewhere
-    import warnings
-
-    warnings.warn("__main__ already imported", ImportWarning)
-    del warnings
-
-if _interactive_mode:
-    logger.info("RDFLib Version: %s" % __version__)
-else:
-    logger.debug("RDFLib Version: %s" % __version__)
-del _interactive_mode
-del sys
-
 
 NORMALIZE_LITERALS = True
 """

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -1,11 +1,12 @@
 import unittest
+import logging
 from pathlib import Path
 from shutil import copyfile
 from tempfile import TemporaryDirectory
 
 from rdflib.exceptions import ParserError
 
-from rdflib import Graph, logger as graph_logger
+from rdflib import Graph
 
 
 class FileParserGuessFormatTest(unittest.TestCase):
@@ -19,10 +20,12 @@ class FileParserGuessFormatTest(unittest.TestCase):
 
     def test_warning(self):
         g = Graph()
+        graph_logger = logging.getLogger("rdflib")
+
         with TemporaryDirectory() as tmpdirname:
             newpath = Path(tmpdirname).joinpath("no_file_ext")
             copyfile("test/rdf/Manifest.rdf", str(newpath))
-            with self.assertLogs(graph_logger, "WARNING") as log_cm:
+            with self.assertLogs(graph_logger, "WARNING"):
                 with self.assertRaises(ParserError):
                     g.parse(str(newpath))
 


### PR DESCRIPTION
importing rdflib has side-effects, if you do so in an interactive terminal the logging module gets configured (or reconfigured if you already have done so...). This is quite unexpected.

Fixes #1135
