### PR TITLE
Fix usage of default-graph for POST and introduce POST_FORM

### DIFF
--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -65,7 +65,7 @@ class SPARQLConnector(object):
     @method.setter
     def method(self, method):
         if method not in ("GET", "POST", "POST_FORM"):
-            raise SPARQLConnectorException('Method must be "GET", "POST", "POST_FORM"')
+            raise SPARQLConnectorException('Method must be "GET", "POST", or "POST_FORM"')
 
         self._method = method
 


### PR DESCRIPTION
Fixes issue of POST requests in combination with default-graph as introduced in #1022 and #1175.

## Proposed Changes

  - Introduce method `POST_FORM` besides `POST` to let the user control whether to use query via URL-encoded POST or query via POST directly as per the SPARQL 1.1 Protocol for query operations (https://www.w3.org/TR/sparql11-protocol/#query-operation)
  - Set the default-graph parameters accordingly
 
## Test
A unit test is still needed for this behavior.

I have written the following test case (also committed here: https://github.com/white-gecko/rdflib/tree/fix_sparqlstore_post_sketchtest), but it requires a context aware SPARQL endpoint at http://localhost:5000/sparql with the following data loaded. This can be achieved on a local setup with a QuitStore or maybe also Virtuoso. Unfortunately the fuseki included is not context aware afaik.

```turtle
graph <http://example.org/> {
    <http://example.org/ExampleInstance> a <http://example.org/Example>
}
graph <http://othergraph.org/> {
    <http://example.org/OtherInstance> a <http://example.org/Example>
}
```

```python
class SPARQLStoreQuitStoreTestCase(unittest.TestCase):
    store_name = "SPARQLStore"
    path = "http://localhost:5000/sparql"
    create = False

    def test_query_via_get(self):
        store = SPARQLStore(query_endpoint=self.path, method="GET")
        self.execute_query_with_store(store)

    def test_query_via_post(self):
        store = SPARQLStore(query_endpoint=self.path, method="POST")
        self.execute_query_with_store(store)

    def test_query_via_post_form(self):
        store = SPARQLStore(query_endpoint=self.path, method="POST_FORM")
        self.execute_query_with_store(store)

    def execute_query_with_store(self, store):
        conjunctivegraph = ConjunctiveGraph(store=store)
        graph = conjunctivegraph.get_context(URIRef("http://example.org/"))
        query = "select distinct ?inst where {?inst a <http://example.org/Example>}"
        res = graph.query(query, initNs={})
        assert len(res) == 1
        for i in res:
            assert type(i[0]) == URIRef, i[0].n3()
            assert i[0] == URIRef("http://example.org/ExampleInstance"), i[0].n3()
```