### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 # http://travis-ci.org/#!/RDFLib/rdflib
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: python
 branches:
   only:


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 
