### PR TITLE
Support parsing paths specified with pathlib

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -12,6 +12,7 @@ want to do so through the Graph class parse method.
 
 import codecs
 import os
+import pathlib
 import sys
 
 from io import BytesIO, TextIOBase, TextIOWrapper, StringIO, BufferedIOBase
@@ -221,6 +222,8 @@ def create_input_source(
         else:
             if isinstance(source, str):
                 location = source
+            elif isinstance(source, pathlib.Path):
+                location = str(source)
             elif isinstance(source, bytes):
                 data = source
             elif hasattr(source, "read") and not isinstance(source, Namespace):

--- a/test/test_parser_reads_from_pathlike_object.py
+++ b/test/test_parser_reads_from_pathlike_object.py
@@ -1,0 +1,26 @@
+import tempfile
+import rdflib
+from pathlib import Path
+
+
+def test_reading_from_path_object():
+    xml_sample = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#"
+         xmlns:cyme="http://www.cyme.com/CIM/1.0.2#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <cim:SwitchInfo rdf:ID="_AB16765A-B19E-4454-A58F-868D23C6CD26" />
+</rdf:RDF>"""
+
+    with tempfile.TemporaryDirectory() as td:
+        sample_file = Path(td) / "sample.xml"
+        open(str(sample_file), 'w').write(xml_sample)
+
+        g = rdflib.Graph()
+        g.parse(sample_file, publicID="")
+
+    subject, predicate, object = next(iter(g))
+
+    assert "_AB16765A-B19E-4454-A58F-868D23C6CD26" in subject
+    assert "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" in predicate
+    assert "http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchInfo" in object


### PR DESCRIPTION
pathlib was added to the standard librarly as of Python 3.4.
This adds support for calling Graph.parse on a file specified
using a pathlib object.


## Proposed Changes

  -  if the source is specified as a Path object or subtype, call str on it
  - `pathlib` objects implement __str__  precisely for this purpose: https://docs.python.org/3/library/pathlib.html
 