### PR TITLE
Implemented function translateAlgebra. This functions takes a SPARQL …

### DIFF
--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -807,6 +807,7 @@ def translateAlgebra(query_algebra: Query = None):
 
     :param query_algebra: An algebra returned by the function call algebra.translateQuery(parse_tree).
     :return: The query form generated from the SPARQL 1.1 algebra tree for select queries.
+
     """
 
     def overwrite(text):

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -28,6 +28,9 @@ from pyparsing import ParseResults
 
 # ---------------------------
 # Some convenience methods
+from rdflib.term import Identifier
+
+
 def OrderBy(p, expr):
     return CompValue("OrderBy", p=p, expr=expr)
 
@@ -793,6 +796,424 @@ def translateQuery(q, base=None, initNs=None):
     _traverseAgg(res, _addVars)
 
     return Query(prologue, res)
+
+
+class ExpressionNotCoveredException(Exception):
+    pass
+
+
+def translateAlgebra(query_algebra: Query = None):
+    """
+
+    :param query_algebra: An algebra returned by the function call algebra.translateQuery(parse_tree).
+    :return: The query form generated from the SPARQL 1.1 algebra tree for select queries.
+    """
+
+    def overwrite(text):
+        file = open("query.txt", "w+")
+        file.write(text)
+        file.close()
+
+    def replace(old, new, search_from_match: str = None, search_from_match_occurrence: int = None):
+        # Read in the file
+        with open('query.txt', 'r') as file:
+            filedata = file.read()
+
+        def find_nth(haystack, needle, n):
+            start = haystack.lower().find(needle)
+            while start >= 0 and n > 1:
+                start = haystack.lower().find(needle, start + len(needle))
+                n -= 1
+            return start
+
+        if search_from_match and search_from_match_occurrence:
+            position = find_nth(filedata, search_from_match, search_from_match_occurrence)
+            filedata_pre = filedata[:position]
+            filedata_post = filedata[position:].replace(old, new, 1)
+            filedata = filedata_pre + filedata_post
+        else:
+            filedata = filedata.replace(old, new, 1)
+
+        # Write the file out again
+        with open('query.txt', 'w') as file:
+            file.write(filedata)
+
+    def convert_node_arg(node_arg):
+        if isinstance(node_arg, Identifier):
+            return node_arg.n3()
+        elif isinstance(node_arg, CompValue):
+            return "{" + node_arg.name + "}"
+        elif isinstance(node_arg, Expr):
+            return "{" + node_arg.name + "}"
+        else:
+            raise ExpressionNotCoveredException(
+                "The expression {0} might not be covered yet.".format(node_arg))
+
+    def sparql_query_text(node):
+        """
+         https://www.w3.org/TR/sparql11-query/#sparqlSyntax
+
+        :param node:
+        :return:
+        """
+
+        if isinstance(node, CompValue):
+            # 18.2 Query Forms
+            if node.name == "SelectQuery":
+                overwrite("-*-SELECT-*- " + "{" + node.p.name + "}")
+
+            # 18.2 Graph Patterns
+            elif node.name == "BGP":
+                # Identifiers or Paths
+                triples = "".join(triple[0].n3() + " " + triple[1].n3() + " " + triple[2].n3() + "."
+                                  for triple in node.triples)
+                replace("{BGP}", triples)
+                # The dummy -*-SELECT-*- is placed during a SelectQuery or Multiset pattern in order to be able
+                # to match extended variables in a specific Select-clause (see "Extend" below)
+                replace("-*-SELECT-*-", "SELECT")
+                # If there is no "Group By" clause the placeholder will simply be deleted. Otherwise there will be
+                # no matching {GroupBy} placeholder because it has already been replaced by "group by variables"
+                replace("{GroupBy}", "")
+            elif node.name == "Join":
+                replace("{Join}", "{" + node.p1.name + "}{" + node.p2.name + "}")  #
+            elif node.name == "LeftJoin":
+                replace("{LeftJoin}", "{" + node.p1.name + "}OPTIONAL{{" + node.p2.name + "}}")
+            elif node.name == "Filter":
+                if isinstance(node.expr, CompValue):
+                    expr = node.expr.name
+                else:
+                    raise ExpressionNotCoveredException("This expression might not be covered yet.")
+                if node.p:
+                    if node.p.name == "AggregateJoin":
+                        replace("{Filter}", "{" + node.p.name + "}HAVING({" + expr + "})")
+                    else:
+                        replace("{Filter}", "{" + node.p.name + "}FILTER({" + expr + "})")
+                else:
+                    replace("{Filter}", "FILTER({" + expr + "})")
+
+            elif node.name == "Union":
+                replace("{Union}", "{{" + node.p1.name + "}}UNION{{" + node.p2.name + "}}")
+            elif node.name == "Graph":
+                expr = "GRAPH " + node.term.n3() + " {{" + node.p.name + "}}"
+                replace("{Graph}", expr)
+            elif node.name == "Extend":
+                query_string = open('query.txt', 'r').read().lower()
+                select_occurrences = query_string.count('-*-select-*-')
+                replace(node.var.n3(), "(" + convert_node_arg(node.expr) + " as " + node.var.n3() + ")",
+                        search_from_match='-*-select-*-', search_from_match_occurrence=select_occurrences)
+                replace("{Extend}", "{" + node.p.name + "}")
+            elif node.name == "Minus":
+                expr = "{" + node.p1.name + "}MINUS{{" + node.p2.name + "}}"
+                replace("{Minus}", expr)
+            elif node.name == "Group":
+                group_by_vars = []
+                if node.expr:
+                    for var in node.expr:
+                        if isinstance(var, Identifier):
+                            group_by_vars.append(var.n3())
+                        else:
+                            raise ExpressionNotCoveredException("This expression might not be covered yet.")
+                    replace("{Group}", "{" + node.p.name + "}")
+                    replace("{GroupBy}", "GROUP BY " + " ".join(group_by_vars) + " ")
+                else:
+                    replace("{Group}", "{" + node.p.name + "}")
+            elif node.name == "AggregateJoin":
+                replace("{AggregateJoin}", "{" + node.p.name + "}")
+                for agg_func in node.A:
+                    if isinstance(agg_func.res, Identifier):
+                        identifier = agg_func.res.n3()
+                    else:
+                        raise ExpressionNotCoveredException("This expression might not be covered yet.")
+                    agg_func_name = agg_func.name.split('_')[1]
+                    distinct = ""
+                    if agg_func.distinct:
+                        distinct = agg_func.distinct + " "
+                    if agg_func_name == 'GroupConcat':
+                        replace(identifier, "GROUP_CONCAT" + "(" + distinct
+                                + agg_func.vars.n3() + ";SEPARATOR=" + agg_func.separator.n3() + ")")
+                    else:
+                        replace(identifier, agg_func_name.upper() + "(" + distinct + agg_func.vars.n3() + ")")
+                    # For non-aggregated variables the aggregation function "sample" is automatically assigned.
+                    # However, we do not want to have "sample" wrapped around non-aggregated variables. That is
+                    # why we replace it. If "sample" is used on purpose it will not be replaced as the alias
+                    # must be different from the variable in this case.
+                    replace("(SAMPLE({0}) as {0})".format(convert_node_arg(agg_func.vars)),
+                            convert_node_arg(agg_func.vars))
+            elif node.name == "GroupGraphPatternSub":
+                replace("GroupGraphPatternSub", " ".join([convert_node_arg(pattern) for pattern in node.part]))
+            elif node.name == "TriplesBlock":
+                replace("{TriplesBlock}", "".join(triple[0].n3() + " " + triple[1].n3() + " " + triple[2].n3() + "."
+                                                   for triple in node.triples))
+
+            # 18.2 Solution modifiers
+            elif node.name == "ToList":
+                raise ExpressionNotCoveredException("This expression might not be covered yet.")
+            elif node.name == "OrderBy":
+                order_conditions = []
+                for c in node.expr:
+                    if isinstance(c.expr, Identifier):
+                        var = c.expr.n3()
+                        if c.order is not None:
+                            cond = var + "(" + c.order + ")"
+                        else:
+                            cond = var
+                        order_conditions.append(cond)
+                    else:
+                        raise ExpressionNotCoveredException("This expression might not be covered yet.")
+                replace("{OrderBy}", "{" + node.p.name + "}")
+                replace("{OrderConditions}", " ".join(order_conditions) + " ")
+            elif node.name == "Project":
+                project_variables = []
+                for var in node.PV:
+                    if isinstance(var, Identifier):
+                        project_variables.append(var.n3())
+                    else:
+                        raise ExpressionNotCoveredException("This expression might not be covered yet.")
+                order_by_pattern = ""
+                if node.p.name == "OrderBy":
+                    order_by_pattern = "ORDER BY {OrderConditions}"
+                replace("{Project}", " ".join(project_variables) + "{{" + node.p.name + "}}"
+                        + "{GroupBy}" + order_by_pattern)
+            elif node.name == "Distinct":
+                replace("{Distinct}", "DISTINCT {" + node.p.name + "}")
+            elif node.name == "Reduced":
+                replace("{Reduced}", "REDUCED {" + node.p.name + "}")
+            elif node.name == "Slice":
+                slice = "OFFSET " + str(node.start) + " LIMIT " + str(node.length)
+                replace("{Slice}", "{" + node.p.name + "}" + slice)
+            elif node.name == "ToMultiSet":
+                if node.p.name == "values":
+                    replace("{ToMultiSet}", "{{" + node.p.name + "}}")
+                else:
+                    replace("{ToMultiSet}", "{-*-SELECT-*- " + "{" + node.p.name + "}" + "}")
+
+            # 18.2 Property Path
+
+            # 17 Expressions and Testing Values
+            # # 17.3 Operator Mapping
+            elif node.name == "RelationalExpression":
+                expr = convert_node_arg(node.expr)
+                op = node.op
+                if isinstance(list, type(node.other)):
+                    other = "(" + ", ".join(convert_node_arg(expr) for expr in node.other) + ")"
+                else:
+                    other = convert_node_arg(node.other)
+                condition = "{left} {operator} {right}".format(left=expr, operator=op, right=other)
+                replace("{RelationalExpression}", condition)
+            elif node.name == "ConditionalAndExpression":
+                inner_nodes = " && ".join([convert_node_arg(expr) for expr in node.other])
+                replace("{ConditionalAndExpression}", convert_node_arg(node.expr) + " && " + inner_nodes)
+            elif node.name == "ConditionalOrExpression":
+                inner_nodes = " || ".join([convert_node_arg(expr) for expr in node.other])
+                replace("{ConditionalOrExpression}", "(" + convert_node_arg(node.expr) + " || " + inner_nodes + ")")
+            elif node.name == "MultiplicativeExpression":
+                left_side = convert_node_arg(node.expr)
+                multiplication = left_side
+                for i, operator in enumerate(node.op):
+                    multiplication += operator + " " + convert_node_arg(node.other[i]) + " "
+                replace("{MultiplicativeExpression}", multiplication)
+            elif node.name == "AdditiveExpression":
+                left_side = convert_node_arg(node.expr)
+                addition = left_side
+                for i, operator in enumerate(node.op):
+                    addition += operator + " " + convert_node_arg(node.other[i]) + " "
+                replace("{AdditiveExpression}", addition)
+            elif node.name == "UnaryNot":
+                replace("{UnaryNot}", "!" + convert_node_arg(node.expr))
+
+            # # 17.4 Function Definitions
+            # # # 17.4.1 Functional Forms
+            elif node.name.endswith('BOUND'):
+                bound_var = convert_node_arg(node.arg)
+                replace("{Builtin_BOUND}", "bound(" + bound_var + ")")
+            elif node.name.endswith('IF'):
+                arg2 = convert_node_arg(node.arg2)
+                arg3 = convert_node_arg(node.arg3)
+
+                if_expression = "IF(" + "{" + node.arg1.name + "}, " + arg2 + ", " + arg3 + ")"
+                replace("{Builtin_IF}", if_expression)
+            elif node.name.endswith('COALESCE'):
+                replace("{Builtin_COALESCE}", "COALESCE(" + ", ".join(convert_node_arg(arg) for arg in node.arg) + ")")
+            elif node.name.endswith('Builtin_EXISTS'):
+                # The node's name which we get with node.graph.name returns "Join" instead of GroupGraphPatternSub
+                # According to https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rExistsFunc
+                # ExistsFunc can only have a GroupGraphPattern as parameter. However, when we print the query algebra
+                # we get a GroupGraphPatternSub
+                replace("{Builtin_EXISTS}", "EXISTS " + "{{" + node.graph.name + "}}")
+                traverse(node.graph, visitPre=sparql_query_text)
+                return node.graph
+            elif node.name.endswith('Builtin_NOTEXISTS'):
+                # The node's name which we get with node.graph.name returns "Join" instead of GroupGraphPatternSub
+                # According to https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rNotExistsFunc
+                # NotExistsFunc can only have a GroupGraphPattern as parameter. However, when we print the query algebra
+                # we get a GroupGraphPatternSub
+                replace("{Builtin_NOTEXISTS}", "NOT EXISTS " + "{{" + node.graph.name + "}}")
+                traverse(node.graph, visitPre=sparql_query_text)
+                return node.graph
+            # # # # 17.4.1.5 logical-or: Covered in "RelationalExpression"
+            # # # # 17.4.1.6 logical-and: Covered in "RelationalExpression"
+            # # # # 17.4.1.7 RDFterm-equal: Covered in "RelationalExpression"
+            elif node.name.endswith('sameTerm'):
+                replace("{Builtin_sameTerm}", "SAMETERM(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            # # # # IN: Covered in "RelationalExpression"
+            # # # # NOT IN: Covered in "RelationalExpression"
+
+            # # # 17.4.2 Functions on RDF Terms
+            elif node.name.endswith('Builtin_isIRI'):
+                replace("{Builtin_isIRI}", "isIRI(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_isBLANK'):
+                replace("{Builtin_isBLANK}", "isBLANK(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_isLITERAL'):
+                replace("{Builtin_isLITERAL}", "isLITERAL(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_isNUMERIC'):
+                replace("{Builtin_isNUMERIC}", "isNUMERIC(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_STR'):
+                replace("{Builtin_STR}", "STR(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_LANG'):
+                replace("{Builtin_LANG}", "LANG(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_DATATYPE'):
+                replace("{Builtin_DATATYPE}", "DATATYPE(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_IRI'):
+                replace("{Builtin_IRI}", "IRI(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_BNODE'):
+                replace("{Builtin_BNODE}", "BNODE(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('STRDT'):
+                replace("{Builtin_STRDT}", "STRDT(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_STRLANG'):
+                replace("{Builtin_STRLANG}", "STRLANG(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_UUID'):
+                replace("{Builtin_UUID}", "UUID()")
+            elif node.name.endswith('Builtin_STRUUID'):
+                replace("{Builtin_STRUUID}", "STRUUID()")
+
+            # # # 17.4.3 Functions on Strings
+            elif node.name.endswith('Builtin_STRLEN'):
+                replace("{Builtin_STRLEN}", "STRLEN(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_SUBSTR'):
+                args = [node.arg.n3(), node.start]
+                if node.length:
+                    args.append(node.length)
+                expr = "SUBSTR(" + ", ".join(args) + ")"
+                replace("{Builtin_SUBSTR}", expr)
+            elif node.name.endswith('Builtin_UCASE'):
+                replace("{Builtin_UCASE}", "UCASE(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_LCASE'):
+                replace("{Builtin_LCASE}", "LCASE(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_STRSTARTS'):
+                replace("{Builtin_STRSTARTS}", "STRSTARTS(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_STRENDS'):
+                replace("{Builtin_STRENDS}", "STRENDS(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_CONTAINS'):
+                replace("{Builtin_CONTAINS}", "CONTAINS(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_STRBEFORE'):
+                replace("{Builtin_STRBEFORE}", "STRBEFORE(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_STRAFTER'):
+                replace("{Builtin_STRAFTER}", "STRAFTER(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('Builtin_ENCODE_FOR_URI'):
+                replace("{Builtin_ENCODE_FOR_URI}", "ENCODE_FOR_URI(" + convert_node_arg(node.arg) + ")")
+            elif node.name.endswith('Builtin_CONCAT'):
+                expr = 'CONCAT({vars})'.format(vars=", ".join(elem.n3() for elem in node.arg))
+                replace("{Builtin_CONCAT}", expr)
+            elif node.name.endswith('Builtin_LANGMATCHES'):
+                replace("{Builtin_LANGMATCHES}", "LANGMATCHES(" + convert_node_arg(node.arg1)
+                        + ", " + convert_node_arg(node.arg2) + ")")
+            elif node.name.endswith('REGEX'):
+                args = [convert_node_arg(node.text), convert_node_arg(node.pattern)]
+                expr = "REGEX(" + ", ".join(args) + ")"
+                replace("{Builtin_REGEX}", expr)
+            elif node.name.endswith('REPLACE'):
+                replace("{Builtin_REPLACE}", "REPLACE(" + convert_node_arg(node.arg)
+                        + ", " + convert_node_arg(node.pattern) + ", " + convert_node_arg(node.replacement) + ")")
+
+            # # # 17.4.4 Functions on Numerics
+            elif node.name == 'Builtin_ABS':
+                replace("{Builtin_ABS}", "ABS(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_ROUND':
+                replace("{Builtin_ROUND}", "ROUND(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_CEIL':
+                replace("{Builtin_CEIL}", "CEIL(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_FLOOR':
+                replace("{Builtin_FLOOR}", "FLOOR(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_RAND':
+                replace("{Builtin_RAND}", "RAND()")
+
+            # # # 17.4.5 Functions on Dates and Times
+            elif node.name == 'Builtin_NOW':
+                replace("{Builtin_NOW}", "NOW()")
+            elif node.name == 'Builtin_YEAR':
+                replace("{Builtin_YEAR}", "YEAR(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_MONTH':
+                replace("{Builtin_MONTH}", "MONTH(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_DAY':
+                replace("{Builtin_DAY}", "DAY(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_HOURS':
+                replace("{Builtin_HOURS}", "HOURS(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_MINUTES':
+                replace("{Builtin_MINUTES}", "MINUTES(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_SECONDS':
+                replace("{Builtin_SECONDS}", "SECONDS(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_TIMEZONE':
+                replace("{Builtin_TIMEZONE}", "TIMEZONE(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_TZ':
+                replace("{Builtin_TZ}", "TZ(" + convert_node_arg(node.arg) + ")")
+
+            # # # 17.4.6 Hash functions
+            elif node.name == 'Builtin_MD5':
+                replace("{Builtin_MD5}", "MD5(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_SHA1':
+                replace("{Builtin_SHA1}", "SHA1(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_SHA256':
+                replace("{Builtin_SHA256}", "SHA256(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_SHA384':
+                replace("{Builtin_SHA384}", "SHA384(" + convert_node_arg(node.arg) + ")")
+            elif node.name == 'Builtin_SHA512':
+                replace("{Builtin_SHA512}", "SHA512(" + convert_node_arg(node.arg) + ")")
+
+            # Other
+            elif node.name == 'values':
+                columns = []
+                for key in node.res[0].keys():
+                    if isinstance(key, Identifier):
+                        columns.append(key.n3())
+                    else:
+                        raise ExpressionNotCoveredException("The expression {0} might not be covered yet.".format(key))
+                values = "VALUES (" + " ".join(columns) +")"
+
+                rows = ""
+                for elem in node.res:
+                    row = []
+                    for term in elem.values():
+                        if isinstance(term, Identifier):
+                            row.append(term.n3())  # n3() is not part of Identifier class but every subclass has it
+                        elif isinstance(term, str):
+                            row.append(term)
+                        else:
+                            raise ExpressionNotCoveredException(
+                                "The expression {0} might not be covered yet.".format(term))
+                    rows += "(" + " ".join(row) + ")"
+
+                replace("values", values + "{" + rows + "}")
+            elif node.name == 'ServiceGraphPattern':
+                replace("{ServiceGraphPattern}", "SERVICE " + convert_node_arg(node.term)
+                        + "{" + node.graph.name + "}")
+                traverse(node.graph, visitPre=sparql_query_text)
+                return node.graph
+            # else:
+            #     raise ExpressionNotCoveredException("The expression {0} might not be covered yet.".format(node.name))
+
+    traverse(query_algebra.algebra, visitPre=sparql_query_text)
+    query_from_algebra = open("query.txt", "r").read()
+    os.remove("query.txt")
+
+    return query_from_algebra
 
 
 def pprintAlgebra(q):

--- a/test/translate_algebra/main.py
+++ b/test/translate_algebra/main.py
@@ -35,7 +35,7 @@ class TestAlgebraToTest(TestExecution):
         self.rdf_engine = None
         self.query_text = None
         self.query_algebra = None
-        self.query_from_algebr = None
+        self.query_from_algebra = None
         self.query_from_query_from_algebra = None
 
     def before_single_test(self, test_name: str):
@@ -76,7 +76,7 @@ class TestAlgebraToTest(TestExecution):
 
         return test
 
-    def test_functions__functions_on_rdf_terms(self):
+    def test_functions__functional_forms_not_exists(self):
         query_tree = parser.parseQuery(self.query_text)
         query_algebra = algebra.translateQuery(query_tree)
         self.query_from_algebra = translateAlgebra(query_algebra)
@@ -87,6 +87,24 @@ class TestAlgebraToTest(TestExecution):
         _pprint_query(self.query_from_query_from_algebra)
 
         test = Test(test_number=2,
+                    tc_desc='Test if the not exists form is properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_functions__functions_on_rdf_terms(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=3,
                     tc_desc='Test if functions on rdf terms are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -104,7 +122,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=3,
+        test = Test(test_number=4,
                     tc_desc='Test if functions on strings are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -122,7 +140,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=4,
+        test = Test(test_number=5,
                     tc_desc='Test if functions on numerics are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -140,7 +158,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=5,
+        test = Test(test_number=6,
                     tc_desc='Test if hash functions are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -158,7 +176,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=6,
+        test = Test(test_number=7,
                     tc_desc='Test if functions on dates and time are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -176,7 +194,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=7,
+        test = Test(test_number=8,
                     tc_desc='Test if aggregate join including all aggregation functions '
                             'are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
@@ -195,7 +213,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=8,
+        test = Test(test_number=9,
                     tc_desc='Test if basic graph patterns are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -213,7 +231,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=9,
+        test = Test(test_number=10,
                     tc_desc='Test if "extend" (=Bind explicitly or implicitly in projection) '
                             'gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
@@ -232,7 +250,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=10,
+        test = Test(test_number=11,
                     tc_desc='Test if filter gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -250,7 +268,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=11,
+        test = Test(test_number=12,
                     tc_desc='Test if "graph" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -268,8 +286,26 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=12,
+        test = Test(test_number=13,
                     tc_desc='Test if "group" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__having(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=14,
+                    tc_desc='Test if "having" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
                     actual_result=self.query_from_query_from_algebra)
@@ -286,7 +322,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=13,
+        test = Test(test_number=15,
                     tc_desc='Test if "join" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -304,7 +340,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=14,
+        test = Test(test_number=16,
                     tc_desc='Test if "left join" gets properly translated into "OPTIONAL {...}" in the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -322,7 +358,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=15,
+        test = Test(test_number=17,
                     tc_desc='Test if "minus" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -340,7 +376,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=16,
+        test = Test(test_number=18,
                     tc_desc='Test if "union" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -358,7 +394,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=17,
+        test = Test(test_number=19,
                     tc_desc='Test if arithmetics are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -376,7 +412,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=18,
+        test = Test(test_number=20,
                     tc_desc='Test if "conditional ands (&&)" are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -394,7 +430,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=19,
+        test = Test(test_number=21,
                     tc_desc='Test if "conditional ors (||)" are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -412,7 +448,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=20,
+        test = Test(test_number=22,
                     tc_desc='Test if relational expressions are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -430,7 +466,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=21,
+        test = Test(test_number=23,
                     tc_desc='Test if unary expressions are properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -446,7 +482,7 @@ class TestAlgebraToTest(TestExecution):
             query_tree = parser.parseQuery(self.query_text)
         except Exception as e:
             print(e)
-            return Test(test_number=22, tc_desc=tc_desc, expected_result="0",
+            return Test(test_number=24, tc_desc=tc_desc, expected_result="0",
                         actual_result="Not executable. Error returned from parseQuery")
         query_algebra = algebra.translateQuery(query_tree)
         self.query_from_algebra = translateAlgebra(query_algebra)
@@ -456,7 +492,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=22,
+        test = Test(test_number=24,
                     tc_desc=tc_desc,
                     expected_result=self.query_from_algebra,
                     actual_result=self.query_from_query_from_algebra)
@@ -471,7 +507,7 @@ class TestAlgebraToTest(TestExecution):
             query_tree = parser.parseQuery(self.query_text)
         except Exception as e:
             print(e)
-            return Test(test_number=23, tc_desc=tc_desc, expected_result="0",
+            return Test(test_number=25, tc_desc=tc_desc, expected_result="0",
                         actual_result="Not executable. Error returned from parseQuery().")
         query_algebra = algebra.translateQuery(query_tree)
         self.query_from_algebra = translateAlgebra(query_algebra)
@@ -481,7 +517,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=23,
+        test = Test(test_number=25,
                     tc_desc=tc_desc,
                     expected_result=self.query_from_algebra,
                     actual_result=self.query_from_query_from_algebra)
@@ -498,7 +534,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=24,
+        test = Test(test_number=26,
                     tc_desc='Test if "values" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -516,7 +552,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=25,
+        test = Test(test_number=27,
                     tc_desc='Test if an alternative path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -534,7 +570,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=26,
+        test = Test(test_number=28,
                     tc_desc='Test if an inverse path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -551,7 +587,7 @@ class TestAlgebraToTest(TestExecution):
             self.query_from_algebra = translateAlgebra(query_algebra)
         except TypeError as e:
             print(e)
-            return Test(test_number=27, tc_desc=tc_desc, expected_result="0",
+            return Test(test_number=29, tc_desc=tc_desc, expected_result="0",
                         actual_result="Not executable. n3() method of NegatedPath class should be fixed. ")
 
         query_tree_2 = parser.parseQuery(self.query_from_algebra)
@@ -559,7 +595,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=27,
+        test = Test(test_number=29,
                     tc_desc=tc_desc,
                     expected_result=self.query_from_algebra,
                     actual_result=self.query_from_query_from_algebra)
@@ -576,7 +612,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=28,
+        test = Test(test_number=30,
                     tc_desc='Test if a oneOrMore path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -594,7 +630,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=29,
+        test = Test(test_number=31,
                     tc_desc='Test if a sequence path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -612,7 +648,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=30,
+        test = Test(test_number=32,
                     tc_desc='Test if a zeroOrMore path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -630,7 +666,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=31,
+        test = Test(test_number=33,
                     tc_desc='Test if a zeroOrOne path gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -648,7 +684,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=32,
+        test = Test(test_number=34,
                     tc_desc='Test if "distinct" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -666,7 +702,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=33,
+        test = Test(test_number=35,
                     tc_desc='Test if "order by" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -684,7 +720,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=34,
+        test = Test(test_number=36,
                     tc_desc='Test if "reduced" gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -702,7 +738,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=35,
+        test = Test(test_number=37,
                     tc_desc='Test if slice get properly translated into the limit and offset. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -720,7 +756,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=36,
+        test = Test(test_number=38,
                     tc_desc='Test if subqueries get properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',
                     expected_result=self.query_from_algebra,
@@ -738,7 +774,7 @@ class TestAlgebraToTest(TestExecution):
         self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
         _pprint_query(self.query_from_query_from_algebra)
 
-        test = Test(test_number=37,
+        test = Test(test_number=39,
                     tc_desc='Test a query with multiple graph patterns and solution modifiers '
                             'gets properly translated into the query text. '
                             'The query must also be executable and shall not violate any SPARQL query syntax.',

--- a/test/translate_algebra/main.py
+++ b/test/translate_algebra/main.py
@@ -728,6 +728,25 @@ class TestAlgebraToTest(TestExecution):
 
         return test
 
+    def test_integration__complex_query1(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=37,
+                    tc_desc='Test a query with multiple graph patterns and solution modifiers '
+                            'gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
 
 t = TestAlgebraToTest(annotated_tests=False)
 t.run_tests()

--- a/test/translate_algebra/main.py
+++ b/test/translate_algebra/main.py
@@ -1,0 +1,734 @@
+from test_base import Test, TestExecution, format_text
+from rdflib.plugins.sparql.algebra import translateAlgebra
+import rdflib.plugins.sparql.parser as parser
+import rdflib.plugins.sparql.algebra as algebra
+import sys
+import logging
+
+
+def _pprint_query(query: str):
+    p = '{'
+    q = "}"
+    i = 0
+    f = 1
+
+    for e in query:
+        if e in p:
+            f or print()
+            print(' ' * i + e)
+            i += 4
+            f = 1
+        elif e in q:
+            f or print()
+            i -= 4
+            f = 1
+            print(' ' * i + e)
+        else:
+            not f or print(' ' * i, end='')
+            f = print(e, end='')
+
+
+class TestAlgebraToTest(TestExecution):
+
+    def __init__(self, annotated_tests: bool = False):
+        super().__init__(annotated_tests)
+        self.rdf_engine = None
+        self.query_text = None
+        self.query_algebra = None
+        self.query_from_algebr = None
+        self.query_from_query_from_algebra = None
+
+    def before_single_test(self, test_name: str):
+        """
+
+        :return:
+        """
+
+        print("Executing before_single_tests ...")
+
+        if self.annotated_tests:
+            test_name = test_name[2:]
+
+        self.query_text = open("test_data/{0}.txt".format(test_name), "r").read()
+
+    def test_functions__functional_forms(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+
+        test = Test(test_number=1,
+                    tc_desc='Test if functional forms are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        try:
+            self.rdf_engine.get_data(self.query_from_query_from_algebra, yn_timestamp_query=False)
+        except Exception as e:
+            print(e)
+            print("The query must be executable. Otherwise, the test has failed.")
+            return Test(test_number=test.test_number, tc_desc=test.tc_desc, expected_result="0",
+                        actual_result="not_executable")
+
+        return test
+
+    def test_functions__functions_on_rdf_terms(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=2,
+                    tc_desc='Test if functions on rdf terms are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_functions__functions_on_strings(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=3,
+                    tc_desc='Test if functions on strings are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_functions__functions_on_numerics(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=4,
+                    tc_desc='Test if functions on numerics are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_functions__hash_functions(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=5,
+                    tc_desc='Test if hash functions are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_functions__functions_on_dates_and_time(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=6,
+                    tc_desc='Test if functions on dates and time are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__aggregate_join(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=7,
+                    tc_desc='Test if aggregate join including all aggregation functions '
+                            'are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__bgp(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=8,
+                    tc_desc='Test if basic graph patterns are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__extend(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=9,
+                    tc_desc='Test if "extend" (=Bind explicitly or implicitly in projection) '
+                            'gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__filter(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=10,
+                    tc_desc='Test if filter gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__graph(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=11,
+                    tc_desc='Test if "graph" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__group(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=12,
+                    tc_desc='Test if "group" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__join(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=13,
+                    tc_desc='Test if "join" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__left_join(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=14,
+                    tc_desc='Test if "left join" gets properly translated into "OPTIONAL {...}" in the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__minus(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=15,
+                    tc_desc='Test if "minus" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_graph_patterns__union(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=16,
+                    tc_desc='Test if "union" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_operators__arithmetics(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=17,
+                    tc_desc='Test if arithmetics are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_operators__conditional_and(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=18,
+                    tc_desc='Test if "conditional ands (&&)" are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_operators__conditional_or(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=19,
+                    tc_desc='Test if "conditional ors (||)" are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_operators__relational(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=20,
+                    tc_desc='Test if relational expressions are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_operators__unary(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=21,
+                    tc_desc='Test if unary expressions are properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_other__service1(self):
+        tc_desc = 'Test if a nested service pattern is properly translated ' \
+                  'into the query text. ' \
+                  'The query must also be executable and shall not violate any SPARQL query syntax.'
+        try:
+            query_tree = parser.parseQuery(self.query_text)
+        except Exception as e:
+            print(e)
+            return Test(test_number=22, tc_desc=tc_desc, expected_result="0",
+                        actual_result="Not executable. Error returned from parseQuery")
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=22,
+                    tc_desc=tc_desc,
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_other__service2(self):
+        tc_desc = 'Test if "service" along with its service string is properly translated ' \
+                  'into the query text. ' \
+                  'The query must also be executable and shall not violate any SPARQL query syntax.'
+        try:
+            query_tree = parser.parseQuery(self.query_text)
+        except Exception as e:
+            print(e)
+            return Test(test_number=23, tc_desc=tc_desc, expected_result="0",
+                        actual_result="Not executable. Error returned from parseQuery().")
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=23,
+                    tc_desc=tc_desc,
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_other__values(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=24,
+                    tc_desc='Test if "values" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__alternative_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=25,
+                    tc_desc='Test if an alternative path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__inverse_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=26,
+                    tc_desc='Test if an inverse path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__negated_property_set(self):
+        tc_desc = 'Test if a negated property set gets properly translated into the query text. ' \
+                  'The query must also be executable and shall not violate any SPARQL query syntax.'
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        try:
+            self.query_from_algebra = translateAlgebra(query_algebra)
+        except TypeError as e:
+            print(e)
+            return Test(test_number=27, tc_desc=tc_desc, expected_result="0",
+                        actual_result="Not executable. n3() method of NegatedPath class should be fixed. ")
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=27,
+                    tc_desc=tc_desc,
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__one_or_more_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=28,
+                    tc_desc='Test if a oneOrMore path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__sequence_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=29,
+                    tc_desc='Test if a sequence path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__zero_or_more_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=30,
+                    tc_desc='Test if a zeroOrMore path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_property_path__zero_or_one_path(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=31,
+                    tc_desc='Test if a zeroOrOne path gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_solution_modifiers__distinct(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=32,
+                    tc_desc='Test if "distinct" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_solution_modifiers__order_by(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=33,
+                    tc_desc='Test if "order by" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_solution_modifiers__reduced(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=34,
+                    tc_desc='Test if "reduced" gets properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_solution_modifiers__slice(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=35,
+                    tc_desc='Test if slice get properly translated into the limit and offset. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+    def test_solution_modifiers__to_multiset(self):
+        query_tree = parser.parseQuery(self.query_text)
+        query_algebra = algebra.translateQuery(query_tree)
+        self.query_from_algebra = translateAlgebra(query_algebra)
+
+        query_tree_2 = parser.parseQuery(self.query_from_algebra)
+        query_algebra_2 = algebra.translateQuery(query_tree_2)
+        self.query_from_query_from_algebra = translateAlgebra(query_algebra_2)
+        _pprint_query(self.query_from_query_from_algebra)
+
+        test = Test(test_number=36,
+                    tc_desc='Test if subqueries get properly translated into the query text. '
+                            'The query must also be executable and shall not violate any SPARQL query syntax.',
+                    expected_result=self.query_from_algebra,
+                    actual_result=self.query_from_query_from_algebra)
+
+        return test
+
+
+t = TestAlgebraToTest(annotated_tests=False)
+t.run_tests()
+t.print_test_results()

--- a/test/translate_algebra/test_base.py
+++ b/test/translate_algebra/test_base.py
@@ -1,0 +1,150 @@
+import pandas as pd
+import configparser
+import os
+import sys
+from tabulate import tabulate
+import logging
+
+
+def format_text(comment, max_line_length):
+    # accumulated line length
+    ACC_length = 0
+    words = comment.split(" ")
+    formatted_text = ""
+    for word in words:
+        # if ACC_length + len(word) and a space is <= max_line_length
+        if ACC_length + (len(word) + 1) <= max_line_length:
+            # append the word and a space
+            formatted_text = formatted_text + word + " "
+            # length = length + length of word + length of space
+            ACC_length = ACC_length + len(word) + 1
+        else:
+            # append a line break, then the word and a space
+            formatted_text = formatted_text + "\n" + word + " "
+            # reset counter of length to the length of a word and a space
+            ACC_length = len(word) + 1
+    return formatted_text
+
+
+class Test:
+
+    def __init__(self, tc_desc: str, expected_result: str = None, actual_result: str = None, test_number: int = None,
+                 test_name: str = None):
+        self.test_number = test_number
+        self.test_name = test_name
+        self.tc_desc = tc_desc
+        self.actual_result = actual_result
+        self.expected_result = expected_result
+        self.yn_passed = False
+
+    def test(self):
+        """
+
+        :return:
+        """
+        assert self.actual_result
+
+        if self.expected_result == self.actual_result:
+            self.yn_passed = True
+
+
+class TestExecution:
+
+    def __init__(self, annotated_tests: bool = False):
+        """
+
+        :param annotated_tests: If this flag is set only tests with the prefix "x_test" will be executed.
+        """
+        test_module_path = os.path.dirname(sys.modules[__class__.__module__].__file__)
+        config_path = test_module_path + "/../config.ini"
+        self.test_config = configparser.ConfigParser()
+        self.test_config.read(config_path)
+        self.annotated_tests = annotated_tests
+        self.tests = []
+
+    def before_all_tests(self):
+        """
+
+        :return:
+        """
+
+        print("Executing before_tests ...")
+
+    def before_single_test(self, test_name: str):
+        """
+
+        :return:
+        """
+
+        print("Executing before_single_tests ...")
+
+    def after_single_test(self):
+        """
+
+        :return:
+        """
+
+        print("Executing after_single_test")
+
+    def after_all_tests(self):
+        """
+
+        :return:
+        """
+
+        print("Executing after_tests ...")
+
+    def run_tests(self):
+        """
+
+        :return:
+        """
+        print("Executing tests ...")
+        logging.getLogger().setLevel(int(self.test_config.get('TEST', 'log_level')))
+
+        self.before_all_tests()
+        test_prefix = 'test_'
+        if self.annotated_tests:
+            test_prefix = 'x_test_'
+        test_functions = [func for func in dir(self) if callable(getattr(self, func)) and func.startswith(test_prefix)]
+        try:
+            test_number = 1
+            for func in test_functions:
+                logging.info("Executing test: " + func)
+                self.before_single_test(func)
+                test_function = getattr(self, func)
+                test = test_function()
+                test_number += 1
+                test.test_name = func
+                test.test()
+                self.tests.append(test)
+                self.after_single_test()
+        except Exception as e:
+            print(e)
+        finally:
+            self.after_all_tests()
+
+    def print_test_results(self):
+        """
+
+        :return:
+        """
+
+        tests_df = pd.DataFrame(columns=['test_number', 'test_passed', 'test_name', 'test_case_description',
+                                         'expected_result', 'actual_result'])
+        for test in self.tests:
+            if isinstance(test, Test):
+                formatted_tc_desc = format_text(test.tc_desc, 100)
+                formatted_expected_result = format_text(test.expected_result, 50)
+                formatted_actual_result = format_text(test.actual_result, 50)
+
+                tests_df = tests_df.append({'test_number': test.test_number,
+                                            'test_passed': test.yn_passed,
+                                            'test_name': test.test_name,
+                                            'test_case_description': formatted_tc_desc,
+                                            'expected_result': formatted_expected_result,
+                                            'actual_result': formatted_actual_result}, ignore_index=True)
+
+        tests_df.sort_values('test_number', inplace=True)
+        pdtabulate = lambda df: tabulate(df, headers='keys', tablefmt='grid', )
+        print(pdtabulate(tests_df))

--- a/test/translate_algebra/test_data/test_functions__functional_forms.txt
+++ b/test/translate_algebra/test_data/test_functions__functional_forms.txt
@@ -1,0 +1,20 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX xsd:   <http://www.w3.org/2001/XMLSchema#>
+SELECT (IF(?givenName = "Obama", if(?givenName = "Obama", "yes", "no"), "no") as ?givenName2) (COALESCE(1/0 *3 *4 +5 + 6, ?x) as ?col)
+WHERE {
+    ?x foaf:givenName  ?givenName .
+    OPTIONAL {
+        ?x dc:date ?date
+    } .
+    FILTER ( bound(?date) )
+    FILTER NOT EXISTS {
+        ?givenName foaf:name ?name.
+        filter(?givenName = "Clark")
+    }
+    FILTER EXISTS {
+        ?givenName foaf:name ?name.
+        filter((?givenName = "Obama" || ?givenName = "Obama2") && ?givenName = "Stern")
+        FILTER (sameTerm(?givenName, ?givenName) && !sameTerm(?givenName, ?givenName2))
+    }
+}

--- a/test/translate_algebra/test_data/test_functions__functional_forms_not_exists.txt
+++ b/test/translate_algebra/test_data/test_functions__functional_forms_not_exists.txt
@@ -1,0 +1,6 @@
+PREFIX citing: <https://github.com/GreenfishK/DataCitation/citing/>
+
+select ?s ?p ?o {
+	?s ?p ?o .
+    filter not exists {?s citing:valid_from ?valid_from} .
+}

--- a/test/translate_algebra/test_data/test_functions__functions_on_dates_and_time.txt
+++ b/test/translate_algebra/test_data/test_functions__functions_on_dates_and_time.txt
@@ -1,0 +1,5 @@
+select (now() as ?now) (year(now()) as ?year) (month(now()) as ?month) (day(now()) as ?day)
+(hours(now()) as ?hours) (minutes(now()) as ?minutes) (seconds(now()) as ?seconds)
+(timezone(now()) as ?timezone) (tz(now()) as ?tz) where {
+	?s ?p ?o .
+} limit 1

--- a/test/translate_algebra/test_data/test_functions__functions_on_numerics.txt
+++ b/test/translate_algebra/test_data/test_functions__functions_on_numerics.txt
@@ -1,0 +1,3 @@
+select (abs(1.6) as ?abs) (round(5.5) as ?round) (ceil(5.5) as ?ceil) (floor(5.5) as ?floor) (rand() as ?rand)  where {
+	?s ?p ?o .
+} limit 1

--- a/test/translate_algebra/test_data/test_functions__functions_on_rdf_terms.txt
+++ b/test/translate_algebra/test_data/test_functions__functions_on_rdf_terms.txt
@@ -1,0 +1,16 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT ?name ?mbox (STRDT("iiii", <http://example/romanNumeral>) as ?strdt) (STRLANG("chat", "en") as ?strlang) (uuid() as ?uuid) (STRUUID() as ?struuid)
+WHERE {
+    ?x foaf:name  ?name ;
+       foaf:mbox  ?mbox .
+    FILTER isIRI(?mbox)
+    FILTER isBlank(?mbox)
+    FILTER isLiteral(?mbox)
+    FILTER isNumeric(?mbox)
+    FILTER STR(?mbox)
+    FILTER LANG(?mbox)
+    FILTER DATATYPE(?mbox)
+    FILTER IRI(?mobox)
+    FILTER BNODE("string")
+}

--- a/test/translate_algebra/test_data/test_functions__functions_on_strings.txt
+++ b/test/translate_algebra/test_data/test_functions__functions_on_strings.txt
@@ -1,0 +1,18 @@
+select
+(strlen("chat") as ?strlen)
+(substr("foobar", 4) as ?substr)
+(ucase("foo") as ?ucase)
+(lcase("FOO") as ?lcase)
+(strStarts("foobar", "foo") as ?strstarts)
+(strEnds("foobar", "bar") as ?strends)
+(contains("foobar", "bar") as ?contains)
+(strbefore("abc","b") as ?strbefore)
+(strafter("abc","b") as ?strafter)
+(encode_for_uri("Los Angeles") as ?encode_for_uri)
+(concat("foo"@en, "bar"@en) as ?concat)
+(replace("abcd", "b", "Z") as ?replace)
+(regex(substr("foobar", 4), "bar", "bar") as ?regex)
+where {
+	?s ?p ?o .
+    FILTER langMatches(lang(?o), "EN" )
+} limit 1

--- a/test/translate_algebra/test_data/test_functions__hash_functions.txt
+++ b/test/translate_algebra/test_data/test_functions__hash_functions.txt
@@ -1,0 +1,9 @@
+select
+(md5("abc") as ?md5)
+(sha1("abc") as ?sha1)
+(SHA256("abc") as ?SHA256)
+(SHA384("abc") as ?SHA384)
+(SHA512("abc") as ?SHA512)
+where {
+	?s ?p ?o .
+} limit 1

--- a/test/translate_algebra/test_data/test_graph_patterns__aggregate_join.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__aggregate_join.txt
@@ -1,0 +1,13 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select
+(sum(?s) as ?sum)
+(count(distinct ?s) as ?count)
+(min(?s) as ?min)
+(max(?s) as ?max)
+(avg(?s) as ?avg)
+(sample(?s) as ?sample)
+(GROUP_CONCAT(?s;SEPARATOR="|") AS ?group_concat)
+where {
+	?s ?p ?o .
+    filter(?s = rdf:type)
+} limit 1

--- a/test/translate_algebra/test_data/test_graph_patterns__bgp.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__bgp.txt
@@ -1,0 +1,11 @@
+PREFIX pub: <http://ontology.ontotext.com/taxonomy/>
+PREFIX publishing: <http://ontology.ontotext.com/publishing#>
+
+select ?personLabel ?party_label ?document ?mention where {
+    ?mention publishing:hasInstance ?person .
+    ?document publishing:containsMention ?mention .
+    ?person pub:memberOfPoliticalParty ?party .
+    ?person pub:preferredLabel ?personLabel .
+    ?party pub:hasValue ?value .
+    ?value pub:preferredLabel ?party_label .
+} order by ?mention

--- a/test/translate_algebra/test_data/test_graph_patterns__extend.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__extend.txt
@@ -1,0 +1,12 @@
+PREFIX pub: <http://ontology.ontotext.com/taxonomy/>
+PREFIX publishing: <http://ontology.ontotext.com/publishing#>
+
+select ?personLabel ?party_name ?document (?mention as ?men) where {
+    ?mention publishing:hasInstance ?person .
+    ?document publishing:containsMention ?mention .
+    ?person pub:memberOfPoliticalParty ?party .
+    ?person pub:preferredLabel ?personLabel .
+    ?party pub:hasValue ?value .
+    ?value pub:preferredLabel ?party_label .
+    Bind(?party_label as ?party_name)
+} order by ?mention

--- a/test/translate_algebra/test_data/test_graph_patterns__filter.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__filter.txt
@@ -1,0 +1,13 @@
+PREFIX pub: <http://ontology.ontotext.com/taxonomy/>
+PREFIX publishing: <http://ontology.ontotext.com/publishing#>
+
+select ?personLabel ?party_label ?document ?mention where {
+    ?mention publishing:hasInstance ?person .
+    ?document publishing:containsMention ?mention .
+    ?person pub:memberOfPoliticalParty ?party .
+    ?person pub:preferredLabel ?personLabel .
+    ?party pub:hasValue ?value .
+    ?value pub:preferredLabel ?party_label .
+
+    filter((?personLabel = "Barack Obama"@en || ?personLabel = "Judy Chu"@en) && ?personLabel = "Michelle Obama"@en )
+} order by ?mention

--- a/test/translate_algebra/test_data/test_graph_patterns__graph.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__graph.txt
@@ -1,0 +1,23 @@
+PREFIX  data:  <http://example.org/foaf/>
+PREFIX  foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX  rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?mbox ?nick ?ppd
+FROM NAMED <http://example.org/foaf/aliceFoaf>
+FROM NAMED <http://example.org/foaf/bobFoaf>
+WHERE
+{
+    GRAPH data:aliceFoaf
+    {
+        ?alice foaf:mbox <mailto:alice@work.example> ;
+               foaf:knows ?whom .
+        ?whom  foaf:mbox ?mbox ;
+               rdfs:seeAlso ?ppd .
+        ?ppd  a foaf:PersonalProfileDocument .
+    } .
+    GRAPH ?ppd
+    {
+        ?w foaf:mbox ?mbox ;
+           foaf:nick ?nick
+    }
+}

--- a/test/translate_algebra/test_data/test_graph_patterns__group.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__group.txt
@@ -1,0 +1,6 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (SUM(?val) AS ?sum) (COUNT(?a) AS ?count)
+WHERE {
+  ?a rdf:value ?val .
+} GROUP BY ?a

--- a/test/translate_algebra/test_data/test_graph_patterns__having.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__having.txt
@@ -1,0 +1,10 @@
+PREFIX : <http://books.example/>
+SELECT (SUM(?lprice) AS ?totalPrice)
+WHERE {
+  ?org :affiliates ?auth .
+  ?auth :writesBook ?book .
+  ?book :price ?lprice .
+  filter(?lprice < 5)
+}
+GROUP BY ?org
+HAVING (SUM(?lprice) > 10)

--- a/test/translate_algebra/test_data/test_graph_patterns__join.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__join.txt
@@ -1,0 +1,11 @@
+PREFIX ex: <http://people.example/>
+SELECT ?select ?minName
+WHERE {
+    ex:alice ex:knows ?select .
+    {
+        SELECT (MIN(?name) AS ?minName) ?select
+        WHERE {
+            ?select ex:name ?name .
+        } GROUP BY ?select
+    }
+}

--- a/test/translate_algebra/test_data/test_graph_patterns__left_join.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__left_join.txt
@@ -1,0 +1,14 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX xsd:   <http://www.w3.org/2001/XMLSchema#>
+SELECT ?givenName
+WHERE {
+    ?x foaf:givenName  ?givenName .
+    OPTIONAL {
+        ?x dc:date ?date
+    } .
+    OPTIONAL {
+        ?x dc:datetime ?datetime
+    } .
+    FILTER ( bound(?date) )
+}

--- a/test/translate_algebra/test_data/test_graph_patterns__minus.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__minus.txt
@@ -1,0 +1,8 @@
+PREFIX : <http://example/>
+SELECT * WHERE {
+    ?x :p ?n
+    MINUS {
+        ?x :q ?m .
+        FILTER(?n = ?m)
+    }
+}

--- a/test/translate_algebra/test_data/test_graph_patterns__union.txt
+++ b/test/translate_algebra/test_data/test_graph_patterns__union.txt
@@ -1,0 +1,14 @@
+PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
+PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
+SELECT ?title ?author
+WHERE  {
+    {
+        ?book dc10:title ?title .
+        ?book dc10:creator ?author
+    }
+    UNION
+    {
+        ?book dc11:title ?title .
+        ?book dc11:creator ?author
+    }
+}

--- a/test/translate_algebra/test_data/test_integration__complex_query1.txt
+++ b/test/translate_algebra/test_data/test_integration__complex_query1.txt
@@ -1,0 +1,34 @@
+# Prefixes
+PREFIX pub: <http://ontology.ontotext.com/taxonomy/>
+PREFIX publishing: <http://ontology.ontotext.com/publishing#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+select ?document ?mention ?personLabel ?party_label {
+    {
+        select *  {
+            ?document publishing:containsMention ?mention .
+            ?person pub:memberOfPoliticalParty ?party .
+            ?person pub:preferredLabel ?personLabel .
+            ?party pub:hasValue ?value .
+            ?value pub:preferredLabel ?party_label .
+            filter(?personLabel = "Judy Chu"@en)
+
+            {
+                Select * where {
+                    ?mention publishing:hasInstance ?person .
+
+                }
+            }
+        }
+    }
+    union
+    {
+        select * where {
+            ?mention publishing:hasInstance ?person .
+            ?document publishing:containsMention ?mention .
+            ?person pub:memberOfPoliticalParty / pub:hasValue / pub:preferredLabel ?party_label .
+            ?person pub:preferredLabel ?personLabel .
+            filter(?personLabel = "Barack Obama"@en)
+        }
+    }
+}

--- a/test/translate_algebra/test_data/test_operators__arithmetics.txt
+++ b/test/translate_algebra/test_data/test_operators__arithmetics.txt
@@ -1,0 +1,3 @@
+select (2*4 -5 + 3 as ?test_arithmetics) where {
+	?s ?p ?o .
+} limit 1

--- a/test/translate_algebra/test_data/test_operators__conditional_and.txt
+++ b/test/translate_algebra/test_data/test_operators__conditional_and.txt
@@ -1,0 +1,5 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select (2*4 -5 + 3 as ?test_arithmetics) where {
+	?s ?p ?o .
+    filter(2=2 && 1=1)
+} limit 1

--- a/test/translate_algebra/test_data/test_operators__conditional_or.txt
+++ b/test/translate_algebra/test_data/test_operators__conditional_or.txt
@@ -1,0 +1,5 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select (2*4 -5 + 3 as ?test_arithmetics) where {
+	?s ?p ?o .
+    filter(2=2 || 1=1)
+} limit 1

--- a/test/translate_algebra/test_data/test_operators__relational.txt
+++ b/test/translate_algebra/test_data/test_operators__relational.txt
@@ -1,0 +1,5 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select (2*4 -5 + 3 as ?test_arithmetics) where {
+	?s ?p ?o .
+    filter(3>2 || 1<2 || 2>=2 || 2<=2 || 1!=2)
+} limit 1

--- a/test/translate_algebra/test_data/test_operators__unary.txt
+++ b/test/translate_algebra/test_data/test_operators__unary.txt
@@ -1,0 +1,5 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select (2*4 -5 + 3 as ?test_arithmetics) where {
+	?s ?p ?o .
+    filter(?o || ?o)
+} limit 1

--- a/test/translate_algebra/test_data/test_other__service1.txt
+++ b/test/translate_algebra/test_data/test_other__service1.txt
@@ -1,0 +1,16 @@
+# https://www.w3.org/TR/sparql11-federated-query/
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+SELECT ?person ?interest ?known
+WHERE
+{
+    SERVICE <http://people.example.org/sparql> {
+        ?person foaf:name ?name .
+        OPTIONAL {
+            ?person foaf:interest ?interest .
+            SERVICE <http://people2.example.org/sparql> {
+                ?person foaf:knows ?known .
+            }
+        }
+    }
+}
+# Error message: maximum recursion depth exceeded in comparison

--- a/test/translate_algebra/test_data/test_other__service2.txt
+++ b/test/translate_algebra/test_data/test_other__service2.txt
@@ -1,0 +1,13 @@
+# https://www.w3.org/TR/sparql11-federated-query/
+
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+
+SELECT ?name
+FROM <http://example.org/myfoaf.rdf>
+WHERE
+{
+  <http://example.org/myfoaf/I> foaf:knows ?person .
+  SERVICE <http://people.example.org/sparql> {
+    ?person foaf:name ?name . }
+}
+# Error message: Unknown namespace prefix : foaf

--- a/test/translate_algebra/test_data/test_other__values.txt
+++ b/test/translate_algebra/test_data/test_other__values.txt
@@ -1,0 +1,14 @@
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX :     <http://example.org/book/>
+PREFIX ns:   <http://example.org/ns#>
+
+SELECT ?book ?title ?price
+{
+    ?book dc:title ?title ;
+          ns:price ?price .
+    VALUES (?book ?title)
+    {
+        (UNDEF "SPARQL Tutorial")
+        (:book2 UNDEF)
+    }
+}

--- a/test/translate_algebra/test_data/test_property_path__alternative_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__alternative_path.txt
@@ -1,0 +1,7 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX : <http://example.org/book/>
+
+select * where {
+	{ :book1 dc:title|rdfs:label ?displayString }
+} limit 100

--- a/test/translate_algebra/test_data/test_property_path__inverse_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__inverse_path.txt
@@ -1,0 +1,11 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX : <http://example.org/book/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+select * where {
+  {
+    ?x foaf:mbox <mailto:alice@example> .
+    ?x ^foaf:knows/foaf:name ?name .
+  }
+} limit 100

--- a/test/translate_algebra/test_data/test_property_path__negated_property_set.txt
+++ b/test/translate_algebra/test_data/test_property_path__negated_property_set.txt
@@ -1,0 +1,7 @@
+# Throw a type error wenn n3() of the negatedPath class is called. Probably n3() method should be fixed
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select * where
+{
+    ?x !(rdf:type|^rdf:type) ?y
+}
+limit 100

--- a/test/translate_algebra/test_data/test_property_path__one_or_more_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__one_or_more_path.txt
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+select * where
+{
+    ?x foaf:mbox <mailto:alice@example> .
+    ?x foaf:knows+/foaf:name ?name .
+}
+limit 100

--- a/test/translate_algebra/test_data/test_property_path__predicate_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__predicate_path.txt
@@ -1,0 +1,1 @@
+# Just an IRI. Nothing to test. Also no examples found here: https://www.w3.org/TR/sparql11-query/

--- a/test/translate_algebra/test_data/test_property_path__sequence_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__sequence_path.txt
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+select * where
+  {
+    ?x foaf:mbox <mailto:alice@example> .
+    ?x foaf:knows/foaf:knows/foaf:name ?name .
+  }
+limit 100

--- a/test/translate_algebra/test_data/test_property_path__zero_or_more_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__zero_or_more_path.txt
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+select * where
+{
+    ?x foaf:mbox <mailto:alice@example> .
+    ?x foaf:knows*/foaf:name ?name .
+}
+limit 100

--- a/test/translate_algebra/test_data/test_property_path__zero_or_one_path.txt
+++ b/test/translate_algebra/test_data/test_property_path__zero_or_one_path.txt
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+select * where
+{
+    ?x foaf:mbox <mailto:alice@example> .
+    ?x foaf:knows?/foaf:name ?name .
+}
+limit 100

--- a/test/translate_algebra/test_data/test_solution_modifiers__distinct.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__distinct.txt
@@ -1,0 +1,6 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select distinct ?x (count(distinct ?y) as ?cnt)  where
+{
+    ?x (rdf:type|^rdf:type) ?y
+}
+group by ?x

--- a/test/translate_algebra/test_data/test_solution_modifiers__order_by.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__order_by.txt
@@ -1,0 +1,7 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select distinct ?x (count(distinct ?y) as ?cnt)  where
+{
+    ?x (rdf:type|^rdf:type) ?y
+}
+group by ?x
+order by ?x

--- a/test/translate_algebra/test_data/test_solution_modifiers__project.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__project.txt
@@ -1,0 +1,2 @@
+# Just the projection of variables within the select clause. It is comprised in every other test
+# Nothing to test explicitly

--- a/test/translate_algebra/test_data/test_solution_modifiers__reduced.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__reduced.txt
@@ -1,0 +1,7 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select reduced ?x (count(distinct ?y) as ?cnt)  where
+{
+    ?x (rdf:type|^rdf:type) ?y
+}
+group by ?x
+order by ?x

--- a/test/translate_algebra/test_data/test_solution_modifiers__slice.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__slice.txt
@@ -1,0 +1,8 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select reduced ?x (count(distinct ?y) as ?cnt)  where
+{
+    ?x (rdf:type|^rdf:type) ?y
+}
+group by ?x
+order by ?x
+limit 50

--- a/test/translate_algebra/test_data/test_solution_modifiers__to_multiset.txt
+++ b/test/translate_algebra/test_data/test_solution_modifiers__to_multiset.txt
@@ -1,0 +1,11 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select reduced ?x (count(distinct ?y) as ?cnt)  where
+{
+    ?x (rdf:type|^rdf:type) ?y
+    {
+        ?y ?a ?z
+    }
+}
+group by ?x
+order by ?x
+limit 50


### PR DESCRIPTION
…query algebra as an input and returns the query text. It should cover the whole SPARQL 1.1 specification for Select-Queries. Tests are in test/translate_algebra. I did not follow any specific test framework like Nose but wrote my own one which can simply be executed by running test/translate_algebra/main.py file.

The specifications I followed from here: https://www.w3.org/TR/sparql11-query/
Especially following sections:
17.3 Operator Mapping
17.4 Function Definitions
18.2 Translation to the SPARQL Algebra

Tests:
I tried to cover all possible constructs. 
Two tests did not pass due to two potential bugs:
1. n3() function of NegatedPath seems not to work properly (see test_property_path__negated_property_set)
2. There is a problem in the parseQuery function with SERVICE. (see test_other__service1)



Reason for not covering ASK queries:
The query form "ASK" is currently not supported as its algebra tree that comes from translateQuery() might be wrongly implemented. ASK-queries do not project any variables in theory but the query algebra shows a "project" node with "vars". Therefore, it would require a special treatment in the new function I am proposing. 