### PR TITLE
Use setName on TokenConverter to set the name property

### DIFF
--- a/rdflib/plugins/sparql/parserutils.py
+++ b/rdflib/plugins/sparql/parserutils.py
@@ -6,11 +6,6 @@ from pyparsing import TokenConverter, ParseResults, originalTextFor
 
 from rdflib import BNode, Variable
 
-DEBUG = True
-DEBUG = False
-if DEBUG:
-    import traceback
-
 """
 
 NOTE: PyParsing setResultName/__call__ provides a very similar solution to this
@@ -111,9 +106,9 @@ class Param(TokenConverter):
     """
 
     def __init__(self, name, expr, isList=False):
-        self.name = name
         self.isList = isList
         TokenConverter.__init__(self, expr)
+        self.setName(name)
         self.addParseAction(self.postParse2)
 
     def postParse2(self, tokenList):
@@ -215,7 +210,7 @@ class Comp(TokenConverter):
     def __init__(self, name, expr):
         self.expr = expr
         TokenConverter.__init__(self, expr)
-        self.name = name
+        self.setName(name)
         self.evalfn = None
 
     def postParse(self, instring, loc, tokenList):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 html5lib
 isodate
-pyparsing==2.*
+pyparsing


### PR DESCRIPTION
This works for both pyparsing 2 and 3.

Fixes #1370