### PR TITLE
Fix/1369 custom resolver

### DIFF
--- a/rdflib/exceptions.py
+++ b/rdflib/exceptions.py
@@ -10,6 +10,8 @@ __all__ = [
     "ObjectTypeError",
     "ContextTypeError",
     "ParserError",
+    "ResolutionError",
+    "ResolutionForbiddenError",
 ]
 
 
@@ -104,12 +106,12 @@ class ResolutionError(Error):
 class ResolutionForbiddenError(Error):
     """Resolution of the given URL is not allowed."""
 
-    def __init__(self, location):
+    def __init__(self, url):
         Error.__init__(self, self.__doc__)
-        self.location = location
+        self.url = url
 
     def __str__(self):
-        return f"Resolution of '{self.location}' is not allowed."
+        return f"Resolution of '{self.url}' is not allowed."
 
 
 class UniquenessError(Error):

--- a/rdflib/exceptions.py
+++ b/rdflib/exceptions.py
@@ -87,6 +87,31 @@ class ParserError(Error):
         return self.msg
 
 
+class ResolutionError(Error):
+    """Resolution error.
+
+    This includes the case when the URI scheme is not supported.
+    """
+
+    def __init__(self, msg):
+        Error.__init__(self, msg)
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class ResolutionForbiddenError(Error):
+    """Resolution of the given URL is not allowed."""
+
+    def __init__(self, location):
+        Error.__init__(self, self.__doc__)
+        self.location = location
+
+    def __str__(self):
+        return f"Resolution of '{self.location}' is not allowed."
+
+
 class UniquenessError(Error):
     """A uniqueness assumption was made in the context, and that is not true"""
 

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -18,8 +18,6 @@ import sys
 from io import BytesIO, TextIOBase, TextIOWrapper, StringIO, BufferedIOBase
 
 from urllib.request import Request
-from urllib.request import url2pathname
-from urllib.parse import urljoin
 from urllib.request import urlopen
 from urllib.error import HTTPError
 
@@ -307,23 +305,6 @@ def create_input_source(
 
 
 def _create_input_source_from_location(file, format, input_source, location):
-    # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
-    path = pathlib.Path(location)
-    if path.exists():
-        location = path.absolute().as_uri()
+    from .resolver import get_default_resolver
 
-    base = pathlib.Path.cwd().as_uri()
-
-    absolute_location = URIRef(location, base=base)
-
-    if absolute_location.startswith("file:///"):
-        filename = url2pathname(absolute_location.replace("file:///", "/"))
-        file = open(filename, "rb")
-    else:
-        input_source = URLInputSource(absolute_location, format)
-
-    auto_close = True
-    # publicID = publicID or absolute_location  # Further to fix
-    # for issue 130
-
-    return absolute_location, auto_close, file, input_source
+    return get_default_resolver().resolve(file, format, input_source, location)

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -307,4 +307,6 @@ def create_input_source(
 def _create_input_source_from_location(file, format, input_source, location):
     from .resolver import get_default_resolver
 
-    return get_default_resolver().resolve(file, format, input_source, location)
+    return get_default_resolver().resolve(
+        file, format, input_source, location, trust=True
+    )

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -313,6 +313,12 @@ def create_input_source(
 def _create_input_source_from_location(file, format, input_source, location):
     from .resolver import get_default_resolver
 
-    return get_default_resolver().resolve(
-        file, format, input_source, location, trust=True
+    input_source = get_default_resolver().resolve(
+        format=format,
+        location=location,
+        trust=True,
     )
+
+    file = input_source.file if isinstance(input_source, FileInputSource) else file
+
+    return input_source.getSystemId(), True, file, input_source

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -37,10 +37,16 @@ __all__ = [
 
 
 class Parser(object):
-    __slots__ = ()
+    __slots__ = ("_resolver",)
 
-    def __init__(self):
-        pass
+    def __init__(self, *, resolver=None):
+        self._resolver = resolver
+
+    @property
+    def resolver(self):
+        from .resolver import get_default_resolver
+
+        return self._resolver or get_default_resolver()
 
     def parse(self, source, sink):
         pass

--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -32,17 +32,16 @@ Example usage::
 
 # NOTE: This code reads the entire JSON object into memory before parsing, but
 # we should consider streaming the input to deal with arbitrarily large graphs.
-
+import contextlib
 import warnings
 from rdflib.graph import ConjunctiveGraph
-from rdflib.parser import Parser, URLInputSource
+from rdflib.parser import Parser, URLInputSource, create_input_source
 from rdflib.namespace import RDF, XSD
 from rdflib.term import URIRef, BNode, Literal
 
 from ..shared.jsonld.context import Context, Term, UNDEF
 from ..shared.jsonld.util import (
     json,
-    source_to_json,
     VOCAB_DELIMS,
     context_from_urlinputsource,
 )
@@ -69,6 +68,8 @@ __all__ = ["JsonLDParser", "to_rdf"]
 
 
 # Add jsonld suffix so RDFLib can guess format from file name
+from ...resolver import get_default_resolver
+
 try:
     from rdflib.util import SUFFIX_FORMAT_MAP
 
@@ -108,7 +109,9 @@ class JsonLDParser(Parser):
 
         generalized_rdf = kwargs.get("generalized_rdf", False)
 
-        data = source_to_json(source)
+        input_source = create_input_source(source)
+        with contextlib.closing(input_source.getByteStream()) as stream:
+            data = json.load(stream)
 
         # NOTE: A ConjunctiveGraph parses into a Graph sink, so no sink will be
         # context_aware. Keeping this check in case RDFLib is changed, or
@@ -118,7 +121,15 @@ class JsonLDParser(Parser):
         else:
             conj_sink = sink
 
-        to_rdf(data, conj_sink, base, context_data, version, generalized_rdf)
+        to_rdf(
+            data,
+            conj_sink,
+            base,
+            context_data,
+            version,
+            generalized_rdf,
+            resolver=self.resolver,
+        )
 
 
 def to_rdf(
@@ -129,15 +140,18 @@ def to_rdf(
     version=None,
     generalized_rdf=False,
     allow_lists_of_lists=None,
+    resolver=None,
 ):
+    resolver = resolver or get_default_resolver()
+
     # TODO: docstring w. args and return value
-    context = Context(base=base, version=version)
+    context = Context(base=base, version=version, resolver=resolver)
     if context_data:
         context.load(context_data)
     parser = Parser(
         generalized_rdf=generalized_rdf, allow_lists_of_lists=allow_lists_of_lists
     )
-    return parser.parse(data, context, dataset)
+    return parser.parse(data, context, dataset, resolver=resolver)
 
 
 class Parser(object):
@@ -149,7 +163,7 @@ class Parser(object):
             else ALLOW_LISTS_OF_LISTS
         )
 
-    def parse(self, data, context, dataset):
+    def parse(self, data, context, dataset, resolver):
         topcontext = False
 
         if isinstance(data, list):

--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -84,9 +84,6 @@ ALLOW_LISTS_OF_LISTS = True  # NOTE: Not allowed in JSON-LD 1.0
 
 
 class JsonLDParser(Parser):
-    def __init__(self):
-        super(JsonLDParser, self).__init__()
-
     def parse(self, source, sink, **kwargs):
         # TODO: docstring w. args and return value
         encoding = kwargs.get("encoding") or "utf-8"

--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -1899,9 +1899,6 @@ class TurtleParser(Parser):
     See http://www.w3.org/TR/turtle/
     """
 
-    def __init__(self):
-        pass
-
     def parse(self, source, graph, encoding="utf-8", turtle=True):
 
         if encoding not in [None, "utf-8"]:
@@ -1932,9 +1929,6 @@ class N3Parser(TurtleParser):
     See http://www.w3.org/DesignIssues/Notation3.html
 
     """
-
-    def __init__(self):
-        pass
 
     def parse(self, source, graph, encoding="utf-8"):
         # we're currently being handed a Graph, not a ConjunctiveGraph

--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -593,9 +593,6 @@ def create_parser(target, store):
 
 
 class RDFXMLParser(Parser):
-    def __init__(self):
-        pass
-
     def parse(self, source, sink, **args):
         self._parser = create_parser(source, sink)
         content_handler = self._parser.getContentHandler()

--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -125,9 +125,6 @@ class TrigParser(Parser):
 
     """
 
-    def __init__(self):
-        pass
-
     def parse(self, source, graph, encoding="utf-8"):
 
         if encoding not in [None, "utf-8"]:

--- a/rdflib/plugins/parsers/trix.py
+++ b/rdflib/plugins/parsers/trix.py
@@ -262,9 +262,6 @@ def create_parser(store):
 class TriXParser(Parser):
     """A parser for TriX. See http://sw.nokia.com/trix/"""
 
-    def __init__(self):
-        pass
-
     def parse(self, source, sink, **args):
         assert (
             sink.store.context_aware

--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -119,7 +119,7 @@ def from_rdf(
         context = context_data
         context_data = context.to_dict()
     else:
-        context = Context(context_data, base=base)
+        context = Context(context_data, base=base, resolver=None)
 
     converter = Converter(context, use_native_types, use_rdf_type)
     result = converter.convert(graph)

--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -18,17 +18,6 @@ from rdflib.parser import create_input_source
 from io import StringIO
 
 
-def source_to_json(source):
-    # TODO: conneg for JSON (fix support in rdflib's URLInputSource!)
-    source = create_input_source(source, format="json-ld")
-
-    stream = source.getByteStream()
-    try:
-        return json.load(StringIO(stream.read().decode("utf-8")))
-    finally:
-        stream.close()
-
-
 VOCAB_DELIMS = ("#", "/", ":")
 
 

--- a/rdflib/resolver.py
+++ b/rdflib/resolver.py
@@ -33,7 +33,7 @@ _unspecified = object()
 
 
 class Resolver:
-    def resolve(self, file, format, input_source, location, trust=False):
+    def resolve(self, location, format, trust=False):
         """Resolve a location (URL) into an InputSource.
 
         The method signature mirrors `rdflib.parser._create_input_source_from_location`,
@@ -62,11 +62,9 @@ class Resolver:
 
         input_source = resolver_func(absolute_location, format, scheme)
 
-        auto_close = True
-        # publicID = publicID or absolute_location  # Further to fix
-        # for issue 130
+        assert input_source.getSystemId()
 
-        return absolute_location, auto_close, file, input_source
+        return input_source
 
     @functools.lru_cache()
     def _get_url_resolvers(self):

--- a/rdflib/resolver.py
+++ b/rdflib/resolver.py
@@ -1,0 +1,41 @@
+import pathlib
+from urllib.request import url2pathname
+
+from .parser import URLInputSource
+from .term import URIRef
+
+
+class Resolver:
+    def resolve(self, file, format, input_source, location):
+        # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
+        path = pathlib.Path(location)
+        if path.exists():
+            location = path.absolute().as_uri()
+
+        base = pathlib.Path.cwd().as_uri()
+
+        absolute_location = URIRef(location, base=base)
+
+        if absolute_location.startswith("file:///"):
+            filename = url2pathname(absolute_location.replace("file:///", "/"))
+            file = open(filename, "rb")
+        else:
+            input_source = URLInputSource(absolute_location, format)
+
+        auto_close = True
+        # publicID = publicID or absolute_location  # Further to fix
+        # for issue 130
+
+        return absolute_location, auto_close, file, input_source
+
+
+_default_resolver = Resolver()
+
+
+def set_default_resolver(resolver: Resolver):
+    global _default_resolver
+    _default_resolver = resolver
+
+
+def get_default_resolver() -> Resolver:
+    return _default_resolver

--- a/rdflib/resolver.py
+++ b/rdflib/resolver.py
@@ -1,3 +1,54 @@
+"""
+RDFLib's document resolution framework and implementation.
+
+This module implements an extensible resolver mechanism that can be used by parsers to
+dereference documents referred to in the process of parsing.
+
+This functionality comes into play with the JSON-LD parser, and is used when resolving
+a document's `@context` document.
+
+A resolver instance can be passed to :meth:`~rdflib.Graph:parse`:
+
+    >>> import io
+    >>>
+    >>> from rdflib import Graph
+    >>>
+    >>>
+    >>> graph.parse(
+    >>>     io.BytesIO(b"<a> <b> <c> ."),
+    >>>     format="application/n-triples",
+    >>>     parser=PermissiveResolver(),
+    >>> )
+
+If no resolver is specified when calling `parse()`, RDFLib falls back to the
+interpreter-wide default resolver. A default resolver instance can be set in code using
+:func:`set_default_resolver`, or via the `RDFLIB_DEFAULT_RESOLVER_CLASS` environment
+variable using a colon-delimited style (i.e. `"path.to.module:ClassName"`). The current
+default resolver instance can be retrieved using :func:`get_default_resolver`.
+
+If the default resolver is not explicitly set, the default resolver will be an instance
+of :class:`DefaultResolver`, which is implements a default-deny policy. This policy can
+be altered using the `RDFLIB_RESOLVABLE_URL_SCHEMES` and
+`RDFLIB_RESOLVABLE_URL_ALLOWLIST` environment variables. The first should be a
+whitespace-delimited list of URL schemes (e.g. `"file https"`) and the second should be a
+whitespace-delimited list of allowed URLs.
+
+Custom resolvers should subclass :class:`Resolver`, e.g.:
+
+    >>> class LocalResolver(Resolver):
+    >>>     documents = {}
+    >>>
+    >>>     def is_resolution_allowed(self, scheme: str, url: str) -> bool:
+    >>>         return url in documents or super().is_resolution_allowed(scheme, url)
+    >>>
+    >>>     @url_resolver(schemes={"http", "https"})
+    >>>     def resolve_http(self, url: str, format: str, scheme: str) -> InputSource:
+    >>>         return self.documents[url]
+
+To replicate the permissive behaviour of older releases, you can set
+:class:`PermissiveResolver` as your default resolver.
+"""
+
 import functools
 import importlib
 import os

--- a/test/jsonld/runner.py
+++ b/test/jsonld/runner.py
@@ -8,6 +8,7 @@ from rdflib.plugins.shared.jsonld.keys import CONTEXT, GRAPH
 
 # monkey-patch N-Quads parser via it's underlying W3CNTriplesParser to keep source bnode id:s ..
 from rdflib.plugins.parsers.ntriples import W3CNTriplesParser, r_nodeid, bNode
+from rdflib.resolver import PermissiveResolver
 
 
 def _preserving_nodeid(self, bnode_context=None):
@@ -29,6 +30,7 @@ def do_test_json(suite_base, cat, num, inputpath, expectedpath, context, options
         base=input_uri,
         context_data=context,
         generalized_rdf=True,
+        resolver=PermissiveResolver(),
     )
     expected_json = _load_json(expectedpath)
     use_native_types = True  # CONTEXT in input_obj
@@ -79,6 +81,7 @@ def do_test_parser(suite_base, cat, num, inputpath, expectedpath, context, optio
         base=options.get("base", input_uri),
         version=version,
         generalized_rdf=options.get("produceGeneralizedRdf", False),
+        resolver=PermissiveResolver(),
     )
     assert isomorphic(result_graph, expected_graph), "Expected:\n%s\nGot:\n%s" % (
         expected_graph.serialize(),

--- a/test/test_issue1160.py
+++ b/test/test_issue1160.py
@@ -22,11 +22,11 @@ class NamedGraphWithFragmentTest(unittest.TestCase):
         """Test that fragment part of the URL is not erased."""
         graph = ConjunctiveGraph()
 
-        with mock.patch("rdflib.parser.URLInputSource") as load_mock:
+        with mock.patch("rdflib.resolver.URLInputSource") as load_mock:
             # We have to expect an exception here.
             self.assertRaises(Exception, graph.query, QUERY)
 
         load_mock.assert_called_with(
             rdflib.URIRef("http://ns.example.com/named#"),
-            "nt",
+            'nt',
         )


### PR DESCRIPTION
Fixes #1369

## Proposed Changes

This adds a new Resolver framework, and updates the JSON-LD parser to use it.

As a result, implementors have much more control over which URLs referenced in JSON-LD documents will be resolved.

This PR implements a default-deny approach to URL resolution, which will need explaining in release notes and documentation. Implementors can revert to the old behaviour via environment variable if they are happy with the risks.

This also provides a base for future extensibility, e.g. caching or using locally-held copies of external resources.

No tests or documentation yet, but all existing tests pass when using the new `PermissiveResolver`.