### PR TITLE
Update SPARQL tests since the DBpedia was updated

### DIFF
--- a/test/test_sparql_service.py
+++ b/test/test_sparql_service.py
@@ -7,18 +7,20 @@ from . import helper
 
 def test_service():
     g = Graph()
-    q = """select ?dbpHypernym ?dbpComment
+    q = """select ?sameAs ?dbpComment
     where
     { service <http://DBpedia.org/sparql>
     { select ?dbpHypernym ?dbpComment
     where
     {
     <http://dbpedia.org/resource/John_Lilburne>
-        <http://purl.org/linguistics/gold/hypernym> ?dbpHypernym ;
+        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
         <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment .
 
     } }  } limit 2"""
     results = helper.query_with_retry(g, q)
+    print(results.vars)
+    print(results.bindings)
     assert len(results) == 2
 
     for r in results:
@@ -27,17 +29,17 @@ def test_service():
 
 def test_service_with_bind():
     g = Graph()
-    q = """select ?dbpHypernym ?dbpComment ?dbpDeathPlace
+    q = """select ?sameAs ?dbpComment ?subject
     where
-    { bind (<http://dbpedia.org/resource/Eltham> as ?dbpDeathPlace)
+    { bind (<http://dbpedia.org/resource/Category:1614_births> as ?subject)
       service <http://DBpedia.org/sparql>
-    { select ?dbpHypernym ?dbpComment ?dbpDeathPlace
+    { select ?sameAs ?dbpComment ?subject
     where
     {
     <http://dbpedia.org/resource/John_Lilburne>
-        <http://purl.org/linguistics/gold/hypernym> ?dbpHypernym ;
+        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
         <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment ;
-        <http://dbpedia.org/ontology/deathPlace> ?dbpDeathPlace .
+        <http://purl.org/dc/terms/subject> ?subject .
 
     } }  } limit 2"""
     results = helper.query_with_retry(g, q)
@@ -49,17 +51,17 @@ def test_service_with_bind():
 
 def test_service_with_values():
     g = Graph()
-    q = """select ?dbpHypernym ?dbpComment ?dbpDeathPlace
+    q = """select ?sameAs ?dbpComment ?subject
     where
-    { values (?dbpHypernym ?dbpDeathPlace) {(<http://dbpedia.org/resource/Leveller> <http://dbpedia.org/resource/London>) (<http://dbpedia.org/resource/Leveller> <http://dbpedia.org/resource/Eltham>)}
+    { values (?sameAs ?subject) {(<http://de.dbpedia.org/resource/John_Lilburne> <http://dbpedia.org/resource/Category:1614_births>) (<https://global.dbpedia.org/id/4t6Fk> <http://dbpedia.org/resource/Category:Levellers>)}
       service <http://DBpedia.org/sparql>
-    { select ?dbpHypernym ?dbpComment ?dbpDeathPlace
+    { select ?sameAs ?dbpComment ?subject
     where
     {
     <http://dbpedia.org/resource/John_Lilburne>
-        <http://purl.org/linguistics/gold/hypernym> ?dbpHypernym ;
+        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
         <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment ;
-        <http://dbpedia.org/ontology/deathPlace> ?dbpDeathPlace .
+        <http://purl.org/dc/terms/subject> ?subject .
 
     } }  } limit 2"""
     results = helper.query_with_retry(g, q)
@@ -126,7 +128,7 @@ def test_service_with_implicit_select_and_allcaps():
     {
       SERVICE <http://dbpedia.org/sparql>
       {
-        ?s <http://purl.org/linguistics/gold/hypernym> <http://dbpedia.org/resource/Leveller> .
+        ?s <http://www.w3.org/2002/07/owl#sameAs> ?sameAs .
       }
     } LIMIT 3"""
     results = helper.query_with_retry(g, q)


### PR DESCRIPTION
Fixes #1229.

## Proposed Changes

  - Update the queries. The DBpedia was updated and some triples do not exist anymore as they were used in the test.
