### PR TITLE
 Feature/forward version to 6.0.0-alpha

### DIFF
--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -45,8 +45,8 @@ A tiny example:
 __docformat__ = "restructuredtext en"
 
 # The format of the __version__ line is matched by a regex in setup.py
-__version__ = "5.0.0"
-__date__ = "2020-04-18"
+__version__ = "6.0.0-pre-alpha"
+__date__ = "2021-03-22"
 
 __all__ = [
     "URIRef",

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -45,7 +45,7 @@ A tiny example:
 __docformat__ = "restructuredtext en"
 
 # The format of the __version__ line is matched by a regex in setup.py
-__version__ = "6.0.0-pre-alpha"
+__version__ = "6.0.0-alpha"
 __date__ = "2021-03-22"
 
 __all__ = [


### PR DESCRIPTION
Replace #1284 

Proposed Changes

- Update the version string to allow installations from the git repo and let pip know, it is newer than the pypi release
- Will allow install with `pip install git+https://github.com/rdflib/rdflib@master` over a pypi installation
