### PR TITLE
Update README with chat info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ Please see the list for all packages/repositories here:
 
 * <https://github.com/RDFLib>
 
-
-## Versions
+## Versions & Releases
 
  * `5.x.y` supports Python 2.7 and 3.4+ and is [mostly backwards compatible with 4.2.2](https://rdflib.readthedocs.io/en/stable/upgrade4to5.html). Only bug fixes will be applied.
  * `6.x.y` is the next major release which will support Python 3.6+. (Current master branch)
 
+See <https://rdflib.dev> for the release schedule.
+
+## Documentation
+See <https://rdflib.readthedocs.io> for our documentation built from the code.
 
 ## Installation
 RDFLib may be installed with Python's package management tool *pip*:
@@ -102,8 +105,8 @@ g.add((
     rdflib.Literal("Nick", datatype=XSD.string)
 ))
 ```
-The triple (in n-triples notation) `<http://example.com/person/nick> <http://xmlns.com/foaf/0.1/givenName> "Nick"^^<http://www.w3.org/2001/XMLSchema#string> .` 
-is created where the property `FOAF.giveName` is the URI `<http://xmlns.com/foaf/0.1/givenName>` and `XSD.string` is the 
+The triple (in n-triples notation) `<http://example.com/person/nick> <http://xmlns.com/foaf/0.1/givenName> "Nick"^^<http://www.w3.org/2001/XMLSchema#string> .`
+is created where the property `FOAF.giveName` is the URI `<http://xmlns.com/foaf/0.1/givenName>` and `XSD.string` is the
 URI `<http://www.w3.org/2001/XMLSchema#string>`.
 
 You can bind namespaces to prefixes to shorten the URIs for RDF/XML, Turtle, N3, TriG, TriX & JSON-LD serializations:
@@ -153,35 +156,6 @@ are listed on [PyPI](https://pypi.python.org/pypi/rdflib/)
 
 Multiple other projects are contained within the RDFlib "family", see <https://github.com/RDFLib/>.
 
-
-## Documentation
-See <https://rdflib.readthedocs.io> for our documentation built from the code.
-
-
-## Support
-For general "how do I..." queries, please use https://stackoverflow.com and tag your question with `rdflib`. 
-Existing questions:
-
-* <https://stackoverflow.com/questions/tagged/rdflib>
-
-
-## Releases
-See <https://rdflib.dev> for the release schedule.
-
-
-## Contributing
-
-RDFLib survives and grows via user contributions!
-Please read our [contributing guide](https://rdflib.readthedocs.io/en/stable/developers.html) to get started.
-Please consider lodging Pull Requests here:
-
-* <https://github.com/RDFLib/rdflib/pulls>
-
-You can also raise issues here:
-
-* <https://github.com/RDFLib/rdflib/issues>
-
-
 ## Running tests
 
 ### Running the tests on the host
@@ -221,8 +195,24 @@ Once tests have produced HTML output of the coverage report, view it by running:
 python -m http.server --directory=cover
 ```
 
+## Contributing
 
-## Contacts
+RDFLib survives and grows via user contributions!
+Please read our [contributing guide](https://rdflib.readthedocs.io/en/stable/developers.html) to get started.
+Please consider lodging Pull Requests here:
+
+* <https://github.com/RDFLib/rdflib/pulls>
+
+You can also raise issues here:
+
+* <https://github.com/RDFLib/rdflib/issues>
+
+## Support & Contacts
+For general "how do I..." queries, please use https://stackoverflow.com and tag your question with `rdflib`.
+Existing questions:
+
+* <https://stackoverflow.com/questions/tagged/rdflib>
+
 If you want to contact the rdflib maintainers, please do so via the rdflib-dev mailing list:
 
 * <https://groups.google.com/group/rdflib-dev>

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Existing questions:
 
 * <https://stackoverflow.com/questions/tagged/rdflib>
 
-If you want to contact the rdflib maintainers, please do so via the rdflib-dev mailing list:
+If you want to contact the rdflib maintainers, please do so via:
 
-* <https://groups.google.com/group/rdflib-dev>
+* the rdflib-dev mailing list: <https://groups.google.com/group/rdflib-dev>
+* the chat, which is available at [gitter](https://gitter.im/RDFLib/rdflib) or via matrix [#RDFLib_rdflib:gitter.im](https://matrix.to/#/#RDFLib_rdflib:gitter.im)

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -13,7 +13,7 @@ Please be as Pythonic as possible (:pep:`8`).
 
 Code should be formatted using `black <https://github.com/psf/black>`_.
 While not yet mandatory, it will be required in the future  (6.0.0+).1
-Use Black v21.6b1, with the black.toml config file provided. 
+Use Black v21.6b1, with the black.toml config file provided.
 
 Any new functionality being added to RDFLib should have doc tests and
 unit tests. Tests should be added for any functionality being changed

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -110,6 +110,4 @@ No matter how you create the release tag, remember to upload tarball to pypi wit
 
 Set new dev version number in the above locations, i.e. next release `-dev`: ``5.0.1-dev`` and commit again.
 
-Tweet, email mailing list and update the topic of #rdflib on freenode irc::
-
-  /msg ChanServ topic #rdflib https://github.com/RDFLib/rdflib | latest stable version: 5.0.0 | docs: http://rdflib.readthedocs.org
+Tweet, email mailing list and inform members in the chat.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. rdflib documentation documentation master file
-   
+
 ================
 rdflib |release|
 ================
@@ -55,7 +55,7 @@ If you are familiar with RDF and are looking for details on how RDFLib handles i
    merging
    upgrade5to6
    upgrade4to5
-   
+
 
 Reference
 ---------
@@ -68,9 +68,9 @@ API reference:
 
    apidocs/modules
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 2
-			  
+
    plugins
 
 .. * :ref:`genindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,9 +86,6 @@ For developers
    docs
    persisting_n3_terms
 
-Developers might also like to join rdflib's dev mailing list: `<https://groups.google.com/group/rdflib-dev>`__
-
-
 Source Code
 -----------
 The rdflib source code is hosted on GitHub at `<https://github.com/RDFLib/rdflib>`__ where you can lodge Issues and
@@ -98,14 +95,19 @@ The RDFlib organisation on GitHub at `<https://github.com/RDFLib>`__ maintains t
 and RDFlib-related packaged that you might also find useful.
 
 
-Further help
-------------
-For asynchronous chat support, try our gitter channel at `<https://gitter.im/RDFLib/rdflib>`__
+Further help & Contact
+----------------------
 
 If you would like more help with using rdflib, rather than developing it, please post a question on StackOverflow using
 the tag ``[rdflib]``. A list of existing ``[rdflib]`` tagged questions is kept there at:
 
 * `<https://stackoverflow.com/questions/tagged/rdflib>`__
+
+You might also like to join rdflib's dev mailing list: `<https://groups.google.com/group/rdflib-dev>`__
+
+The chat is available at `gitter <https://gitter.im/RDFLib/rdflib>`_ or via matrix `#RDFLib_rdflib:gitter.im <https://matrix.to/#/#RDFLib_rdflib:gitter.im>`_.
+
+
 
 Glossary
 --------


### PR DESCRIPTION
Fixes #1341 

## Proposed Changes

  - update:
    - https://rdflib.readthedocs.io/en/stable/index.html - docco front page
    - https://rdflib.readthedocs.io/en/stable/developers.html - developers page (remove irc part and just write chat)
    - https://rdflib.dev/ - web page (done in https://github.com/RDFLib/rdflib.github.io/commit/e29426a77b6b19524d0f79dc9933b4e4558f9bc9)
    - https://github.com/RDFLib/rdflib - repo README
