### PR TITLE
Changed to support passing fully qualified queries through the graph …

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -167,7 +167,7 @@ class SPARQLStore(SPARQLConnector, Store):
         self.debug = DEBUG
         assert isinstance(query, str)
 
-        if initNs is not None:
+        if initNs is not None and len(initNs) > 0:
             query = self._inject_prefixes(query, initNs)
 
         if initBindings:

--- a/test/test_sparqlstore.py
+++ b/test/test_sparqlstore.py
@@ -67,6 +67,19 @@ class SPARQLStoreDBPediaTestCase(unittest.TestCase):
         for i in res:
             assert type(i[0]) == Literal, i[0].n3()
 
+    def test_query_with_added_rdf_prolog(self):
+        prologue = """\
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX xyzzy: <http://www.w3.org/2004/02/skos/core#>
+        """
+        query = """\
+        SELECT ?label WHERE
+            { ?s a xyzzy:Concept ; xyzzy:prefLabel ?label . } LIMIT 10
+        """
+        res = helper.query_with_retry(self.graph, prologue + query)
+        for i in res:
+            assert type(i[0]) == Literal, i[0].n3()
+
     def test_counting_graph_and_store_queries(self):
         query = """
             SELECT ?s


### PR DESCRIPTION
…and store by passing empty initNs dict.

Fixes #1252

## Proposed Changes

  - Only inject store prefixes if the initNs dict is non-empty.