### PR TITLE
Add JSON-LD to guess_format()

### DIFF
--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -364,6 +364,8 @@ SUFFIX_FORMAT_MAP = {
     "svg": "rdfa",
     "nq": "nquads",
     "trig": "trig",
+    "json": "json-ld",
+    "jsonld": "json-ld",
 }
 
 
@@ -378,6 +380,8 @@ def guess_format(fpath, fmap=None):
         'xml'
         >>> guess_format('path/to/file.ttl')
         'turtle'
+        >>> guess_format('path/to/file.json')
+        'json-ld'
         >>> guess_format('path/to/file.xhtml')
         'rdfa'
         >>> guess_format('path/to/file.svg')


### PR DESCRIPTION
Now that the `rdflib` package provides the functionality formerly in the
package `rdflib-jsonld`, it would be helpful for the utility function
`guess_format` to recognize file extensions indicative of JSON-LD
content.

This patch adds recognition of two file extensions, preserving syntax of
the `SUFFIX_FORMAT_MAP` variable:
* `.json`
* `.jsonld`

The latter is in recognition of the IANA media type
`application/ld+json` reporting the `.jsonld` file extension.
References:
https://www.iana.org/assignments/media-types/application/ld+json
via https://www.iana.org/assignments/media-types/media-types.xhtml
via https://w3c.github.io/json-ld-syntax/#iana-considerations

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>

## Proposed Changes

  - Add "json" and "json-ld" to recognized extensions
  - Add "json" example to docstring for `guess_format`