### PR TITLE
Fix tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,15 +8,10 @@ setenv =
 commands =
     {envpython} setup.py clean --all
     {envpython} setup.py build
-    {envpython} run_tests.py --with-xunit
+    {envpython} run_tests.py
 deps =
-    nose
-    isodate
-    html5lib
-    pyparsing
-    bsddb3
-    six
-    SPARQLWrapper>=1.6.2
+	-r requirements.txt
+	-r requirements.dev.txt
 
 [testenv:cover]
 basepython =
@@ -25,12 +20,7 @@ commands =
     {envpython} run_tests.py --where=./ \
                  --with-coverage --cover-html --cover-html-dir=./coverage \
                  --cover-package=rdflib --cover-inclusive
+
 deps =
-    coverage
-    nose
-    isodate
-    html5lib
-    pyparsing
-    bsddb3
-    six
-    SPARQLWrapper>=1.6.2
+	-r requirements.txt
+	-r requirements.dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ commands =
     {envpython} setup.py build
     {envpython} run_tests.py
 deps =
-	-r requirements.txt
-	-r requirements.dev.txt
+	-rrequirements.txt
+	-rrequirements.dev.txt
 
 [testenv:cover]
 basepython =
@@ -22,5 +22,5 @@ commands =
                  --cover-package=rdflib --cover-inclusive
 
 deps =
-	-r requirements.txt
-	-r requirements.dev.txt
+	-rrequirements.txt
+	-rrequirements.dev.txt


### PR DESCRIPTION
The current tox config does not work as the dependencies are out of sync
and doctest has troubles with xunit.

This fixes it so that tox works again and makes it easier for other
people to contribute.

Fixes #1312

## Proposed Changes

  - Don't run tests with xunit
  - Use `requirements.txt` and `requirements.dev.txt` instead of duplicating requirements.
 

