### PR TITLE
Add a Drone config file.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,60 @@
+---
+kind: pipeline
+name: python-3-6
+type: docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: python:3.6
+  commands:
+  - pip install -U setuptools pip
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - pip install --default-timeout 60 coverage coveralls nose-timer && export HAS_COVERALLS=1
+  - python setup.py install
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib
+
+---
+kind: pipeline
+name: python-3-7
+type: docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: python:3.7
+  commands:
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - pip install --default-timeout 60 coverage coveralls nose-timer && export HAS_COVERALLS=1
+  - python setup.py install
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib
+
+---
+kind: pipeline
+name: python-3-8
+type: docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: python:3.8
+  commands:
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - pip install --default-timeout 60 coverage coveralls nose-timer && export HAS_COVERALLS=1
+  - python setup.py install
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42 --with-coverage --cover-tests --cover-package=rdflib


### PR DESCRIPTION
Replaces #1246
Unfortunately the code duplication is required in this case. Drone doesn't have quite as sophisticated matrix runner functionality that Travis has. See here: https://docs.drone.io/pipeline/docker/examples/languages/python/
We could parametrically create the runners using a jsonnet file (as shown at the bottom of that example page) but I wanted to keep it all in the .yml file if possible.