### PR TITLE
Fix serialize with multiple disks on windows

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -992,10 +992,11 @@ class Graph(Node):
             stream = os.fdopen(fd, "wb")
             serializer.serialize(stream, base=base, encoding=encoding, **args)
             stream.close()
+            dest = path if scheme == "file" else location
             if hasattr(shutil, "move"):
-                shutil.move(name, location)
+                shutil.move(name, dest)
             else:
-                shutil.copy(name, location)
+                shutil.copy(name, dest)
                 os.remove(name)
 
     def parse(

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -993,9 +993,9 @@ class Graph(Node):
             serializer.serialize(stream, base=base, encoding=encoding, **args)
             stream.close()
             if hasattr(shutil, "move"):
-                shutil.move(name, path)
+                shutil.move(name, location)
             else:
-                shutil.copy(name, path)
+                shutil.copy(name, location)
                 os.remove(name)
 
     def parse(


### PR DESCRIPTION
Fixes #1170 

## Proposed Changes
I replaced the `path` variable in the `shutil.move` call with `location`.
The former is the output of an `urlencode` call, which strips the drive letter on windows machines.
If the user has multiple drives, `shutil.move` will fail if the drive letter is not there.