### PR TITLE
Speedup Literal.__hash__ and Literal.__eq__ by accessing directly _da…

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -969,6 +969,7 @@ class Literal(Identifier):
         """
         # don't use super()... for efficiency reasons, see Identifier.__hash__
         res = str.__hash__(self)
+        # Directly accessing the member is faster than the property.
         if self._language:
             res ^= hash(self._language.lower())
         if self._datatype:
@@ -1015,6 +1016,7 @@ class Literal(Identifier):
             return True
         if other is None:
             return False
+        # Directly accessing the member is faster than the property.
         if isinstance(other, Literal):
             return (
                 self._datatype == other._datatype

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -969,10 +969,10 @@ class Literal(Identifier):
         """
         # don't use super()... for efficiency reasons, see Identifier.__hash__
         res = str.__hash__(self)
-        if self.language:
-            res ^= hash(self.language.lower())
-        if self.datatype:
-            res ^= hash(self.datatype)
+        if self._language:
+            res ^= hash(self._language.lower())
+        if self._datatype:
+            res ^= hash(self._datatype)
         return res
 
     def __eq__(self, other):
@@ -1017,9 +1017,9 @@ class Literal(Identifier):
             return False
         if isinstance(other, Literal):
             return (
-                self.datatype == other.datatype
-                and (self.language.lower() if self.language else None)
-                == (other.language.lower() if other.language else None)
+                self._datatype == other._datatype
+                and (self._language.lower() if self._language else None)
+                == (other._language.lower() if other._language else None)
                 and str.__eq__(self, other)
             )
 


### PR DESCRIPTION
Literal.__hash__ and Literal.__eq__ use self.datatype and self. language properties. It is faster to directly use the private members Literal._dataype and Literal.__language.

Test importing orkg.nt

Before:
![image](https://user-images.githubusercontent.com/2873024/118641304-e4d2cc00-b7d1-11eb-96e9-c15c8f71ed62.png)


After:
  -
![image](https://user-images.githubusercontent.com/2873024/118641869-9540d000-b7d2-11eb-8cd5-e3c66a66cd49.png)
