### PR TITLE
Small improvement to serialize docs

### DIFF
--- a/docs/intro_to_parsing.rst
+++ b/docs/intro_to_parsing.rst
@@ -67,3 +67,15 @@ files you'll find on the net.
 
 RDFLib will also happily read RDF from any file-like object,
 i.e. anything with a ``.read()`` method.
+
+
+Saving RDF
+----------
+
+To store a graph in a file use the :func:`rdflib.Graph.serialize` function:
+
+.. code-block:: python
+
+    g.parse("http://bigasterisk.com/foaf.rdf")
+    with open("foaf.n3", "wb") as f:
+        g.serialize(f, format="n3")

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import logging
 from warnings import warn
 import random
@@ -957,11 +958,11 @@ class Graph(Node):
 
     def serialize(
         self, destination=None, format="xml", base=None, encoding=None, **args
-    ):
+    ) -> Optional[bytes]:
         """Serialize the Graph to destination
 
-        If destination is None serialize method returns the serialization as a
-        string. Format defaults to xml (AKA rdf/xml).
+        If destination is None serialize method returns the serialization as
+        bytes. Format defaults to xml (AKA rdf/xml).
 
         Format support can be extended with plugins,
         but "xml", "n3", "turtle", "nt", "pretty-xml", "trix", "trig" and "nquads" are built in.


### PR DESCRIPTION
Docs state that serialize returns a `string` but returns `bytes`.