### PR TITLE
rd2dot Escape HTML in node label and URI text

### DIFF
--- a/rdflib/tools/rdf2dot.py
+++ b/rdflib/tools/rdf2dot.py
@@ -153,7 +153,7 @@ def rdf2dot(g, stream, opts={}):
             + "<font point-size='10' color='#6666ff'>%s</font></td>"
             + "</tr>%s</table> > ] \n"
         )
-        stream.write(opstr % (n, NODECOLOR, label(u, g), u, u, "".join(f)))
+        stream.write(opstr % (n, NODECOLOR, html.escape(label(u, g)), u, html.escape(u), "".join(f)))
 
     stream.write("}\n")
 


### PR DESCRIPTION
Fixes #1208 

## Proposed Changes
 - escapes HTML in the node label
 - escapes HTML in the URI text
