### PR TITLE
Add test for adding JSON-LD to guess_format()

### DIFF
--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -10,6 +10,10 @@ from rdflib import Graph
 
 
 class FileParserGuessFormatTest(unittest.TestCase):
+    def test_jsonld(self):
+        g = Graph()
+        self.assertIsInstance(g.parse("test/jsonld/1.1/manifest.jsonld"), Graph)
+
     def test_ttl(self):
         g = Graph()
         self.assertIsInstance(g.parse("test/w3c/turtle/IRI_subject.ttl"), Graph)


### PR DESCRIPTION
This is a follow-on patch to:
e778e9413510721c2fedaae56d4ff826df265c30

Test was confirmed to pass by running this on the current `master`
branch, and confirmed to fail with e778e941 reverted.

    nosetests test/test_parse_file_guess_format.py

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>

## Proposed Changes

  - Adds unit test to confirm JSON-LD example parses without format hint assistance.