### PR TITLE
Remove the usage of assert in the SPARQLConnector

### DIFF
--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -52,8 +52,10 @@ class SPARQLConnector(object):
         self.kwargs = kwargs
         self.method = method
         if auth is not None:
-            assert type(auth) == tuple, "auth must be a tuple"
-            assert len(auth) == 2, "auth must be a tuple (user, password)"
+            if type(auth) != tuple:
+                raise SPARQLConnectorException("auth must be a tuple")
+            if len(auth) != 2:
+                raise SPARQLConnectorException("auth must be a tuple (user, password)")
             base64string = base64.b64encode(bytes('%s:%s' % auth, 'ascii'))
             self.kwargs.setdefault("headers", {})
             self.kwargs["headers"].update({"Authorization": "Basic %s" % base64string.decode('utf-8')})


### PR DESCRIPTION
Fixes the usage of `assert` as introduced in #1175 in the SPARQLConnector.

## Proposed Changes

In my eyes it is no good practice to have assert in production code, so it should not be in a library.
The Python reference states:

> The current code generator emits no code for an assert statement when optimization is requested at compile time.
> https://docs.python.org/3/reference/simple_stmts.html#assert

So I think it should be replaced by if and raise an exception.

There are many more usages of `assert` which should be replaced at some point as well.