### PR TITLE
do not use current time in sparql TIMEZONE

### DIFF
--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -492,7 +492,7 @@ def Builtin_TIMEZONE(e, ctx):
     if not dt.tzinfo:
         raise SPARQLError("datatime has no timezone: %r" % dt)
 
-    delta = dt.tzinfo.utcoffset(ctx.now)
+    delta = dt.utcoffset()
 
     d = delta.days
     s = delta.seconds

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -223,7 +223,6 @@ class FrozenBindings(FrozenDict):
 
 
 class QueryContext(object):
-
     """
     Query context - passed along when evaluating the query
     """
@@ -245,9 +244,15 @@ class QueryContext(object):
             self.graph = graph
 
         self.prologue = None
-        self.now = datetime.datetime.now(isodate.tzinfo.UTC)
+        self._now = None
 
         self.bnodes = collections.defaultdict(BNode)
+
+    @property
+    def now(self) -> datetime.datetime:
+        if self._now is None:
+            self._now = datetime.datetime.now(isodate.tzinfo.UTC)
+        return self._now
 
     def clone(self, bindings=None):
         r = QueryContext(


### PR DESCRIPTION
Calculating the timezone should use date date and time from the
datetime object the timezone is requested from instead from the
current time. This makes a difference if the timezone for the given
location has changed in the past. In this particular case it is probably
not possible as iso 8601 seems not have a method to specify the
time zone via a location.
Therefore this cleans up unnecessary code and removing the
call to now in every sparql context creation gives a nice
performance increase.

Speedup varies depending on benchmark between 3% and 12%

(To be honest I am surprised myself with those 12% but could reproduce the result)