### PR TITLE
Speedup decodeUnicodeEscape by avoiding useless string replace.

### DIFF
--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -119,6 +119,7 @@ def decodeUnicodeEscape(s):
     """
     if "\\" not in s:
         # Most of times, there are no backslashes in strings.
+        # In the general case, it could use maketrans and translate.
         return s
 
     s = s.replace("\\t", "\t")

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -117,6 +117,10 @@ def decodeUnicodeEscape(s):
     s is a unicode string
     replace ``\\n`` and ``\\u00AC`` unicode escapes
     """
+    if "\\" not in s:
+        # Most of times, there are no backslashes in strings.
+        return s
+
     s = s.replace("\\t", "\t")
     s = s.replace("\\n", "\n")
     s = s.replace("\\r", "\r")


### PR DESCRIPTION
This avoids costly strings replaces if there is no backslash in the string.

Tested by parsing orkg.nt :
Before:
![image](https://user-images.githubusercontent.com/2873024/118933194-d2c36b80-b940-11eb-949a-0390d6de7bd1.png)

After:
![image](https://user-images.githubusercontent.com/2873024/118933403-0f8f6280-b941-11eb-928b-b29929d84fb4.png)

Explanation: When there are no backslashes in the string (which is the most common case), the function decodeUnicodeEscape() returns immediately.