### PR TITLE
Update graph operator overloading for subclasses

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -558,7 +558,7 @@ class Graph(Node):
     def __add__(self, other):
         """Set-theoretic union
            BNode IDs are not changed."""
-        retval = Graph()
+        retval = self.__class__()
         for (prefix, uri) in set(list(self.namespaces()) + list(other.namespaces())):
             retval.bind(prefix, uri)
         for x in self:
@@ -570,7 +570,7 @@ class Graph(Node):
     def __mul__(self, other):
         """Set-theoretic intersection.
            BNode IDs are not changed."""
-        retval = Graph()
+        retval = self.__class__()
         for x in other:
             if x in self:
                 retval.add(x)
@@ -579,7 +579,7 @@ class Graph(Node):
     def __sub__(self, other):
         """Set-theoretic difference.
            BNode IDs are not changed."""
-        retval = Graph()
+        retval = self.__class__()
         for x in self:
             if x not in other:
                 retval.add(x)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -559,7 +559,7 @@ class Graph(Node):
         """Set-theoretic union
            BNode IDs are not changed."""
         try:
-            retval = self.__class__()
+            retval = type(self)()
         except TypeError:
             retval = Graph()
         for (prefix, uri) in set(list(self.namespaces()) + list(other.namespaces())):
@@ -574,7 +574,7 @@ class Graph(Node):
         """Set-theoretic intersection.
            BNode IDs are not changed."""
         try:
-            retval = self.__class__()
+            retval = type(self)()
         except TypeError:
             retval = Graph()
         for x in other:
@@ -586,7 +586,7 @@ class Graph(Node):
         """Set-theoretic difference.
            BNode IDs are not changed."""
         try:
-            retval = self.__class__()
+            retval = type(self)()
         except TypeError:
             retval = Graph()
         for x in self:

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -558,7 +558,10 @@ class Graph(Node):
     def __add__(self, other):
         """Set-theoretic union
            BNode IDs are not changed."""
-        retval = self.__class__()
+        try:
+            retval = self.__class__()
+        except TypeError:
+            retval = Graph()
         for (prefix, uri) in set(list(self.namespaces()) + list(other.namespaces())):
             retval.bind(prefix, uri)
         for x in self:
@@ -570,7 +573,10 @@ class Graph(Node):
     def __mul__(self, other):
         """Set-theoretic intersection.
            BNode IDs are not changed."""
-        retval = self.__class__()
+        try:
+            retval = self.__class__()
+        except TypeError:
+            retval = Graph()
         for x in other:
             if x in self:
                 retval.add(x)
@@ -579,7 +585,10 @@ class Graph(Node):
     def __sub__(self, other):
         """Set-theoretic difference.
            BNode IDs are not changed."""
-        retval = self.__class__()
+        try:
+            retval = self.__class__()
+        except TypeError:
+            retval = Graph()
         for x in self:
             if x not in other:
                 retval.add(x)

--- a/test/test_graph_operator.py
+++ b/test/test_graph_operator.py
@@ -1,0 +1,27 @@
+from rdflib import Graph
+
+
+class MyGraph(Graph):
+    def my_method(self):
+        pass
+
+
+def test_subclass_add_operator():
+    g = MyGraph()
+
+    g = g + g
+    assert "my_method" in dir(g)
+
+
+def test_subclass_sub_operator():
+    g = MyGraph()
+
+    g = g - g
+    assert "my_method" in dir(g)
+
+
+def test_subclass_mul_operator():
+    g = MyGraph()
+
+    g = g * g
+    assert "my_method" in dir(g)


### PR DESCRIPTION
This PR makes the set operations for rdflib.Graph subclasses (like `g1 = g1 + g2`) more intuitive and similar to the results of in-place set operations (like `g1 += g2`).

**Example**:

If you were to do a union of a `ConjunctiveGraph` (a subclass of Graph) instance with itself **or** any other `ConjunctiveGraph` instance using something like `g = g + g`, the instance would lose all the methods specific to the `ConjunctiveGraph`.


**Steps to reproduce the issue**:

```python
from rdflib import Graph

class MyGraph(Graph):
    def perform_reasoning(self):
        pass

g = MyGraph()
"perform_reasoning" in dir(g)
# True

g += g
"perform_reasoning" in dir(g)
# True

g = g + g
"perform_reasoning" in dir(g)
# False
```


## Proposed Changes
  - Use `type(self)()` instead of `Graph()` as the initial return value for set operations.
  - This would allow `Graph` to pass down similar behavior to its derived classes (unless overridden) without breaking any existing functionality.