### PR TITLE
URI Validation Performance Improvements

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -74,7 +74,7 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    return all([ord(c) > 256 or not c in _invalid_uri_chars for c in uri])
+    return not bool([c for c in uri if c in _invalid_uri_chars and ord(c) <= 256])
 
 
 _lang_tag_regex = compile("^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -74,8 +74,8 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    for c in uri:
-        if c in _invalid_uri_chars:
+    for c in _invalid_uri_chars:
+        if c in uri:
             return False
     return True
 

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -74,7 +74,10 @@ _invalid_uri_chars = '<>" {}|\\^`'
 
 
 def _is_valid_uri(uri):
-    return not bool([c for c in uri if c in _invalid_uri_chars and ord(c) <= 256])
+    for c in uri:
+        if c in _invalid_uri_chars:
+            return False
+    return True
 
 
 _lang_tag_regex = compile("^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")


### PR DESCRIPTION
I've found _is_valid_uri to be a hotspot in serialization and
deserialization.

Benchmarking this version of the function against the original with 1e7
urls results in runtime improvement of ~5x

Tests against real RDF graphs with 2e6+ triples results in runtime
improvement of ~10-12% in serialization and deserialization.

Functionally there is one diff - I don't believe the `ord(c)` check is
necessary.  In the original code effectively the check for each char
is that:

    ord(c) > 256
            OR
    c not in _invalid_uri_chars

Since for all c in _invalid_uri_chars ord(c) <= 256 there is no case where
the `ord(c) > 256` condition holds true but `c not in _invalid_uri_chars`
does not also.

I tried a few other approaches including performing this check in a list
comprehension, e.g.

    return bool([c for c in _invalid_uri_chars if c in uri])

but this was significantly slower for large numbers of calls, though faster than
the original code by ~2x.

