### PR TITLE
Move to using graph.parse() rather than deprecated graph.load()

### DIFF
--- a/rdflib/plugins/sparql/results/rdfresults.py
+++ b/rdflib/plugins/sparql/results/rdfresults.py
@@ -15,7 +15,7 @@ class RDFResult(Result):
 
         if not isinstance(source, Graph):
             graph = Graph()
-            graph.load(source, **kwargs)
+            graph.parse(source, **kwargs)
         else:
             graph = source
 

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -274,16 +274,20 @@ class QueryContext(object):
     def load(self, source, default=False, **kwargs):
         def _load(graph, source):
             try:
-                return graph.load(source, **kwargs)
-            except:
+                return graph.parse(source, format="turtle", **kwargs)
+            except Exception:
                 pass
             try:
-                return graph.load(source, format="n3", **kwargs)
-            except:
+                return graph.parse(source, format="xml", **kwargs)
+            except Exception:
                 pass
             try:
-                return graph.load(source, format="nt", **kwargs)
-            except:
+                return graph.parse(source, format="n3", **kwargs)
+            except Exception:
+                pass
+            try:
+                return graph.parse(source, format="nt", **kwargs)
+            except Exception:
                 raise Exception(
                     "Could not load %s as either RDF/XML, N3 or NTriples" % source
                 )


### PR DESCRIPTION
Replaced all usages of graph.load() in rdflib, it is deprected, move to use graph.parse().