### PR TITLE
Issue 1160 missing url fragment

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -206,18 +206,12 @@ def create_input_source(
     """
 
     # test that exactly one of source, location, file, and data is not None.
-    if (
-        sum(
-            (
-                source is not None,
-                location is not None,
-                file is not None,
-                data is not None,
-            )
+    non_empty_arguments = list(filter(bool, [source, location, file, data]))
+
+    if len(non_empty_arguments) != 1:
+        raise ValueError(
+            "exactly one of source, location, file or data must be given",
         )
-        != 1
-    ):
-        raise ValueError("exactly one of source, location, file or data must be given")
 
     input_source = None
 
@@ -259,7 +253,7 @@ def create_input_source(
         if os.path.exists(location):
             location = pathname2url(location)
         base = urljoin("file:", "%s/" % pathname2url(os.getcwd()))
-        absolute_location = URIRef(location, base=base).defrag()
+        absolute_location = URIRef(location, base=base)
         if absolute_location.startswith("file:///"):
             filename = url2pathname(absolute_location.replace("file:///", "/"))
             file = open(filename, "rb")

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -206,7 +206,10 @@ def create_input_source(
     """
 
     # test that exactly one of source, location, file, and data is not None.
-    non_empty_arguments = list(filter(bool, [source, location, file, data]))
+    non_empty_arguments = list(filter(
+        lambda v: v is not None,
+        [source, location, file, data],
+    ))
 
     if len(non_empty_arguments) != 1:
         raise ValueError(
@@ -248,20 +251,19 @@ def create_input_source(
     absolute_location = None  # Further to fix for issue 130
 
     auto_close = False  # make sure we close all file handles we open
+
     if location is not None:
-        # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
-        if os.path.exists(location):
-            location = pathname2url(location)
-        base = urljoin("file:", "%s/" % pathname2url(os.getcwd()))
-        absolute_location = URIRef(location, base=base)
-        if absolute_location.startswith("file:///"):
-            filename = url2pathname(absolute_location.replace("file:///", "/"))
-            file = open(filename, "rb")
-        else:
-            input_source = URLInputSource(absolute_location, format)
-        auto_close = True
-        # publicID = publicID or absolute_location  # Further to fix
-        # for issue 130
+        (
+            absolute_location,
+            auto_close,
+            file,
+            input_source,
+        ) = _create_input_source_from_location(
+            file=file,
+            format=format,
+            input_source=input_source,
+            location=location,
+        )
 
     if file is not None:
         input_source = FileInputSource(file)
@@ -282,3 +284,25 @@ def create_input_source(
         elif input_source.getPublicId() is None:
             input_source.setPublicId(absolute_location or "")
         return input_source
+
+
+def _create_input_source_from_location(file, format, input_source, location):
+    # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
+    if os.path.exists(location):
+        location = pathname2url(location)
+
+    base = urljoin("file:", "%s/" % pathname2url(os.getcwd()))
+
+    absolute_location = URIRef(location, base=base)
+
+    if absolute_location.startswith("file:///"):
+        filename = url2pathname(absolute_location.replace("file:///", "/"))
+        file = open(filename, "rb")
+    else:
+        input_source = URLInputSource(absolute_location, format)
+
+    auto_close = True
+    # publicID = publicID or absolute_location  # Further to fix
+    # for issue 130
+
+    return absolute_location, auto_close, file, input_source

--- a/test/test_create_input_source.py
+++ b/test/test_create_input_source.py
@@ -19,3 +19,7 @@ class ParserTestCase(unittest.TestCase):
             source='a',
             location='b',
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_create_input_source.py
+++ b/test/test_create_input_source.py
@@ -1,0 +1,21 @@
+import unittest
+
+from rdflib.parser import create_input_source
+
+
+class ParserTestCase(unittest.TestCase):
+    def test_empty_arguments(self):
+        """create_input_source() function must receive exactly one argument."""
+        self.assertRaises(
+            ValueError,
+            create_input_source,
+        )
+
+    def test_too_many_arguments(self):
+        """create_input_source() function has a few conflicting arguments."""
+        self.assertRaises(
+            ValueError,
+            create_input_source,
+            source='a',
+            location='b',
+        )

--- a/test/test_issue1160.py
+++ b/test/test_issue1160.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest import mock
+
+import rdflib
+
+from rdflib import ConjunctiveGraph
+from rdflib.parser import URLInputSource
+
+QUERY = '''
+SELECT DISTINCT ?g
+FROM NAMED <http://ns.example.com/named#>
+WHERE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+'''
+
+
+class NamedGraphWithFragmentTest(unittest.TestCase):
+    def test_named_graph_with_fragment(self):
+        """Test that fragment part of the URL is not erased."""
+        graph = ConjunctiveGraph()
+
+        with mock.patch('rdflib.parser.URLInputSource') as load_mock:
+            # We have to expect an exception here.
+            self.assertRaises(Exception, graph.query, QUERY)
+
+        load_mock.assert_called_with(
+            rdflib.URIRef('http://ns.example.com/named#'),
+            'nt',
+        )


### PR DESCRIPTION
Fixes #1160 

## Proposed Changes

  - Refactored out `_create_input_source_from_location()` from `create_input_source()` in vew of that function being too large;
  - Removed `.defrag()` call which removed the URL fragment part of the named graph IRI;
  - Added a test to ensure that now, when querying against a named graph using `FROM NAMED`, we will have more predictable graph IRI to choose via `GRAPH` statement.
