### PR TITLE
support headers in SPARQLConnector, allow urlencoding and take care of long uri's in commit

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -589,7 +589,26 @@ class SPARQLUpdateStore(SPARQLStore):
             and reads can degenerate to the original call-per-triple situation that originally existed.
         """
         if self._edits and len(self._edits) > 0:
-            self._update("\n;\n".join(self._edits))
+
+            edits = "\n;\n".join(self._edits)
+            if self.postAsEncoded:
+                if len(edits) > 2000:
+                    edits = ''
+                    for edit in self._edits:
+                        edits += edit + '\n;\n'
+                        if len(edits) > 2000:
+                            edits = edits[0:len(edits)-len(edit + '\n;\n')]
+                            if len(edits) > 2000:
+                                raise Exception("Triple/Quad is too long to be convertion to an URI")#or continue and silently return error?
+                            self._update(edits)
+                            edits = ''
+                else:
+                    self._update(edits)
+
+            else:
+
+                self._update(edits)
+
             self._edits = None
 
     def rollback(self):


### PR DESCRIPTION
This is just something that came up while working with rdflib and the blazegraph db. 

Currently any header that is set in the init is overwritten in the code. Simple checks whether there are headers in the `self.kwargs` prevents them from being overwritten with the default ones. In addition rdflib sets the `postAsEncoded` argument but never uses it anywhere. I modified the SPARQLConnector so that updates can be POSTed via urlencoded uri's. A drawback is that the commit method must take care of too long uris and split the commit into several pieces.

Maybe these changes are redundant in sense that the maintainers choose to do updates differently(this seemed fixed https://github.com/RDFLib/rdflib/pull/315 and talked about here https://github.com/RDFLib/rdflib/pull/1175), but maybe its worth a discussion, again - if not just ignore this PR.
