### PR TITLE
Add documentation and type hints for rdflib.query.Result and rdflib.graph.Graph

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1130,13 +1130,13 @@ class Graph(Node):
     def query(
         self,
         query_object,
-        processor="sparql",
-        result="sparql",
+        processor: str = "sparql",
+        result: str = "sparql",
         initNs=None,
         initBindings=None,
-        use_store_provided=True,
+        use_store_provided: bool = True,
         **kwargs
-    ):
+    ) -> query.Result:
         """
         Query this graph.
 
@@ -1147,7 +1147,7 @@ class Graph(Node):
         if none are given, the namespaces from the graph's namespace manager
         are used.
 
-        :returntype: rdflib.query.QueryResult
+        :returntype: rdflib.query.Result
 
         """
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import warnings
 import types
+from typing import Optional
 
 from io import BytesIO
 
@@ -205,8 +206,29 @@ class Result(object):
 
         return parser.parse(source, content_type=content_type, **kwargs)
 
-    def serialize(self, destination=None, encoding="utf-8", format="xml", **args):
+    def serialize(
+            self,
+            destination: Optional[str] = None,
+            encoding: str = "utf-8",
+            format: str = "xml",
+            **args,
+    ) -> Optional[bytes]:
+        """
+        Serialize the query result.
 
+        The :code:`format` argument determines the Serializer class to use.
+
+        - csv: :class:`~rdflib.plugins.sparql.results.csvresults.CSVResultSerializer`
+        - json: :class:`~rdflib.plugins.sparql.results.jsonresults.JSONResultSerializer`
+        - txt: :class:`~rdflib.plugins.sparql.results.txtresults.TXTResultSerializer`
+        - xml: :class:`~rdflib.plugins.sparql.results.xmlresults.XMLResultSerializer`
+
+        :param destination: Path of file output.
+        :param encoding: Encoding of output.
+        :param format: One of ['csv', 'json', 'txt', xml']
+        :param args:
+        :return: bytes
+        """
         if self.type in ("CONSTRUCT", "DESCRIBE"):
             return self.graph.serialize(
                 destination, encoding=encoding, format=format, **args


### PR DESCRIPTION
## Add documentation and type hints for `rdflib.query.Result`. Update documentation and type hints for `rdflib.graph.Graph`.

I am keen to work on adding documentation and type hints to rdflib. `rdflib.query.Result`'s `serialize()` is an example of this work. 
Please leave any comments on styling and conventions. 

## Proposed Changes

 - Progressively update documentation and add type hints everywhere
 - Remove sphinx-style documentation such as parameter and return types and update with newer Python type hints.

For the second point, an example would be to remove https://github.com/RDFLib/rdflib/blob/c5ff12717c02cf21abc8dd00ed8f0ec27071ba5d/rdflib/graph.py#L1150 and replace it with using python type hints. 

E.g. 
```python3
def query(
        self,
        ...
        **kwargs
    ) -> query.Result:
```
Sphinx also understands this and adds hyperlinks automatically as well.

If this is acceptable, we should draft a guideline on adding/updating documentation and type hints to the rdflib codebase.