### PR TITLE
Fixes 1190 - pin major version of pyparsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 html5lib
 isodate
-pyparsing
+pyparsing==2.*


### PR DESCRIPTION
Fixes #1190 -- currently rdflib sparql engine breaks with pyparsing 3b

