### PR TITLE
Make graph and other methods chainable

### DIFF
--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -17,12 +17,18 @@ class Collection(object):
     >>> g = Graph('Memory')
     >>> listItem1 = BNode()
     >>> listItem2 = BNode()
-    >>> g.add((listName, RDF.first, Literal(1)))
-    >>> g.add((listName, RDF.rest, listItem1))
-    >>> g.add((listItem1, RDF.first, Literal(2)))
-    >>> g.add((listItem1, RDF.rest, listItem2))
-    >>> g.add((listItem2, RDF.rest, RDF.nil))
-    >>> g.add((listItem2, RDF.first, Literal(3)))
+    >>> g.add((listName, RDF.first, Literal(1))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((listName, RDF.rest, listItem1)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((listItem1, RDF.first, Literal(2))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((listItem1, RDF.rest, listItem2)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((listItem2, RDF.rest, RDF.nil)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((listItem2, RDF.first, Literal(3))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> c = Collection(g,listName)
     >>> pprint([term.n3() for term in c])
     [u'"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
@@ -51,12 +57,18 @@ class Collection(object):
         >>> g = Graph('Memory')
         >>> listItem1 = BNode()
         >>> listItem2 = BNode()
-        >>> g.add((listName, RDF.first, Literal(1)))
-        >>> g.add((listName, RDF.rest, listItem1))
-        >>> g.add((listItem1, RDF.first, Literal(2)))
-        >>> g.add((listItem1, RDF.rest, listItem2))
-        >>> g.add((listItem2, RDF.rest, RDF.nil))
-        >>> g.add((listItem2, RDF.first, Literal(3)))
+        >>> g.add((listName, RDF.first, Literal(1))) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((listName, RDF.rest, listItem1)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((listItem1, RDF.first, Literal(2))) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((listItem1, RDF.rest, listItem2)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((listItem2, RDF.rest, RDF.nil)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((listItem2, RDF.first, Literal(3))) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
         >>> c = Collection(g, listName)
         >>> print(c.n3()) #doctest: +NORMALIZE_WHITESPACE
         ( "1"^^<http://www.w3.org/2001/XMLSchema#integer>
@@ -131,12 +143,18 @@ class Collection(object):
         >>> a = BNode('foo')
         >>> b = BNode('bar')
         >>> c = BNode('baz')
-        >>> g.add((a, RDF.first, RDF.type))
-        >>> g.add((a, RDF.rest, b))
-        >>> g.add((b, RDF.first, RDFS.label))
-        >>> g.add((b, RDF.rest, c))
-        >>> g.add((c, RDF.first, RDFS.comment))
-        >>> g.add((c, RDF.rest, RDF.nil))
+        >>> g.add((a, RDF.first, RDF.type)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((a, RDF.rest, b)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((b, RDF.first, RDFS.label)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((b, RDF.rest, c)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((c, RDF.first, RDFS.comment)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((c, RDF.rest, RDF.nil)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
         >>> len(g)
         6
         >>> def listAncestry(node, graph):

--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -213,6 +213,7 @@ class Collection(object):
 
         self.graph.add((end, RDF.first, item))
         self.graph.add((end, RDF.rest, RDF.nil))
+        return self
 
     def __iadd__(self, other):
 
@@ -228,6 +229,7 @@ class Collection(object):
             self.graph.add((end, RDF.first, item))
 
         self.graph.add((end, RDF.rest, RDF.nil))
+        return self
 
     def clear(self):
         container = self.uri
@@ -237,6 +239,7 @@ class Collection(object):
             graph.remove((container, RDF.first, None))
             graph.remove((container, RDF.rest, None))
             container = rest
+        return self
 
 
 def test():

--- a/rdflib/container.py
+++ b/rdflib/container.py
@@ -183,6 +183,8 @@ class Container(object):
         self.graph.add((container, URIRef(elem_uri), item))
         self._len += 1
 
+        return self
+
     def append_multiple(self, other):
         """Adding multiple elements to the container to the end which are in python list other"""
 
@@ -195,6 +197,8 @@ class Container(object):
             self._len += 1
             elem_uri = str(RDF) + "_" + str(end)
             self.graph.add((container, URIRef(elem_uri), item))
+
+        return self
 
     def clear(self):
         """Removing all elements from the container"""
@@ -210,6 +214,7 @@ class Container(object):
             else:
                 break
         self._len = 0
+        return self
 
 
 class Bag(Container):
@@ -254,6 +259,7 @@ class Seq(Container):
             elem_uri_pos = str(RDF) + "_" + str(pos)
             self.graph.add((container, URIRef(elem_uri_pos), item))
             self._len += 1
+        return self
 
 
 class NoElementException(Exception):

--- a/rdflib/container.py
+++ b/rdflib/container.py
@@ -28,7 +28,8 @@ class Container(object):
         Two
 
         >>> # add a new item
-        >>> b.append(Literal("Hello"))
+        >>> b.append(Literal("Hello")) # doctest: +ELLIPSIS
+        <rdflib.container.Bag object at ...>
         >>> print(g.serialize(format="turtle"))
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         <BLANKLINE>

--- a/rdflib/events.py
+++ b/rdflib/events.py
@@ -13,7 +13,8 @@ to handle Event events.  A handler is a simple function or method that
 accepts the event as an argument:
 
   >>> def handler1(event): print(repr(event))
-  >>> d.subscribe(Event, handler1)
+  >>> d.subscribe(Event, handler1) # doctest: +ELLIPSIS
+  <rdflib.events.Dispatcher object at ...>
 
 Now dispatch a new event into the dispatcher, and see handler1 get
 fired:

--- a/rdflib/events.py
+++ b/rdflib/events.py
@@ -56,6 +56,7 @@ class Dispatcher(object):
 
     def set_map(self, amap):
         self._dispatch_map = amap
+        return self
 
     def get_map(self):
         return self._dispatch_map
@@ -72,6 +73,7 @@ class Dispatcher(object):
         else:
             lst.append(handler)
         self._dispatch_map[event_type] = lst
+        return self
 
     def dispatch(self, event):
         """Dispatch the given event to the subscribed handlers for

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -402,8 +402,7 @@ class Graph(Node):
         Might be necessary for stores that require closing a connection to a
         database or releasing some resource.
         """
-        self.__store.close(commit_pending_transaction=commit_pending_transaction)
-        return self
+        return self.__store.close(commit_pending_transaction=commit_pending_transaction)
 
     def add(self, triple):
         """Add a triple with self as context"""

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -354,15 +354,18 @@ class Graph(Node):
     def destroy(self, configuration):
         """Destroy the store identified by `configuration` if supported"""
         self.__store.destroy(configuration)
+        return self
 
     # Transactional interfaces (optional)
     def commit(self):
         """Commits active transactions"""
         self.__store.commit()
+        return self
 
     def rollback(self):
         """Rollback active transactions"""
         self.__store.rollback()
+        return self
 
     def open(self, configuration, create=False):
         """Open the graph store
@@ -379,6 +382,7 @@ class Graph(Node):
         database or releasing some resource.
         """
         self.__store.close(commit_pending_transaction=commit_pending_transaction)
+        return self
 
     def add(self, triple):
         """Add a triple with self as context"""
@@ -387,6 +391,7 @@ class Graph(Node):
         assert isinstance(p, Node), "Predicate %s must be an rdflib term" % (p,)
         assert isinstance(o, Node), "Object %s must be an rdflib term" % (o,)
         self.__store.add((s, p, o), self, quoted=False)
+        return self
 
     def addN(self, quads):
         """Add a sequence of triple with context"""
@@ -398,6 +403,7 @@ class Graph(Node):
             and c.identifier is self.identifier
             and _assertnode(s, p, o)
         )
+        return self
 
     def remove(self, triple):
         """Remove a triple from the graph
@@ -406,6 +412,7 @@ class Graph(Node):
         from all contexts.
         """
         self.__store.remove(triple, context=self)
+        return self
 
     def triples(self, triple):
         """Generator over the triple store
@@ -622,6 +629,7 @@ class Graph(Node):
         ), "p can't be None in .set([s,p,o]), as it would remove (s, *, *)"
         self.remove((subject, predicate, None))
         self.add((subject, predicate, object_))
+        return self
 
     def subjects(self, predicate=None, object=None):
         """A generator of subjects with the given predicate and object"""
@@ -1098,7 +1106,7 @@ class Graph(Node):
             else:
                 shutil.copy(name, dest)
                 os.remove(name)
-        return None
+        return self
 
     def print(self, format="turtle", encoding="utf-8", out=None):
         print(
@@ -1233,7 +1241,7 @@ class Graph(Node):
                 "Please use graph.parse() instead."
             )
         )
-        self.parse(source, publicID, format)
+        return self.parse(source, publicID, format)
 
     def query(
         self,
@@ -1551,6 +1559,7 @@ class ConjunctiveGraph(Graph):
         _assertnode(s, p, o)
 
         self.store.add((s, p, o), context=c, quoted=False)
+        return self
 
     def _graph(self, c):
         if c is None:
@@ -1566,6 +1575,7 @@ class ConjunctiveGraph(Graph):
         self.store.addN(
             (s, p, o, self._graph(c)) for s, p, o, c in quads if _assertnode(s, p, o)
         )
+        return self
 
     def remove(self, triple_or_quad):
         """
@@ -1579,6 +1589,7 @@ class ConjunctiveGraph(Graph):
         s, p, o, c = self._spoc(triple_or_quad)
 
         self.store.remove((s, p, o), context=c)
+        return self
 
     def triples(self, triple_or_quad, context=None):
         """
@@ -1898,6 +1909,7 @@ class Dataset(ConjunctiveGraph):
             # default graph cannot be removed
             # only triples deleted, so add it back in
             self.store.add_graph(self.default_context)
+        return self
 
     def contexts(self, triple=None):
         default = False
@@ -1941,6 +1953,7 @@ class QuotedGraph(Graph):
         assert isinstance(o, Node), "Object %s must be an rdflib term" % (o,)
 
         self.store.add((s, p, o), self, quoted=True)
+        return self
 
     def addN(self, quads):
         """Add a sequence of triple with context"""
@@ -1952,6 +1965,7 @@ class QuotedGraph(Graph):
             and c.identifier is self.identifier
             and _assertnode(s, p, o)
         )
+        return self
 
     def n3(self):
         """Return an n3 identifier for the Graph"""
@@ -2230,6 +2244,7 @@ class BatchAddGraph(object):
         """
         self.batch = []
         self.count = 0
+        return self
 
     def add(self, triple_or_quad):
         """
@@ -2245,6 +2260,7 @@ class BatchAddGraph(object):
             self.batch.append(triple_or_quad + self.__graph_tuple)
         else:
             self.batch.append(triple_or_quad)
+        return self
 
     def addN(self, quads):
         if self.__batch_addn:
@@ -2252,6 +2268,7 @@ class BatchAddGraph(object):
                 self.add(q)
         else:
             self.graph.addN(quads)
+        return self
 
     def __enter__(self):
         self.reset()

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -132,11 +132,15 @@ via triple pattern:
     >>> statementId = BNode()
     >>> print(len(g))
     0
-    >>> g.add((statementId, RDF.type, RDF.Statement))
+    >>> g.add((statementId, RDF.type, RDF.Statement)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g.add((statementId, RDF.subject,
-    ...     URIRef("http://rdflib.net/store/ConjunctiveGraph")))
-    >>> g.add((statementId, RDF.predicate, namespace.RDFS.label))
-    >>> g.add((statementId, RDF.object, Literal("Conjunctive Graph")))
+    ...     URIRef("http://rdflib.net/store/ConjunctiveGraph"))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((statementId, RDF.predicate, namespace.RDFS.label)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g.add((statementId, RDF.object, Literal("Conjunctive Graph"))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> print(len(g))
     4
     >>> for s, p, o in g:
@@ -151,7 +155,8 @@ via triple pattern:
     ...     print(o)
     ...
     Conjunctive Graph
-    >>> g.remove((statementId, RDF.type, RDF.Statement))
+    >>> g.remove((statementId, RDF.type, RDF.Statement)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> print(len(g))
     3
 
@@ -171,10 +176,14 @@ by RDFLib they are UUIDs and unique.
     >>> g1 = Graph()
     >>> g2 = Graph()
     >>> u = URIRef("http://example.com/foo")
-    >>> g1.add([u, namespace.RDFS.label, Literal("foo")])
-    >>> g1.add([u, namespace.RDFS.label, Literal("bar")])
-    >>> g2.add([u, namespace.RDFS.label, Literal("foo")])
-    >>> g2.add([u, namespace.RDFS.label, Literal("bing")])
+    >>> g1.add([u, namespace.RDFS.label, Literal("foo")]) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g1.add([u, namespace.RDFS.label, Literal("bar")]) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g2.add([u, namespace.RDFS.label, Literal("foo")]) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g2.add([u, namespace.RDFS.label, Literal("bing")]) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> len(g1 + g2)  # adds bing as label
     3
     >>> len(g1 - g2)  # removes foo
@@ -194,23 +203,35 @@ the same store:
     >>> stmt1 = BNode()
     >>> stmt2 = BNode()
     >>> stmt3 = BNode()
-    >>> g1.add((stmt1, RDF.type, RDF.Statement))
+    >>> g1.add((stmt1, RDF.type, RDF.Statement)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g1.add((stmt1, RDF.subject,
-    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph')))
-    >>> g1.add((stmt1, RDF.predicate, namespace.RDFS.label))
-    >>> g1.add((stmt1, RDF.object, Literal('Conjunctive Graph')))
-    >>> g2.add((stmt2, RDF.type, RDF.Statement))
+    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph'))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g1.add((stmt1, RDF.predicate, namespace.RDFS.label)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g1.add((stmt1, RDF.object, Literal('Conjunctive Graph'))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g2.add((stmt2, RDF.type, RDF.Statement)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g2.add((stmt2, RDF.subject,
-    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph')))
-    >>> g2.add((stmt2, RDF.predicate, RDF.type))
-    >>> g2.add((stmt2, RDF.object, namespace.RDFS.Class))
-    >>> g3.add((stmt3, RDF.type, RDF.Statement))
+    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph'))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g2.add((stmt2, RDF.predicate, RDF.type)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g2.add((stmt2, RDF.object, namespace.RDFS.Class)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g3.add((stmt3, RDF.type, RDF.Statement)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g3.add((stmt3, RDF.subject,
-    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph')))
-    >>> g3.add((stmt3, RDF.predicate, namespace.RDFS.comment))
+    ...     URIRef('http://rdflib.net/store/ConjunctiveGraph'))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+    >>> g3.add((stmt3, RDF.predicate, namespace.RDFS.comment)) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g3.add((stmt3, RDF.object, Literal(
     ...     'The top-level aggregate graph - The sum ' +
-    ...     'of all named graphs within a Store')))
+    ...     'of all named graphs within a Store'))) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> len(list(ConjunctiveGraph(store).subjects(RDF.type, RDF.Statement)))
     3
     >>> len(list(ReadOnlyGraphAggregate([g1,g2]).subjects(
@@ -437,7 +458,8 @@ class Graph(Node):
 
         >>> import rdflib
         >>> g = rdflib.Graph()
-        >>> g.add((rdflib.URIRef("urn:bob"), namespace.RDFS.label, rdflib.Literal("Bob")))
+        >>> g.add((rdflib.URIRef("urn:bob"), namespace.RDFS.label, rdflib.Literal("Bob"))) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
 
         >>> list(g[rdflib.URIRef("urn:bob")]) # all triples about bob
         [(rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('Bob'))]
@@ -763,18 +785,22 @@ class Graph(Node):
         >>> from pprint import pprint
         >>> g = ConjunctiveGraph()
         >>> u = URIRef("http://example.com/foo")
-        >>> g.add([u, namespace.RDFS.label, Literal("foo")])
-        >>> g.add([u, namespace.RDFS.label, Literal("bar")])
+        >>> g.add([u, namespace.RDFS.label, Literal("foo")]) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.ConjunctiveGraph'>)>
+        >>> g.add([u, namespace.RDFS.label, Literal("bar")]) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.ConjunctiveGraph'>)>
         >>> pprint(sorted(g.preferredLabel(u)))
         [(rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'),
           rdflib.term.Literal('bar')),
          (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'),
           rdflib.term.Literal('foo'))]
-        >>> g.add([u, namespace.SKOS.prefLabel, Literal("bla")])
+        >>> g.add([u, namespace.SKOS.prefLabel, Literal("bla")]) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.ConjunctiveGraph'>)>
         >>> pprint(g.preferredLabel(u))
         [(rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel'),
           rdflib.term.Literal('bla'))]
-        >>> g.add([u, namespace.SKOS.prefLabel, Literal("blubb", lang="en")])
+        >>> g.add([u, namespace.SKOS.prefLabel, Literal("blubb", lang="en")]) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.ConjunctiveGraph'>)>
         >>> sorted(g.preferredLabel(u)) #doctest: +NORMALIZE_WHITESPACE
         [(rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel'),
           rdflib.term.Literal('bla')),
@@ -859,12 +885,18 @@ class Graph(Node):
         >>> a=BNode("foo")
         >>> b=BNode("bar")
         >>> c=BNode("baz")
-        >>> g.add((a,RDF.first,RDF.type))
-        >>> g.add((a,RDF.rest,b))
-        >>> g.add((b,RDF.first,namespace.RDFS.label))
-        >>> g.add((b,RDF.rest,c))
-        >>> g.add((c,RDF.first,namespace.RDFS.comment))
-        >>> g.add((c,RDF.rest,RDF.nil))
+        >>> g.add((a,RDF.first,RDF.type)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((a,RDF.rest,b)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((b,RDF.first,namespace.RDFS.label)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((b,RDF.rest,c)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((c,RDF.first,namespace.RDFS.comment)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
+        >>> g.add((c,RDF.rest,RDF.nil)) # doctest: +ELLIPSIS
+        <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
         >>> def topList(node,g):
         ...    for s in g.subjects(RDF.rest, node):
         ...       yield s
@@ -1742,7 +1774,8 @@ class Dataset(ConjunctiveGraph):
     >>> # simple triples goes to default graph
     >>> ds.add((URIRef("http://example.org/a"),
     ...    URIRef("http://www.example.org/b"),
-    ...    Literal("foo")))
+    ...    Literal("foo")))  # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Dataset'>)>
     >>>
     >>> # Create a graph in the dataset, if the graph name has already been
     >>> # used, the corresponding graph will be returned
@@ -1753,12 +1786,14 @@ class Dataset(ConjunctiveGraph):
     >>> g.add(
     ...     (URIRef("http://example.org/x"),
     ...     URIRef("http://example.org/y"),
-    ...     Literal("bar")) )
+    ...     Literal("bar")) ) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> # alternatively: add a quad to the dataset -> goes to the graph
     >>> ds.add(
     ...     (URIRef("http://example.org/x"),
     ...     URIRef("http://example.org/z"),
-    ...     Literal("foo-bar"),g) )
+    ...     Literal("foo-bar"),g) ) # doctest: +ELLIPSIS
+    <Graph identifier=... (<class 'rdflib.graph.Dataset'>)>
     >>>
     >>> # querying triples return them all regardless of the graph
     >>> for t in ds.triples((None,None,None)):  # doctest: +SKIP


### PR DESCRIPTION
## Proposed Changes

Makes certain graph methods, like `remove` or `add` chainable. This will make it possible to write more concise code involving multiple graph modifications, along the lines of:

```python
g = Graph().add(...).addN(...).add(...).remove(...)
```