### PR TITLE
Speedup __add_triple_context.

### DIFF
--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -477,7 +477,7 @@ class Memory(Store):
             self.__defaultContexts = triple_context
         # if the context info is the same as default, no need to store it
         if triple_context == self.__defaultContexts:
-            del triple_context
+            del self.__tripleContexts[triple]
 
     def __get_context_for_triple(self, triple, skipQuoted=False):
         """return a list of contexts (str) for the triple, skipping

--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -446,7 +446,7 @@ class Memory(Store):
             # we know the triple exists somewhere in the store
             try:
                 triple_context = self.__tripleContexts[triple]
-            except IndexError:
+            except KeyError:
                 # triple exists with default ctx info
                 # start with a copy of the default ctx info
                 triple_context = self.__tripleContexts[triple] = self.__defaultContexts.copy()

--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -444,20 +444,24 @@ class Memory(Store):
             subj, pred, obj = triple
             _ = self.__spo[subj][pred][obj]
             # we know the triple exists somewhere in the store
-            if triple not in self.__tripleContexts:
+            try:
+                triple_context = self.__tripleContexts[triple]
+            except IndexError:
                 # triple exists with default ctx info
                 # start with a copy of the default ctx info
-                self.__tripleContexts[triple] = self.__defaultContexts.copy()
+                triple_context = self.__tripleContexts[triple] = self.__defaultContexts.copy()
 
-            self.__tripleContexts[triple][ctx] = quoted
+            triple_context[ctx] = quoted
+
             if not quoted:
-                self.__tripleContexts[triple][None] = quoted
+                triple_context[None] = quoted
+
         except KeyError:
             # the triple didn't exist before in the store
             if quoted:  # this context only
-                self.__tripleContexts[triple] = {ctx: quoted}
+                triple_context = self.__tripleContexts[triple] = {ctx: quoted}
             else:  # default context as well
-                self.__tripleContexts[triple] = {ctx: quoted, None: quoted}
+                triple_context = self.__tripleContexts[triple] = {ctx: quoted, None: quoted}
 
         # if the triple is not quoted add it to the default context
         if not quoted:
@@ -470,11 +474,10 @@ class Memory(Store):
 
         # if this is the first ever triple in the store, set default ctx info
         if self.__defaultContexts is None:
-            self.__defaultContexts = self.__tripleContexts[triple]
-
+            self.__defaultContexts = triple_context
         # if the context info is the same as default, no need to store it
-        if self.__tripleContexts[triple] == self.__defaultContexts:
-            del self.__tripleContexts[triple]
+        if triple_context == self.__defaultContexts:
+            del triple_context
 
     def __get_context_for_triple(self, triple, skipQuoted=False):
         """return a list of contexts (str) for the triple, skipping


### PR DESCRIPTION
Related to #1261.

(cherry picked from commit 85e1cfee04e8f9c590171379f57c751e0d5b9828)

This eliminates between two and five lookups in the container self.__tripleContexts (depending on the execution) by storing  its reference in the variable triple_context = self.__tripleContexts[triple], and reusing it.

