### PR TITLE
Remove Tox reference to Python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36,py37,py38,py39
+    py37,py38,py39
 
 [testenv]
 setenv =


### PR DESCRIPTION
This aligns testing with the list of supported versions in the setup.py Python version classifiers list.

I have not tested this, but I assume it corrects an oversight in the 6.0.0 release.

## Proposed Changes

  - Remove py36 environment from `tox.ini`.