### PR TITLE
fixes #1374 adding RDF.li property to its correspoding namespace

### DIFF
--- a/rdflib/namespace/_RDF.py
+++ b/rdflib/namespace/_RDF.py
@@ -31,6 +31,10 @@ class RDF(DefinedNamespace):
     type: URIRef  # The subject is an instance of a class.
     value: URIRef  # Idiomatic property used for structured values.
 
+    # There is an rdf:li special property element that is equivalent to rdf:_1, rdf:_2 
+    # See https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-list-elements
+    li: URIRef
+
     # http://www.w3.org/2000/01/rdf-schema#Class
     Alt: URIRef  # The class of containers of alternatives.
     Bag: URIRef  # The class of unordered containers.


### PR DESCRIPTION
Fixes #1374 

## Proposed Changes

  - Add li property to RDF namespace

## To be done

 - Is not on me to decide how to handle `_{positive_integer}` forms. 

