### PR TITLE
Correct behaviour of compute_qname for URNs

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -897,7 +897,7 @@ class NamespaceManager(object):
 NAME_START_CATEGORIES = ["Ll", "Lu", "Lo", "Lt", "Nl"]
 SPLIT_START_CATEGORIES = NAME_START_CATEGORIES + ["Nd"]
 NAME_CATEGORIES = NAME_START_CATEGORIES + ["Mc", "Me", "Mn", "Lm", "Nd"]
-ALLOWED_NAME_CHARS = ["\u00B7", "\u0387", "-", ".", "_", ":", "%"]
+ALLOWED_NAME_CHARS = ["\u00B7", "\u0387", "-", ".", "_", "%"]
 
 
 # http://www.w3.org/TR/REC-xml-names/#NT-NCName
@@ -914,7 +914,7 @@ def is_ncname(name):
             for i in range(1, len(name)):
                 c = name[i]
                 if not category(c) in NAME_CATEGORIES:
-                    if c != ":" and c in ALLOWED_NAME_CHARS:
+                    if c in ALLOWED_NAME_CHARS:
                         continue
                     return 0
                 # if in compatibility area

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -31,6 +31,15 @@ class NamespacePrefixTest(unittest.TestCase):
             g.compute_qname(URIRef("http://foo/bar/")),
             ("ns1", URIRef("http://foo/bar/"), ""),
         )
+        # should compute qnames of URNs correctly as well
+        self.assertEqual(
+            g.compute_qname(URIRef("urn:ISSN:0167-6423")),
+            ("ns5", URIRef("urn:ISSN:"), "0167-6423"),
+        )
+        self.assertEqual(
+            g.compute_qname(URIRef("urn:ISSN:")),
+            ("ns5", URIRef("urn:ISSN:"), ""),
+        )
 
     def test_reset(self):
         data = (

--- a/test/test_turtle_serialize.py
+++ b/test/test_turtle_serialize.py
@@ -1,4 +1,4 @@
-from rdflib import Graph, URIRef, BNode, RDF, Literal, Namespace
+from rdflib import Graph, URIRef, BNode, RDF, RDFS, Literal, Namespace
 from rdflib.collection import Collection
 from rdflib.plugins.serializers.turtle import TurtleSerializer
 
@@ -80,11 +80,20 @@ def test_turtle_namespace():
     graph.bind("GENO", "http://purl.obolibrary.org/obo/GENO_")
     graph.bind("RO", "http://purl.obolibrary.org/obo/RO_")
     graph.bind("RO_has_phenotype", "http://purl.obolibrary.org/obo/RO_0002200")
+    graph.bind("SERIAL", "urn:ISSN:")
     graph.add(
         (
             URIRef("http://example.org"),
             URIRef("http://purl.obolibrary.org/obo/RO_0002200"),
             URIRef("http://purl.obolibrary.org/obo/GENO_0000385"),
+        )
+    )
+    graph.add(
+        (
+            URIRef("urn:ISSN:0167-6423"),
+            RDFS.label,
+            Literal("Science of Computer Programming"),
+
         )
     )
     output = [
@@ -95,6 +104,7 @@ def test_turtle_namespace():
     output = " ".join(output)
     assert "RO_has_phenotype:" in output
     assert "GENO:0000385" in output
+    assert "SERIAL:0167-6423" in output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: Allow URN qnames to be computed correcly by compute_qname
Removed colon from ALLOWED_NAME_CHARS, as having it included results in URN identifiers never being split by split_uri and thus no qname being computed by compute_qname for URNs.
I've also added some tests for correct behaviour of compute_qname for URNs and turtle serialization (where this issue surfaced initally, see the end of https://github.com/RDFLib/rdflib/issues/977)

