### PR TITLE
Fix formatting of xsd:decimal

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1544,7 +1544,7 @@ _GenericPythonToXSDRules = [
     (bool, (lambda i: str(i).lower(), _XSD_BOOLEAN)),
     (int, (None, _XSD_INTEGER)),
     (long_type, (None, _XSD_INTEGER)),
-    (Decimal, (None, _XSD_DECIMAL)),
+    (Decimal, (lambda i: f"{i:f}", _XSD_DECIMAL)),
     (datetime, (lambda i: i.isoformat(), _XSD_DATETIME)),
     (date, (lambda i: i.isoformat(), _XSD_DATE)),
     (time, (lambda i: i.isoformat(), _XSD_TIME)),

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import unittest
 import datetime
 
@@ -231,6 +232,9 @@ class TestXsdLiterals(unittest.TestCase):
             ("", XSD.hexBinary, bytes),
             ("UkRGTGli", XSD.base64Binary, bytes),
             ("", XSD.base64Binary, bytes),
+            ("0.0000000000000000000000000000001", XSD.decimal, Decimal),
+            ("0.1", XSD.decimal, Decimal),
+            ("1", XSD.integer, int),
         ]
         self.check_make_literals(inputs)
 
@@ -249,6 +253,7 @@ class TestXsdLiterals(unittest.TestCase):
             ("1921-05-01+00:00", XSD.date, datetime.date),
             ("1921-05-01+00:00", XSD.date, datetime.date),
             ("1921-05-01T00:00:00Z", XSD.dateTime, datetime.datetime),
+            ("1e-31", XSD.decimal, None),  # This is not a valid decimal value
         ]
         self.check_make_literals(inputs)
 


### PR DESCRIPTION
Fixes #1314

## Proposed Changes

  - Format `xsd:decimal` using `f"{x:f}"` to ensure it complies with https://www.w3.org/TR/xmlschema11-2/#decimal

NOTE: This uses the tests added in https://github.com/RDFLib/rdflib/pull/1315 so it might make sense to merge that first before this, only the second commit (https://github.com/RDFLib/rdflib/commit/c018c8fd767da8b6926a28363466610ec912cce5) is relevant here.