### PR TITLE
Add pathlib.PurePath support for Graph.serialize and Graph.parse

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -19,6 +19,7 @@ from rdflib.exceptions import ParserError
 import os
 import shutil
 import tempfile
+import pathlib
 
 from io import BytesIO, BufferedIOBase
 from urllib.parse import urlparse
@@ -1065,7 +1066,10 @@ class Graph(Node):
             stream = cast(BufferedIOBase, destination)
             serializer.serialize(stream, base=base, encoding=encoding, **args)
         else:
-            location = cast(str, destination)
+            if isinstance(destination, pathlib.PurePath):
+                location = str(destination)
+            else:
+                location = cast(str, destination)
             scheme, netloc, path, params, _query, fragment = urlparse(location)
             if netloc != "":
                 print(

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -238,7 +238,7 @@ def create_input_source(
         else:
             if isinstance(source, str):
                 location = source
-            elif isinstance(source, pathlib.Path):
+            elif isinstance(source, pathlib.PurePath):
                 location = str(source)
             elif isinstance(source, bytes):
                 data = source

--- a/test/test_serialize.py
+++ b/test/test_serialize.py
@@ -1,0 +1,43 @@
+import unittest
+from rdflib import Graph, URIRef
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from pathlib import Path, PurePath
+
+
+class TestSerialize(unittest.TestCase):
+    def setUp(self) -> None:
+
+        graph = Graph()
+        subject = URIRef("example:subject")
+        predicate = URIRef("example:predicate")
+        object = URIRef("example:object")
+        self.triple = (
+            subject,
+            predicate,
+            object,
+        )
+        graph.add(self.triple)
+        self.graph = graph
+        return super().setUp()
+
+    def test_serialize_to_purepath(self):
+        with TemporaryDirectory() as td:
+            tfpath = PurePath(td) / "out.nt"
+            self.graph.serialize(destination=tfpath, format="nt")
+            graph_check = Graph()
+            graph_check.parse(source=tfpath, format="nt")
+
+        self.assertEqual(self.triple, next(iter(graph_check)))
+
+    def test_serialize_to_path(self):
+        with NamedTemporaryFile() as tf:
+            tfpath = Path(tf.name)
+            self.graph.serialize(destination=tfpath, format="nt")
+            graph_check = Graph()
+            graph_check.parse(source=tfpath, format="nt")
+
+        self.assertEqual(self.triple, next(iter(graph_check)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Graph.parse did already support `pathlib.Path` but there is no good reason to not support `pathlib.PurePath` AFAICT.

Fixes #1227

## Proposed Changes

  - Add `pathlib.PurePath` support to `Graph.serialize`
  - Change `pathlib.Path` check for `Graph.parse` to instead check for `pathlib.PurePath`
