### PR TITLE
Adding Namespace.__contains__()

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -112,7 +112,11 @@ class Namespace(str):
     rdflib.term.URIRef(u'http://example.org/Person')
     >>> n['first-name'] # as item - for things that are not valid python identifiers
     rdflib.term.URIRef(u'http://example.org/first-name')
-
+    >>> n.Person in n
+    True
+    >>> n2 = Namespace("http://example2.org/")
+    >>> n.Person in n2
+    False
     """
 
     def __new__(cls, value):
@@ -141,6 +145,9 @@ class Namespace(str):
 
     def __repr__(self):
         return "Namespace(%r)" % str(self)
+    
+    def __contains__(self, other):
+        return other.startswith(self) # test namespace membership with "ref in ns" syntax
 
 
 class URIPattern(str):

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,8 +1,7 @@
-from rdflib.rdflib.namespace import Namespace
 import unittest
 
 from rdflib.graph import Graph
-from rdflib.namespace import FOAF, RDF, RDFS, SH
+from rdflib.namespace import Namespace, FOAF, RDF, RDFS, SH
 from rdflib.term import URIRef
 
 

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,7 +1,8 @@
+from rdflib.rdflib.namespace import Namespace
 import unittest
 
 from rdflib.graph import Graph
-from rdflib.namespace import FOAF
+from rdflib.namespace import FOAF, RDF, RDFS, SH
 from rdflib.term import URIRef
 
 
@@ -112,3 +113,18 @@ class NamespacePrefixTest(unittest.TestCase):
             add_not_in_namespace("givenName"),
             URIRef("http://xmlns.com/foaf/0.1/givenName"),
         )
+
+    def test_contains_method(self):
+        """Tests for Namespace.__contains__() methods."""
+
+        ref = URIRef('http://www.w3.org/ns/shacl#example')
+        self.assertTrue(type(SH) == Namespace, "SH no longer a Namespace, update test.")
+        self.assertTrue(ref in SH, "sh:example not in SH")
+
+        ref = URIRef('http://www.w3.org/2000/01/rdf-schema#label')
+        self.assertTrue(ref in RDFS, "ClosedNamespace(RDFS) does not include rdfs:label")
+        ref = URIRef('http://www.w3.org/2000/01/rdf-schema#example')
+        self.assertFalse(ref in RDFS, "ClosedNamespace(RDFS) includes out-of-ns member rdfs:example")
+
+        ref = URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+        self.assertTrue(ref in RDF, "_RDFNamespace does not include rdf:type")


### PR DESCRIPTION
No issue for this, just a quick addition for usability/literacy while working with the library.

## Proposed Changes

  - Adds a `Namespace.__contains__()` method to enable syntax sugar of `ref in ns`. This is a natural way to discover if an arbitrary `URIRef` is in the `Namespace`.
  - Current method would be manually writing `ref.startswith(ns)`, which doesn't preserve semantics

This has possible extension to `NamespaceManager`, testing if a `URIRef` is in any managed namespace.

```
class NamespaceManager():
    def __contians__(self, ref):
        return any(ref.startswith(ns) for x, ns in self.namespaces())
```

Note that in `NamespaceManager`, namespaces are stored as `URIRef`s, not `Namespace` objects :/

Hoping this starts a discussion about some usability concerns.