### PR TITLE
optimize sparql.Bindings

### DIFF
--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -52,12 +52,12 @@ class Bindings(MutableMapping):
         self.outer = outer
 
     def __getitem__(self, key):
-        try:
+        if key in self._d:
             return self._d[key]
-        except KeyError:
-            if not self.outer:
-                raise
-            return self.outer[key]
+        
+        if not self.outer:
+            raise KeyError()
+        return self.outer[key]
 
     def __contains__(self, key):
         try:
@@ -72,17 +72,18 @@ class Bindings(MutableMapping):
     def __delitem__(self, key):
         raise Exception("DelItem is not implemented!")
 
-    def __len__(self):
+    def __len__(self) -> int:
         i = 0
-        for x in self:
-            i += 1
+        d = self
+        while d is not None:
+            i += len(d._d)
+            d = d.outer
         return i
 
     def __iter__(self):
         d = self
         while d is not None:
-            for i in dict.__iter__(d._d):
-                yield i
+            yield from d._d
             d = d.outer
 
     def __str__(self):

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -1,3 +1,4 @@
+from rdflib.plugins.sparql import sparql
 from rdflib import Graph, URIRef, Literal, BNode
 from rdflib.plugins.sparql import prepareQuery
 from rdflib.compare import isomorphic
@@ -110,6 +111,24 @@ def test_sparql_update_with_bnode_serialize_parse():
     except Exception as e:
         raised = True
     assert not raised
+
+
+def test_bindings():
+    layer_0 = sparql.Bindings(d={"v": 1, "bar": 2})
+    layer_1 = sparql.Bindings(outer=layer_0, d={"v": 3})
+
+
+    assert layer_0["v"] == 1
+    assert layer_1["v"] == 3
+    assert layer_1["bar"] == 2
+
+    assert "foo" not in layer_0
+    assert "v" in layer_0
+    assert "bar" in layer_1
+
+    # XXX This might not be intendet behaviour
+    #     but is kept for compatibility for now.
+    assert len(layer_1) == 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This improves performance 13% on the rdflib-benchmark with the default (memory) store and a store size of 4k.

Moving straight to `collections.ChainMap` was considered but 
1) `Bindings` behaves differently when one key is in multiple dicts, as they are iterated over multiple times and also counted on `__len__` multiple times
2) The API is a bit different, increasing the changes size

I do think that the differences for `__len__` and `__iter__` are unintentional / bugs. If so, I would rework this MR to fix those.