### PR TITLE
Reset graph on exit from context

### DIFF
--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -187,6 +187,7 @@ def evalGraph(ctx, part):
 
     ctx = ctx.clone()
     graph = ctx[part.term]
+    prev_graph = ctx.graph
     if graph is None:
 
         for graph in ctx.dataset.contexts():
@@ -199,11 +200,13 @@ def evalGraph(ctx, part):
             c = c.push()
             graphSolution = [{part.term: graph.identifier}]
             for x in _join(evalPart(c, part.p), graphSolution):
+                x.ctx.graph = prev_graph
                 yield x
 
     else:
         c = ctx.pushGraph(ctx.dataset.get_context(graph))
         for x in evalPart(c, part.p):
+            x.ctx.graph = prev_graph
             yield x
 
 

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -120,27 +120,27 @@ def test_named_filter_graph_query():
     ex = Namespace('https://ex.com/')
     g.namespace_manager.bind('ex', ex)
     g.get_context(ex.g1).parse(format="turtle", data=f"""
-    prefix ex: <https://ex.com/>
-    prefix rdfs: <{str(RDFS)}>
+    PREFIX ex: <{str(ex)}>
+    PREFIX rdfs: <{str(RDFS)}>
     ex:Boris rdfs:label "Boris" .
     ex:Susan rdfs:label "Susan" .
     """)
-    g.get_context(ex.g2).parse(format="turtle", data="""
-    prefix ex: <https://ex.com/>
+    g.get_context(ex.g2).parse(format="turtle", data=f"""
+    PREFIX ex: <{str(ex)}>
     ex:Boris a ex:Person .
     """)
 
-    assert list(g.query("select ?l where { graph ex:g1 { ?a rdfs:label ?l } ?a a ?type }",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ex:g1 { ?a rdfs:label ?l } ?a a ?type }",
                         initNs={'ex': ex})) == [(Literal('Boris'),)]
-    assert list(g.query("select ?l where { graph ex:g1 { ?a rdfs:label ?l } filter exists { ?a a ?type }}",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ex:g1 { ?a rdfs:label ?l } FILTER EXISTS { ?a a ?type }}",
                         initNs={'ex': ex})) == [(Literal('Boris'),)]
-    assert list(g.query("select ?l where { graph ex:g1 { ?a rdfs:label ?l } filter not exists { ?a a ?type }}",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ex:g1 { ?a rdfs:label ?l } FILTER NOT EXISTS { ?a a ?type }}",
                         initNs={'ex': ex})) == [(Literal('Susan'),)]
-    assert list(g.query("select ?l where { graph ?g { ?a rdfs:label ?l } ?a a ?type }",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ?g { ?a rdfs:label ?l } ?a a ?type }",
                         initNs={'ex': ex})) == [(Literal('Boris'),)]
-    assert list(g.query("select ?l where { graph ?g { ?a rdfs:label ?l } filter exists { ?a a ?type }}",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ?g { ?a rdfs:label ?l } FILTER EXISTS { ?a a ?type }}",
                         initNs={'ex': ex})) == [(Literal('Boris'),)]
-    assert list(g.query("select ?l where { graph ?g { ?a rdfs:label ?l } filter not exists { ?a a ?type }}",
+    assert list(g.query("SELECT ?l WHERE { GRAPH ?g { ?a rdfs:label ?l } FILTER NOT EXISTS { ?a a ?type }}",
                         initNs={'ex': ex})) == [(Literal('Susan'),)]
 
 


### PR DESCRIPTION
Fixes #1205

## Proposed Changes

  - After the body of the `GRAPH` clause is evaluated, restore the context graph value before returning the result. 
  - Tested both fixed and variable graph specifications for coverage.
