### PR TITLE
Update intro_to_sparql.rst

### DIFF
--- a/docs/intro_to_sparql.rst
+++ b/docs/intro_to_sparql.rst
@@ -39,7 +39,8 @@ For example...
         ?a foaf:name ?aname .
         ?b foaf:name ?bname .
     }"""
-
+    
+    qres = g.query(knows_query)
     for row in qres:
         print(f"{row.aname} knows {row.bname}")
 


### PR DESCRIPTION
One line missing in the SPARQL example where the query should be run as in `qres = g.query(knows_query)`

Fixes #

## Proposed Changes

  -
  -
  -
