### PR TITLE
Make Result.serialize work more like Graph.serialize

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -351,15 +351,15 @@ class Graph(Node):
         self.default_union = False
 
     @property
-    def store(self):
+    def store(self) -> Store:  # read-only attr
         return self.__store
 
     @property
-    def identifier(self):
+    def identifier(self) -> Node:  # read-only attr
         return self.__identifier
 
     @property
-    def namespace_manager(self):
+    def namespace_manager(self) -> NamespaceManager:
         """
         this graph's namespace-manager
         """
@@ -368,8 +368,9 @@ class Graph(Node):
         return self.__namespace_manager
 
     @namespace_manager.setter
-    def namespace_manager(self, nm):
-        self.__namespace_manager = nm
+    def namespace_manager(self, value: NamespaceManager):
+        """this graph's namespace-manager"""
+        self.__namespace_manager = value
 
     def __repr__(self):
         return "<Graph identifier=%s (%s)>" % (self.identifier, type(self))
@@ -1096,18 +1097,37 @@ class Graph(Node):
         encoding: Optional[str] = None,
         **args: Any,
     ) -> Union[bytes, str, "Graph"]:
-        """Serialize the Graph to destination
+        """
+        Serialize the graph.
 
-        If destination is None serialize method returns the serialization as
-        bytes or string.
-
-        If encoding is None and destination is None, returns a string
-        If encoding is set, and Destination is None, returns bytes
-
-        Format defaults to turtle.
-
-        Format support can be extended with plugins,
-        but "xml", "n3", "turtle", "nt", "pretty-xml", "trix", "trig" and "nquads" are built in.
+        :param destination:
+           The destination to serialize the graph to. This can be a path as a
+           :class:`str` or :class:`~pathlib.PurePath` object, or it can be a
+           :class:`~typing.IO[bytes]` like object. If this parameter is not
+           supplied the serialized graph will be returned.
+        :type destination: Optional[Union[str, typing.IO[bytes], pathlib.PurePath]]
+        :param format:
+           The format that the output should be written in. This value
+           references a :class:`~rdflib.serializer.Serializer` plugin. Format
+           support can be extended with plugins, but `"xml"`, `"n3"`,
+           `"turtle"`, `"nt"`, `"pretty-xml"`, `"trix"`, `"trig"`, `"nquads"`
+           and `"json-ld"` are built in. Defaults to `"turtle"`.
+        :type format: str
+        :param base:
+           The base IRI for formats that support it. For the turtle format this
+           will be used as the `@base` directive.
+        :type base: Optional[str]
+        :param encoding: Encoding of output.
+        :type encoding: Optional[str]
+        :param **args:
+           Additional arguments to pass to the
+           :class:`~rdflib.serializer.Serializer` that will be used.
+        :type **args: Any
+        :return: The serialized graph if `destination` is `None`.
+        :rtype: :class:`bytes` if `destination` is `None` and `encoding` is not `None`.
+        :rtype: :class:`bytes` if `destination` is `None` and `encoding` is `None`.
+        :return: `self` (i.e. the :class:`~rdflib.graph.Graph` instance) if `destination` is not None.
+        :rtype: :class:`~rdflib.graph.Graph` if `destination` is not None.
         """
 
         # if base is not given as attribute use the base set for the graph
@@ -1298,7 +1318,7 @@ class Graph(Node):
         if none are given, the namespaces from the graph's namespace manager
         are used.
 
-        :returntype: rdflib.query.Result
+        :returntype: :class:`~rdflib.query.Result`
 
         """
 

--- a/rdflib/plugins/serializers/n3.py
+++ b/rdflib/plugins/serializers/n3.py
@@ -109,7 +109,7 @@ class N3Serializer(TurtleSerializer):
             self.write("{")
             self.depth += 1
             serializer = N3Serializer(node, parent=self)
-            serializer.serialize(self.stream)
+            serializer.serialize(self.stream.buffer)
             self.depth -= 1
             self.write(self.indent() + "}")
             return True

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -12,6 +12,8 @@ from rdflib.serializer import Serializer
 import warnings
 import codecs
 
+from rdflib.util import as_textio
+
 __all__ = ["NTSerializer"]
 
 
@@ -38,9 +40,15 @@ class NTSerializer(Serializer):
                 f"Given encoding was: {encoding}"
             )
 
-        for triple in self.store:
-            stream.write(_nt_row(triple).encode())
-        stream.write("\n".encode())
+        with as_textio(
+            stream,
+            encoding=encoding,  # TODO: CHECK: self.encoding set removed, why?
+            errors="_rdflib_nt_escape",
+            write_through=True,
+        ) as text_stream:
+            for triple in self.store:
+                text_stream.write(_nt_row(triple))
+            text_stream.write("\n")
 
 
 class NT11Serializer(NTSerializer):

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -1,4 +1,4 @@
-from typing import IO, Dict, Optional, Set
+from typing import IO, Dict, Optional, Set, cast
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
 
 from rdflib.namespace import Namespace, RDF, RDFS  # , split_uri
@@ -173,6 +173,8 @@ class PrettyXMLSerializer(Serializer):
         encoding: Optional[str] = None,
         **args,
     ):
+        # TODO FIXME: this should be Optional, but it's not because nothing
+        # treats it as such.
         self.__serialized: Dict[Identifier, int] = {}
         store = self.store
         # if base is given here, use that, if not and a base is set for the graph use that
@@ -241,6 +243,7 @@ class PrettyXMLSerializer(Serializer):
         writer = self.writer
 
         if subject in self.forceRDFAbout:
+            subject = cast(URIRef, subject)
             writer.push(RDFVOC.Description)
             writer.attribute(RDFVOC.about, self.relativize(subject))
             writer.pop(RDFVOC.Description)
@@ -282,6 +285,7 @@ class PrettyXMLSerializer(Serializer):
 
         elif subject in self.forceRDFAbout:
             # TODO FIXME?: this looks like a duplicate of first condition
+            subject = cast(URIRef, subject)
             writer.push(RDFVOC.Description)
             writer.attribute(RDFVOC.about, self.relativize(subject))
             writer.pop(RDFVOC.Description)

--- a/rdflib/plugins/sparql/results/jsonresults.py
+++ b/rdflib/plugins/sparql/results/jsonresults.py
@@ -3,6 +3,7 @@ from typing import IO, Any, Dict, Optional, TextIO, Union
 
 from rdflib.query import Result, ResultException, ResultSerializer, ResultParser
 from rdflib import Literal, URIRef, BNode, Variable
+from rdflib.util import as_textio
 
 
 """A Serializer for SPARQL results in JSON:
@@ -29,8 +30,9 @@ class JSONResultSerializer(ResultSerializer):
     def __init__(self, result):
         ResultSerializer.__init__(self, result)
 
-    def serialize(self, stream: IO, encoding: str = None):  # type: ignore[override]
-
+    def serialize(
+        self, stream: Union[IO[bytes], TextIO], encoding: Optional[str] = None, **kwargs
+    ):
         res: Dict[str, Any] = {}
         if self.result.type == "ASK":
             res["head"] = {}
@@ -45,9 +47,7 @@ class JSONResultSerializer(ResultSerializer):
             ]
 
         r = json.dumps(res, allow_nan=False, ensure_ascii=False)
-        if encoding is not None:
-            stream.write(r.encode(encoding))
-        else:
+        with as_textio(stream, encoding=encoding) as stream:
             stream.write(r)
 
     def _bindingToJSON(self, b):

--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -1,5 +1,5 @@
 import logging
-from typing import IO, Optional
+from typing import IO, Optional, TextIO, Union
 
 from xml.sax.saxutils import XMLGenerator
 from xml.dom import XML_NAMESPACE
@@ -112,8 +112,11 @@ class XMLResultSerializer(ResultSerializer):
     def __init__(self, result):
         ResultSerializer.__init__(self, result)
 
-    def serialize(self, stream: IO, encoding: str = "utf-8", **kwargs):
-
+    def serialize(
+        self, stream: Union[IO[bytes], TextIO], encoding: Optional[str] = None, **kwargs
+    ):
+        if encoding is None:
+            encoding = "utf-8"
         writer = SPARQLXMLWriter(stream, encoding)
         if self.result.type == "ASK":
             writer.write_header([])

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -31,13 +31,14 @@ Statement and component type checkers
 
 from calendar import timegm
 from time import altzone
-from typing import Optional
+from typing import IO, Generator, Optional, TextIO, Union, cast
 
 # from time import daylight
 from time import gmtime
 from time import localtime
 from time import time
 from time import timezone
+from io import TextIOWrapper
 
 from os.path import splitext
 
@@ -52,6 +53,7 @@ from rdflib.term import BNode
 from rdflib.term import Literal
 from rdflib.term import URIRef
 from rdflib.compat import sign
+from contextlib import contextmanager
 
 __all__ = [
     "list2set",
@@ -504,6 +506,27 @@ def get_tree(
             tree.append(t)
 
     return (mapper(root), sorted(tree, key=sortkey))
+
+
+@contextmanager
+def as_textio(
+    anyio: Union[IO[bytes], TextIO],
+    encoding: Optional[str] = None,
+    errors: Union[str, None] = None,
+    write_through: bool = False,
+) -> Generator[TextIO, None, None]:
+    if hasattr(anyio, "encoding"):
+        yield cast(TextIO, anyio)
+    else:
+        textio_wrapper = TextIOWrapper(
+            cast(IO[bytes], anyio),
+            encoding=encoding,
+            errors=errors,
+            write_through=write_through,
+        )
+        yield textio_wrapper
+        textio_wrapper.flush()
+        textio_wrapper.detach()
 
 
 def test():

--- a/test/test_conjunctivegraph/test_conjunctive_graph.py
+++ b/test/test_conjunctivegraph/test_conjunctive_graph.py
@@ -5,9 +5,11 @@ Tests for ConjunctiveGraph that do not depend on the underlying store
 import pytest
 
 from rdflib import ConjunctiveGraph, Graph
+from rdflib.namespace import Namespace
 from rdflib.term import Identifier, URIRef, BNode
 from rdflib.parser import StringInputSource
-from os import path
+
+from .testutils import GraphHelper
 
 
 DATA = """
@@ -15,6 +17,17 @@ DATA = """
 """
 
 PUBLIC_ID = "http://example.org/record/1"
+
+EG = Namespace("http://example.com/")
+
+
+def test_add() -> None:
+    quad = (EG["subject"], EG["predicate"], EG["object"], EG["graph"])
+    g = ConjunctiveGraph()
+    g.add(quad)
+    quad_set = GraphHelper.quad_set(g)
+    assert len(quad_set) == 1
+    assert next(iter(quad_set)) == quad
 
 
 def test_bnode_publicid():

--- a/test/test_issues/test_issue523.py
+++ b/test/test_issues/test_issue523.py
@@ -9,9 +9,10 @@ def test_issue523():
         "SELECT (<../baz> as ?test) WHERE {}",
         base=rdflib.URIRef("http://example.org/foo/bar"),
     )
-    res = r.serialize(format="csv")
+    res = r.serialize(format="csv", encoding="utf-8")
     assert res == b"test\r\nhttp://example.org/baz\r\n", repr(res)
-
+    res = r.serialize(format="csv")
+    assert res == "test\r\nhttp://example.org/baz\r\n", repr(res)
     # expected result:
     # test
     # http://example.org/baz

--- a/test/test_serializers/test_serializer.py
+++ b/test/test_serializers/test_serializer.py
@@ -1,8 +1,198 @@
 import logging
+import enum
+import inspect
+import itertools
+import sys
 import unittest
 from rdflib import RDF, Graph, Literal, Namespace, URIRef
 from tempfile import TemporaryDirectory
+from contextlib import ExitStack
+from io import IOBase
 from pathlib import Path, PurePath
+from tempfile import TemporaryDirectory
+from test.testutils import GraphHelper, get_unique_plugins
+from typing import (
+    IO,
+    Any,
+    Dict,
+    Iterable,
+    NamedTuple,
+    Optional,
+    Set,
+    TextIO,
+    Tuple,
+    Union,
+    cast,
+)
+
+from rdflib import Graph
+from rdflib.graph import ConjunctiveGraph
+from rdflib.namespace import Namespace
+from rdflib.plugin import PluginException
+from rdflib.serializer import Serializer
+
+EG = Namespace("http://example.com/")
+
+
+class DestinationType(str, enum.Enum):
+    PATH = enum.auto()
+    PURE_PATH = enum.auto()
+    PATH_STR = enum.auto()
+    IO_BYTES = enum.auto()
+    TEXT_IO = enum.auto()
+
+
+class DestinationFactory:
+    _counter: int = 0
+
+    def __init__(self, tmpdir: Path) -> None:
+        self.tmpdir = tmpdir
+
+    def make(
+        self,
+        type: DestinationType,
+        stack: Optional[ExitStack] = None,
+    ) -> Tuple[Union[str, Path, PurePath, IO[bytes], TextIO], Path]:
+        self._counter += 1
+        count = self._counter
+        path = self.tmpdir / f"file-{type}-{count:05d}"
+        if type is DestinationType.PATH:
+            return (path, path)
+        if type is DestinationType.PURE_PATH:
+            return (PurePath(path), path)
+        if type is DestinationType.PATH_STR:
+            return (f"{path}", path)
+        if type is DestinationType.IO_BYTES:
+            return (
+                path.open("wb")
+                if stack is None
+                else stack.enter_context(path.open("wb")),
+                path,
+            )
+        if type is DestinationType.TEXT_IO:
+            return (
+                path.open("w")
+                if stack is None
+                else stack.enter_context(path.open("w")),
+                path,
+            )
+        raise ValueError(f"unsupported type {type}")
+
+
+class GraphType(str, enum.Enum):
+    QUAD = enum.auto()
+    TRIPLE = enum.auto()
+
+
+class FormatInfo(NamedTuple):
+    serializer_name: str
+    deserializer_name: str
+    graph_types: Set[GraphType]
+    encodings: Set[str]
+
+
+class FormatInfos(Dict[str, FormatInfo]):
+    def add_format(
+        self,
+        serializer_name: str,
+        *,
+        deserializer_name: Optional[str] = None,
+        graph_types: Set[GraphType],
+        encodings: Set[str],
+    ) -> None:
+        self[serializer_name] = FormatInfo(
+            serializer_name,
+            serializer_name if deserializer_name is None else deserializer_name,
+            {GraphType.QUAD, GraphType.TRIPLE} if graph_types is None else graph_types,
+            encodings,
+        )
+
+    def select(
+        self,
+        *,
+        name: Optional[Set[str]] = None,
+        graph_type: Optional[Set[GraphType]] = None,
+    ) -> Iterable[FormatInfo]:
+        for format in self.values():
+            if graph_type is not None and not graph_type.isdisjoint(format.graph_types):
+                yield format
+            if name is not None and format.serializer_name in name:
+                yield format
+
+    @classmethod
+    def make_graph(self, format_info: FormatInfo) -> Graph:
+        if GraphType.QUAD in format_info.graph_types:
+            return ConjunctiveGraph()
+        else:
+            return Graph()
+
+    @classmethod
+    def make(cls) -> "FormatInfos":
+        result = cls()
+
+        flexible_formats = {
+            "trig",
+        }
+        for format in flexible_formats:
+            result.add_format(
+                format,
+                graph_types={GraphType.TRIPLE, GraphType.QUAD},
+                encodings={"utf-8"},
+            )
+
+        triple_only_formats = {
+            "turtle",
+            "nt11",
+            "xml",
+            "n3",
+        }
+        for format in triple_only_formats:
+            result.add_format(
+                format, graph_types={GraphType.TRIPLE}, encodings={"utf-8"}
+            )
+
+        quad_only_formats = {
+            "nquads",
+            "trix",
+            "json-ld",
+        }
+        for format in quad_only_formats:
+            result.add_format(format, graph_types={GraphType.QUAD}, encodings={"utf-8"})
+
+        result.add_format(
+            "pretty-xml",
+            deserializer_name="xml",
+            graph_types={GraphType.TRIPLE},
+            encodings={"utf-8"},
+        )
+        result.add_format(
+            "ntriples",
+            graph_types={GraphType.TRIPLE},
+            encodings={"ascii"},
+        )
+
+        return result
+
+
+format_infos = FormatInfos.make()
+
+
+def assert_graphs_equal(
+    test_case: unittest.TestCase, lhs: Graph, rhs: Graph, check_context: bool = True
+) -> None:
+    lhs_has_quads = hasattr(lhs, "quads")
+    rhs_has_quads = hasattr(rhs, "quads")
+    lhs_set: Set[Any]
+    rhs_set: Set[Any]
+    if lhs_has_quads and rhs_has_quads and check_context:
+        lhs = cast(ConjunctiveGraph, lhs)
+        rhs = cast(ConjunctiveGraph, rhs)
+        lhs_set, rhs_set = GraphHelper.quad_sets([lhs, rhs])
+    else:
+        lhs_set, rhs_set = GraphHelper.triple_sets([lhs, rhs])
+    test_case.assertEqual(lhs_set, rhs_set)
+    test_case.assertTrue(len(lhs_set) > 0)
+    test_case.assertTrue(len(rhs_set) > 0)
 
 from typing import Tuple, cast
 
@@ -51,39 +241,49 @@ def test_rdf_type(format: str, tuple_index: int, is_keyword: bool) -> None:
 
 class TestSerialize(unittest.TestCase):
     def setUp(self) -> None:
-
-        graph = Graph()
-        subject = URIRef("example:subject")
-        predicate = URIRef("example:predicate")
-        object = Literal("日本語の表記体系", lang="jpx")
         self.triple = (
-            subject,
-            predicate,
-            object,
+            EG["subject"],
+            EG["predicate"],
+            Literal("日本語の表記体系", lang="jpx"),
         )
-        graph.add(self.triple)
-        self.graph = graph
+        self.context = EG["graph"]
+        self.quad = (*self.triple, self.context)
+
+        conjunctive_graph = ConjunctiveGraph()
+        conjunctive_graph.add(self.quad)
+        self.graph = conjunctive_graph
+
+        query = """
+        CONSTRUCT { ?subject ?predicate ?object } WHERE {
+            ?subject ?predicate ?object
+        } ORDER BY ?object
+        """
+        self.result = self.graph.query(query)
+        self.assertIsNotNone(self.result.graph)
+
+        self._tmpdir = TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
         return super().setUp()
 
-    def test_serialize_to_purepath(self):
-        with TemporaryDirectory() as td:
-            tfpath = PurePath(td) / "out.nt"
-            self.graph.serialize(destination=tfpath, format="nt", encoding="utf-8")
-            graph_check = Graph()
-            graph_check.parse(source=tfpath, format="nt")
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
 
-        self.assertEqual(self.triple, next(iter(graph_check)))
+    def test_graph(self) -> None:
+        quad_set = GraphHelper.quad_set(self.graph)
+        self.assertEqual(quad_set, {self.quad})
 
-    def test_serialize_to_path(self):
-        with TemporaryDirectory() as td:
-            tfpath = Path(td) / "out.nt"
-            self.graph.serialize(destination=tfpath, format="nt", encoding="utf-8")
-            graph_check = Graph()
-            graph_check.parse(source=tfpath, format="nt")
+    def test_all_formats_specified(self) -> None:
+        plugins = get_unique_plugins(Serializer)
+        for plugin_refs in plugins.values():
+            names = {plugin_ref.name for plugin_ref in plugin_refs}
+            self.assertNotEqual(
+                names.intersection(format_infos.keys()),
+                set(),
+                f"serializers does not include any of {names}",
+            )
 
-        self.assertEqual(self.triple, next(iter(graph_check)))
-
-    def test_serialize_to_neturl(self):
+    def test_serialize_to_neturl(self) -> None:
         with self.assertRaises(ValueError) as raised:
             self.graph.serialize(
                 destination="http://example.com/", format="nt", encoding="utf-8"
@@ -101,3 +301,232 @@ class TestSerialize(unittest.TestCase):
             graph_check = Graph()
             graph_check.parse(source=tfpath, format="nt")
         self.assertEqual(self.triple, next(iter(graph_check)))
+
+    def test_serialize_badformat(self) -> None:
+        with self.assertRaises(PluginException) as raised:
+            self.graph.serialize(destination="http://example.com/", format="badformat")
+        self.assertIn("badformat", f"{raised.exception}")
+
+    def test_str(self) -> None:
+        """
+        This function tests serialization of graphs to strings, either directly
+        or from query results.
+
+        This function also checks that the various string serialization
+        overloads are correct.
+        """
+        for format in format_infos.keys():
+            format_info = format_infos[format]
+
+            def check(data: str, check_context: bool = True) -> None:
+                with self.subTest(format=format, caller=inspect.stack()[1]):
+                    self.assertIsInstance(data, str)
+
+                    graph_check = FormatInfos.make_graph(format_info)
+                    graph_check.parse(data=data, format=format_info.deserializer_name)
+                    assert_graphs_equal(self, self.graph, graph_check, check_context)
+
+            if format == "turtle":
+                check(self.graph.serialize())
+                check(self.graph.serialize(None))
+            check(self.graph.serialize(None, format))
+            check(self.graph.serialize(None, format, encoding=None))
+            check(self.graph.serialize(None, format, None, None))
+            check(self.graph.serialize(None, format=format))
+            check(self.graph.serialize(None, format=format, encoding=None))
+
+            if GraphType.TRIPLE not in format_info.graph_types:
+                # tests below are only for formats that can work with context-less graphs.
+                continue
+
+            if format == "turtle":
+                check(self.result.serialize(), False)
+                check(self.result.serialize(None), False)
+            check(self.result.serialize(None, format=format), False)
+            check(self.result.serialize(None, None, format), False)
+            check(self.result.serialize(None, None, format=format), False)
+            check(self.result.serialize(None, encodin=None, format=format), False)
+            check(
+                self.result.serialize(destination=None, encoding=None, format=format),
+                False,
+            )
+
+    def test_bytes(self) -> None:
+        """
+        This function tests serialization of graphs to bytes, either directly or
+        from query results.
+
+        This function also checks that the various bytes serialization overloads
+        are correct.
+        """
+        for (format, encoding) in itertools.chain(
+            *(
+                itertools.product({format_info.serializer_name}, format_info.encodings)
+                for format_info in format_infos.values()
+            )
+        ):
+            format_info = format_infos[format]
+
+            def check(data: bytes, check_context: bool = True) -> None:
+                with self.subTest(
+                    format=format, encoding=encoding, caller=inspect.stack()[1]
+                ):
+                    # self.check_data_bytes(data, format=format, encoding=encoding)
+                    self.assertIsInstance(data, bytes)
+
+                    # double check that encoding is right
+                    data_str = data.decode(encoding)
+                    graph_check = FormatInfos.make_graph(format_info)
+                    graph_check.parse(
+                        data=data_str, format=format_info.deserializer_name
+                    )
+                    assert_graphs_equal(self, self.graph, graph_check, check_context)
+
+                    # actual check
+                    # TODO FIXME : handle other encodings
+                    if encoding == "utf-8":
+                        graph_check = FormatInfos.make_graph(format_info)
+                        graph_check.parse(
+                            data=data, format=format_info.deserializer_name
+                        )
+                        assert_graphs_equal(
+                            self, self.graph, graph_check, check_context
+                        )
+
+            if format == "turtle":
+                check(self.graph.serialize(encoding=encoding))
+            check(self.graph.serialize(None, format, encoding=encoding))
+            check(self.graph.serialize(None, format, None, encoding=encoding))
+            check(self.graph.serialize(None, format, encoding=encoding))
+            check(self.graph.serialize(None, format=format, encoding=encoding))
+
+            if GraphType.TRIPLE not in format_info.graph_types:
+                # tests below are only for formats that can work with context-less graphs.
+                continue
+
+            if format == "turtle":
+                check(self.result.serialize(encoding=encoding), False)
+                check(self.result.serialize(None, encoding), False)
+            check(self.result.serialize(encoding=encoding, format=format), False)
+            check(self.result.serialize(None, encoding, format), False)
+            check(self.result.serialize(None, encoding=encoding, format=format), False)
+            check(
+                self.result.serialize(
+                    destination=None, encoding=encoding, format=format
+                ),
+                False,
+            )
+
+    def test_file(self) -> None:
+        """
+        This function tests serialization of graphs to destinations, either directly or
+        from query results.
+
+        This function also checks that the various bytes serialization overloads
+        are correct.
+        """
+        dest_factory = DestinationFactory(self.tmpdir)
+
+        for (format, encoding, dest_type) in itertools.chain(
+            *(
+                itertools.product(
+                    {format_info.serializer_name},
+                    format_info.encodings,
+                    set(DestinationType).difference({DestinationType.TEXT_IO}),
+                )
+                for format_info in format_infos.values()
+            )
+        ):
+            format_info = format_infos[format]
+            with ExitStack() as stack:
+                dest_path: Path
+                _dest: Union[str, Path, PurePath, IO[bytes]]
+
+                def dest() -> Union[str, Path, PurePath, IO[bytes]]:
+                    nonlocal dest_path
+                    nonlocal _dest
+                    _dest, dest_path = cast(
+                        Tuple[Union[str, Path, PurePath, IO[bytes]], Path],
+                        dest_factory.make(dest_type, stack),
+                    )
+                    return _dest
+
+                def _check(check_context: bool = True) -> None:
+                    with self.subTest(
+                        format=format,
+                        encoding=encoding,
+                        dest_type=dest_type,
+                        caller=inspect.stack()[2],
+                    ):
+                        if isinstance(_dest, IOBase):  # type: ignore[unreachable]
+                            _dest.flush()
+
+                        source = Path(dest_path)
+
+                        # double check that encoding is right
+                        data_str = source.read_text(encoding=encoding)
+                        graph_check = FormatInfos.make_graph(format_info)
+                        graph_check.parse(
+                            data=data_str, format=format_info.deserializer_name
+                        )
+                        assert_graphs_equal(
+                            self, self.graph, graph_check, check_context
+                        )
+
+                        self.assertTrue(source.exists())
+                        # actual check
+                        # TODO FIXME : This should work for all encodings, not just utf-8
+                        if encoding == "utf-8":
+                            graph_check = FormatInfos.make_graph(format_info)
+                            graph_check.parse(
+                                source=source, format=format_info.deserializer_name
+                            )
+                            assert_graphs_equal(
+                                self, self.graph, graph_check, check_context
+                            )
+
+                        dest_path.unlink()
+
+                def check_a(graph: Graph) -> None:
+                    _check()
+
+                if (format, encoding) == ("turtle", "utf-8"):
+                    check_a(self.graph.serialize(dest()))
+                    check_a(self.graph.serialize(dest(), encoding=None))
+                if format == "turtle":
+                    check_a(self.graph.serialize(dest(), encoding=encoding))
+                if encoding == sys.getdefaultencoding():
+                    check_a(self.graph.serialize(dest(), format))
+                    check_a(self.graph.serialize(dest(), format, None))
+                    check_a(self.graph.serialize(dest(), format, None, None))
+
+                check_a(self.graph.serialize(dest(), format, encoding=encoding))
+                check_a(self.graph.serialize(dest(), format, None, encoding))
+
+                if GraphType.TRIPLE not in format_info.graph_types:
+                    # tests below are only for formats that can work with context-less graphs.
+                    continue
+
+                def check_b(none: None) -> None:
+                    _check(False)
+
+                if format == "turtle":
+                    check_b(self.result.serialize(dest(), encoding))
+                    check_b(
+                        self.result.serialize(
+                            destination=cast(str, dest()),
+                            encoding=encoding,
+                        )
+                    )
+                check_b(self.result.serialize(dest(), encoding=encoding, format=format))
+                check_b(
+                    self.result.serialize(
+                        destination=dest(), encoding=encoding, format=format
+                    )
+                )
+                check_b(
+                    self.result.serialize(
+                        destination=dest(), encoding=None, format=format
+                    )
+                )
+                check_b(self.result.serialize(destination=dest(), format=format))

--- a/test/test_sparql/test_sparql.py
+++ b/test/test_sparql/test_sparql.py
@@ -240,8 +240,15 @@ def test_txtresult():
     assert result.type == "SELECT"
     assert len(result) == 1
     assert result.vars == vars
-    txtresult = result.serialize(format="txt")
-    lines = txtresult.decode().splitlines()
+
+    bytesresult = result.serialize(format="txt", encoding="utf-8")
+    lines = bytesresult.decode().splitlines()
+    assert len(lines) == 3
+    vars_check = [Variable(var.strip()) for var in lines[0].split("|")]
+    assert vars_check == vars
+
+    strresult = result.serialize(format="txt")
+    lines = strresult.splitlines()
     assert len(lines) == 3
     vars_check = [Variable(var.strip()) for var in lines[0].split("|")]
     assert vars_check == vars

--- a/test/test_sparql_result_serialize.py
+++ b/test/test_sparql_result_serialize.py
@@ -1,0 +1,281 @@
+from contextlib import ExitStack
+import itertools
+from typing import (
+    IO,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    TextIO,
+    Union,
+    cast,
+)
+from rdflib.query import Result, ResultRow
+from test.test_serializer import DestinationFactory, DestinationType
+from test.testutils import GraphHelper
+from rdflib.term import Node
+import unittest
+from rdflib import Graph, Namespace
+from tempfile import TemporaryDirectory
+from pathlib import Path, PurePath
+from io import BytesIO, IOBase, StringIO
+import inspect
+
+EG = Namespace("http://example.com/")
+
+
+class FormatInfo(NamedTuple):
+    serializer_name: str
+    deserializer_name: str
+    encodings: Set[str]
+
+
+class FormatInfos(Dict[str, FormatInfo]):
+    def add_format(
+        self,
+        serializer_name: str,
+        deserializer_name: str,
+        *,
+        encodings: Set[str],
+    ) -> None:
+        self[serializer_name] = FormatInfo(
+            serializer_name,
+            deserializer_name,
+            encodings,
+        )
+
+    def select(
+        self,
+        *,
+        name: Optional[Set[str]] = None,
+    ) -> Iterable[FormatInfo]:
+        for format in self.values():
+            if name is not None and format.serializer_name in name:
+                yield format
+
+    @classmethod
+    def make(cls) -> "FormatInfos":
+        result = cls()
+        result.add_format("csv", "csv", encodings={"utf-8"})
+        result.add_format("json", "json", encodings={"utf-8"})
+        result.add_format("xml", "xml", encodings={"utf-8"})
+        result.add_format("txt", "txt", encodings={"utf-8"})
+
+        return result
+
+
+format_infos = FormatInfos.make()
+
+
+class ResultHelper:
+    @classmethod
+    def to_list(cls, result: Result) -> List[Dict[str, Node]]:
+        output: List[Dict[str, Node]] = []
+        row: ResultRow
+        for row in result:
+            output.append(row.asdict())
+        return output
+
+
+def check_txt(test_case: unittest.TestCase, result: Result, data: str) -> None:
+    """
+    This does somewhat of a smoke tests that data is the txt serialization of the
+    given result. This is by no means perfect but better than nothing.
+    """
+    txt_lines = data.splitlines()
+    test_case.assertEqual(len(txt_lines) - 2, len(result))
+    test_case.assertRegex(txt_lines[1], r"^[-]+$")
+    header = txt_lines[0]
+    test_case.assertIsNotNone(result.vars)
+    assert result.vars is not None
+    for var in result.vars:
+        test_case.assertIn(var, header)
+    for row_index, row in enumerate(result):
+        txt_row = txt_lines[row_index + 2]
+        value: Node
+        for key, value in row.asdict().items():
+            test_case.assertIn(f"{value}", txt_row)
+
+
+class TestSerializeSelect(unittest.TestCase):
+    def setUp(self) -> None:
+        graph = Graph()
+        triples = [
+            (EG["e0"], EG["a0"], EG["e1"]),
+            (EG["e0"], EG["a0"], EG["e2"]),
+            (EG["e0"], EG["a0"], EG["e3"]),
+            (EG["e1"], EG["a1"], EG["e2"]),
+            (EG["e1"], EG["a1"], EG["e3"]),
+            (EG["e2"], EG["a2"], EG["e3"]),
+        ]
+        GraphHelper.add_triples(graph, triples)
+
+        query = """
+        PREFIX eg: <http://example.com/>
+        SELECT ?subject ?predicate ?object WHERE {
+            VALUES ?predicate { eg:a1 }
+            ?subject ?predicate ?object
+        } ORDER BY ?object
+        """
+        self.result = graph.query(query)
+        self.result_table = [
+            ["subject", "predicate", "object"],
+            ["http://example.com/e1", "http://example.com/a1", "http://example.com/e2"],
+            ["http://example.com/e1", "http://example.com/a1", "http://example.com/e3"],
+        ]
+
+        self._tmpdir = TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_str(self) -> None:
+        for format in format_infos.keys():
+
+            def check(data: str) -> None:
+                with self.subTest(format=format, caller=inspect.stack()[1]):
+                    self.assertIsInstance(data, str)
+                    format_info = format_infos[format]
+                    if format_info.deserializer_name == "txt":
+                        check_txt(self, self.result, data)
+                    else:
+                        result_check = Result.parse(
+                            StringIO(data), format=format_info.deserializer_name
+                        )
+                        self.assertEqual(self.result, result_check)
+
+            if format == "txt":
+                check(self.result.serialize())
+                check(self.result.serialize(None, None, None))
+            check(self.result.serialize(None, None, format))
+            check(self.result.serialize(format=format))
+            check(self.result.serialize(destination=None, format=format))
+            check(self.result.serialize(destination=None, encoding=None, format=format))
+
+    def test_bytes(self) -> None:
+        for (format, encoding) in itertools.chain(
+            *(
+                itertools.product({format_info.serializer_name}, format_info.encodings)
+                for format_info in format_infos.values()
+            )
+        ):
+
+            def check(data: bytes) -> None:
+                with self.subTest(format=format, caller=inspect.stack()[1]):
+                    self.assertIsInstance(data, bytes)
+                    format_info = format_infos[format]
+                    if format_info.deserializer_name == "txt":
+                        check_txt(self, self.result, data.decode(encoding))
+                    else:
+                        result_check = Result.parse(
+                            BytesIO(data), format=format_info.deserializer_name
+                        )
+                        self.assertEqual(self.result, result_check)
+
+            if format == "txt":
+                check(self.result.serialize(encoding=encoding))
+                check(self.result.serialize(None, encoding, None))
+                check(self.result.serialize(None, encoding))
+            check(self.result.serialize(None, encoding, format))
+            check(self.result.serialize(format=format, encoding=encoding))
+            check(
+                self.result.serialize(
+                    destination=None, format=format, encoding=encoding
+                )
+            )
+            check(
+                self.result.serialize(
+                    destination=None, encoding=encoding, format=format
+                )
+            )
+
+    def test_file(self) -> None:
+
+        dest_factory = DestinationFactory(self.tmpdir)
+
+        for (format, encoding, dest_type) in itertools.chain(
+            *(
+                itertools.product(
+                    {format_info.serializer_name},
+                    format_info.encodings,
+                    set(DestinationType),
+                )
+                for format_info in format_infos.values()
+            )
+        ):
+            with ExitStack() as stack:
+                dest_path: Path
+                _dest: Union[str, Path, PurePath, IO[bytes], TextIO]
+
+                def dest() -> Union[str, Path, PurePath, IO[bytes], TextIO]:
+                    nonlocal dest_path
+                    nonlocal _dest
+                    _dest, dest_path = dest_factory.make(dest_type, stack)
+                    return _dest
+
+                def check(none: None) -> None:
+                    with self.subTest(
+                        format=format,
+                        encoding=encoding,
+                        dest_type=dest_type,
+                        caller=inspect.stack()[1],
+                    ):
+                        if isinstance(_dest, IOBase):  # type: ignore[unreachable]
+                            _dest.flush()
+                        format_info = format_infos[format]
+                        data_str = dest_path.read_text(encoding=encoding)
+                        if format_info.deserializer_name == "txt":
+                            check_txt(self, self.result, data_str)
+                        else:
+                            result_check = Result.parse(
+                                StringIO(data_str), format=format_info.deserializer_name
+                            )
+                            self.assertEqual(self.result, result_check)
+                        dest_path.unlink()
+
+                if dest_type == DestinationType.IO_BYTES:
+                    check(
+                        self.result.serialize(
+                            cast(IO[bytes], dest()),
+                            encoding,
+                            format,
+                        )
+                    )
+                    check(
+                        self.result.serialize(
+                            cast(IO[bytes], dest()),
+                            encoding,
+                            format=format,
+                        )
+                    )
+                    check(
+                        self.result.serialize(
+                            cast(IO[bytes], dest()),
+                            encoding=encoding,
+                            format=format,
+                        )
+                    )
+                    check(
+                        self.result.serialize(
+                            destination=cast(IO[bytes], dest()),
+                            encoding=encoding,
+                            format=format,
+                        )
+                    )
+                check(
+                    self.result.serialize(
+                        destination=dest(), encoding=None, format=format
+                    )
+                )
+                check(self.result.serialize(destination=dest(), format=format))
+                check(self.result.serialize(dest(), format=format))
+                check(self.result.serialize(dest(), None, format))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**DO NOT REVIEW**: I'm going to split everything off from this that I can to reduce it to just the breaking changes so we can merge it before 7.0.0.

~~**Reviewers beware**: This patch is pretty big and contains a lot of things that could be merged separately. I may at some point break off some of the changes to separate PRs.~~

This patch makes the following changes to `Result.serialize`.

* Return str by default instead of bytes.
* Use "txt" as the default tabular serialization format.
* Use "turtle" as the default graph serialization format.
* Support both typing.IO[bytes] and typing.TextIO destinations.

Corresponding changes are made to the specific serializers also.

This patch also changes how text is written to typing.IO[bytes] in
serializers to ensure that the buffer is flushed and
detatched from the TextIOWrapper once the serialization function
completes so it can be used normally afterwards.

This patch further includes a bunch of additional type hints.

Fixes #1338