### PR TITLE
URI Validation Performance Improvements

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -76,7 +76,7 @@ _invalid_uri_chars = set('<>" {}|\\^`')
 def _is_valid_uri(uri):
     try:
         uri.encode("ascii")
-    except UnicodeDecodeError:
+    except UnicodeEncodeError:
         return False
     return not bool([c for c in _invalid_uri_chars if c in uri])
 

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -70,11 +70,15 @@ rdflib_skolem_genid = "/.well-known/genid/rdflib/"
 skolems = {}
 
 
-_invalid_uri_chars = '<>" {}|\\^`'
+_invalid_uri_chars = set('<>" {}|\\^`')
 
 
 def _is_valid_uri(uri):
-    return all([ord(c) > 256 or not c in _invalid_uri_chars for c in uri])
+    try:
+        uri.encode("ascii")
+    except UnicodeDecodeError:
+        return False
+    return not bool([c for c in _invalid_uri_chars if c in uri])
 
 
 _lang_tag_regex = compile("^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")


### PR DESCRIPTION
I've found _is_valid_uri to be a hotspot in serialization and
deserialization.

Benchmarking this version of the function against the original
with 1e7 urls results in runtime improvement of nearly 3x.

Tests against real RDF graphs with 2e6+ triples results in runtime
improvement of 10-12% in serialization and deserialization.