### PR TITLE
A new Turtle serializer

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -161,6 +161,7 @@ register(
     "text/turtle", Serializer, "rdflib.plugins.serializers.turtle", "TurtleSerializer"
 )
 register("turtle", Serializer, "rdflib.plugins.serializers.turtle", "TurtleSerializer")
+register("turtle2", Serializer, "rdflib.plugins.serializers.turtle2", "TurtleSerializer2")
 register("ttl", Serializer, "rdflib.plugins.serializers.turtle", "TurtleSerializer")
 register(
     "application/n-triples", Serializer, "rdflib.plugins.serializers.nt", "NTSerializer"

--- a/rdflib/plugins/serializers/turtle2.py
+++ b/rdflib/plugins/serializers/turtle2.py
@@ -1,0 +1,331 @@
+"""
+Turtle2 RDF graph serializer for RDFLib.
+See <http://www.w3.org/TeamSubmission/turtle/> for syntax specification.
+
+This variant, turtle2 as opposed to just turtle, makes some small format changes
+to turtle - the original turtle serializer - which are:
+
+* using PREFIX instead of @prefix
+* using BASE instead of @base
+* adding a new line at RDF.type, or 'a'
+* adding newline and an indent for all triples with more than one object (object list)
+* adding a new line and ';' for the last triple in a set with '.'
+    on the start of the next line
+* default encoding (encode()) is used instead of "latin-1"
+
+- Nicholas Car, 2021
+"""
+
+from collections import defaultdict
+from functools import cmp_to_key
+
+from rdflib.term import BNode, Literal, URIRef
+from rdflib.exceptions import Error
+from rdflib.serializer import Serializer
+from .turtle import RecursiveSerializer
+from rdflib.namespace import RDF, RDFS
+
+__all__ = ["RecursiveSerializer", "TurtleSerializer2"]
+
+
+def _object_comparator(a, b):
+    """
+    for nice clean output we sort the objects of triples,
+    some of them are literals,
+    these are sorted according to the sort order of the underlying python objects
+    in py3 not all things are comparable.
+    This falls back on comparing string representations when not.
+    """
+
+    try:
+        if a > b:
+            return 1
+        if a < b:
+            return -1
+        return 0
+
+    except TypeError:
+        a = str(a)
+        b = str(b)
+        return (a > b) - (a < b)
+
+SUBJECT = 0
+VERB = 1
+OBJECT = 2
+
+_GEN_QNAME_FOR_DT = False
+_SPACIOUS_OUTPUT = False
+
+
+class TurtleSerializer2(RecursiveSerializer):
+
+    short_name = "turtle2"
+    indentString = "    "
+
+    def __init__(self, store):
+        self._ns_rewrite = {}
+        super(TurtleSerializer2, self).__init__(store)
+        self.keywords = {RDF.type: "a"}
+        self.reset()
+        self.stream = None
+        self._spacious = _SPACIOUS_OUTPUT
+
+    def addNamespace(self, prefix, namespace):
+        # Turtle does not support prefixes that start with _
+        # if they occur in the graph, rewrite to p_blah
+        # this is more complicated since we need to make sure p_blah
+        # does not already exist. And we register namespaces as we go, i.e.
+        # we may first see a triple with prefix _9 - rewrite it to p_9
+        # and then later find a triple with a "real" p_9 prefix
+
+        # so we need to keep track of ns rewrites we made so far.
+
+        if (prefix > "" and prefix[0] == "_") or self.namespaces.get(
+            prefix, namespace
+        ) != namespace:
+
+            if prefix not in self._ns_rewrite:
+                p = "p" + prefix
+                while p in self.namespaces:
+                    p = "p" + p
+                self._ns_rewrite[prefix] = p
+
+            prefix = self._ns_rewrite.get(prefix, prefix)
+
+        super(TurtleSerializer2, self).addNamespace(prefix, namespace)
+        return prefix
+
+    def reset(self):
+        super(TurtleSerializer2, self).reset()
+        self._shortNames = {}
+        self._started = False
+        self._ns_rewrite = {}
+
+    def serialize(self, stream, base=None, encoding=None, spacious=None, **args):
+        self.reset()
+        self.stream = stream
+        # if base is given here, use that, if not and a base is set for the graph use that
+        if base is not None:
+            self.base = base
+        elif self.store.base is not None:
+            self.base = self.store.base
+
+        if spacious is not None:
+            self._spacious = spacious
+
+        self.preprocess()
+        subjects_list = self.orderSubjects()
+
+        self.startDocument()
+
+        firstTime = True
+        for subject in subjects_list:
+            if self.isDone(subject):
+                continue
+            if firstTime:
+                firstTime = False
+            if self.statement(subject) and not firstTime:
+                self.write("\n")
+
+        self.endDocument()
+        self.write("\n")
+
+        self.base = None
+
+    def preprocessTriple(self, triple):
+        super(TurtleSerializer2, self).preprocessTriple(triple)
+        for i, node in enumerate(triple):
+            if node in self.keywords:
+                continue
+            # Don't use generated prefixes for subjects and objects
+            self.getQName(node, gen_prefix=(i == VERB))
+            if isinstance(node, Literal) and node.datatype:
+                self.getQName(node.datatype, gen_prefix=_GEN_QNAME_FOR_DT)
+        p = triple[1]
+        if isinstance(p, BNode):  # hmm - when is P ever a bnode?
+            self._references[p] += 1
+
+    def getQName(self, uri, gen_prefix=True):
+        if not isinstance(uri, URIRef):
+            return None
+
+        parts = None
+
+        try:
+            parts = self.store.compute_qname(uri, generate=gen_prefix)
+        except:
+
+            # is the uri a namespace in itself?
+            pfx = self.store.store.prefix(uri)
+
+            if pfx is not None:
+                parts = (pfx, uri, "")
+            else:
+                # nothing worked
+                return None
+
+        prefix, namespace, local = parts
+
+        # QName cannot end with .
+        if local.endswith("."):
+            return None
+
+        prefix = self.addNamespace(prefix, namespace)
+
+        return "%s:%s" % (prefix, local)
+
+    def startDocument(self):
+        self._started = True
+        ns_list = sorted(self.namespaces.items())
+
+        if self.base:
+            self.write(self.indent() + "BASE <%s>\n" % self.base)
+        for prefix, uri in ns_list:
+            self.write(self.indent() + "PREFIX %s: <%s>\n" % (prefix, uri))
+        if ns_list and self._spacious:
+            self.write("\n")
+
+    def endDocument(self):
+        if self._spacious:
+            self.write("\n")
+
+    def statement(self, subject):
+        self.subjectDone(subject)
+        return self.s_squared(subject) or self.s_default(subject)
+
+    def s_default(self, subject):
+        self.write("\n" + self.indent())
+        self.path(subject, SUBJECT)
+        self.write("\n" + self.indent())
+        self.predicateList(subject)
+        self.write(" ;\n.")
+        return True
+
+    def s_squared(self, subject):
+        if (self._references[subject] > 0) or not isinstance(subject, BNode):
+            return False
+        self.write("\n" + self.indent() + "[]")
+        self.predicateList(subject)
+        self.write(" ;\n.")
+        return True
+
+    def path(self, node, position, newline=False):
+        if not (
+            self.p_squared(node, position, newline)
+            or self.p_default(node, position, newline)
+        ):
+            raise Error("Cannot serialize node '%s'" % (node,))
+
+    def p_default(self, node, position, newline=False):
+        if position != SUBJECT and not newline:
+            self.write(" ")
+        self.write(self.label(node, position))
+        return True
+
+    def label(self, node, position):
+        if node == RDF.nil:
+            return "()"
+        if position is VERB and node in self.keywords:
+            return self.keywords[node]
+        if isinstance(node, Literal):
+            return node._literal_n3(
+                use_plain=True,
+                qname_callback=lambda dt: self.getQName(dt, _GEN_QNAME_FOR_DT),
+            )
+        else:
+            node = self.relativize(node)
+
+            return self.getQName(node, position == VERB) or node.n3()
+
+    def p_squared(self, node, position, newline=False):
+        if (
+            not isinstance(node, BNode)
+            or node in self._serialized
+            or self._references[node] > 1
+            or position == SUBJECT
+        ):
+            return False
+
+        if not newline:
+            self.write(" ")
+
+        if self.isValidList(node):
+            # this is a list
+            self.depth += 2
+            self.write("(\n")
+            self.depth -= 1
+            self.doList(node)
+            self.depth -= 1
+            self.write("\n" + self.indent(1) + ")")
+        else:
+            self.subjectDone(node)
+            self.depth += 2
+            self.write("[\n")
+            self.depth -= 1
+            self.predicateList(node, newline=False)
+            self.depth -= 1
+            self.write("\n" + self.indent(1) + "]")
+
+        return True
+
+    def isValidList(self, l_):
+        """
+        Checks if l is a valid RDF list, i.e. no nodes have other properties.
+        """
+        try:
+            if self.store.value(l_, RDF.first) is None:
+                return False
+        except:
+            return False
+        while l_:
+            if l_ != RDF.nil and len(list(self.store.predicate_objects(l_))) != 2:
+                return False
+            l_ = self.store.value(l_, RDF.rest)
+        return True
+
+    def doList(self, l_):
+        i = 0
+        while l_:
+            item = self.store.value(l_, RDF.first)
+            if item is not None:
+                if i == 0:
+                    self.write(self.indent(1))
+                else:
+                    self.write("\n" + self.indent(1))
+                self.path(item, OBJECT, newline=True)
+                self.subjectDone(l_)
+            l_ = self.store.value(l_, RDF.rest)
+            i += 1
+
+    def predicateList(self, subject, newline=False):
+        properties = self.buildPredicateHash(subject)
+        propList = self.sortProperties(properties)
+        if len(propList) == 0:
+            return
+        self.write(self.indent(1))
+        self.verb(propList[0], newline=True)
+        self.objectList(properties[propList[0]])
+        for predicate in propList[1:]:
+            self.write(" ;\n" + self.indent(1))
+            self.verb(predicate, newline=True)
+            self.objectList(properties[predicate])
+
+    def verb(self, node, newline=False):
+        self.path(node, VERB, newline)
+
+    def objectList(self, objects):
+        count = len(objects)
+        if count == 0:
+            return
+        depthmod = (count == 1) and 0 or 1
+        self.depth += depthmod
+        first_nl = False
+        if count > 1:
+            self.write("\n" + self.indent(1))
+            first_nl = True
+        self.path(objects[0], OBJECT, newline=first_nl)
+        for obj in objects[1:]:
+            self.write(" ,\n")
+            self.write(self.indent(1))
+            self.path(obj, OBJECT, newline=True)
+        self.depth -= depthmod

--- a/rdflib/plugins/serializers/turtle2.py
+++ b/rdflib/plugins/serializers/turtle2.py
@@ -49,6 +49,7 @@ def _object_comparator(a, b):
         b = str(b)
         return (a > b) - (a < b)
 
+
 SUBJECT = 0
 VERB = 1
 OBJECT = 2

--- a/rdflib/plugins/serializers/turtle2.py
+++ b/rdflib/plugins/serializers/turtle2.py
@@ -3,52 +3,25 @@ Turtle2 RDF graph serializer for RDFLib.
 See <http://www.w3.org/TeamSubmission/turtle/> for syntax specification.
 
 This variant, turtle2 as opposed to just turtle, makes some small format changes
-to turtle - the original turtle serializer - which are:
+to turtle - the original turtle serializer. It:
 
-* using PREFIX instead of @prefix
-* using BASE instead of @base
-* adding a new line at RDF.type, or 'a'
-* adding newline and an indent for all triples with more than one object (object list)
-* adding a new line and ';' for the last triple in a set with '.'
+* uses PREFIX instead of @prefix
+* uses BASE instead of @base
+* adds a new line at RDF.type, or 'a'
+* adds a newline and an indent for all triples with more than one object (object list)
+* adds a new line and ';' for the last triple in a set with '.'
     on the start of the next line
-* default encoding (encode()) is used instead of "latin-1"
+* uses default encoding (encode()) is used instead of "latin-1"
 
 - Nicholas Car, 2021
 """
 
-from collections import defaultdict
-from functools import cmp_to_key
-
 from rdflib.term import BNode, Literal, URIRef
 from rdflib.exceptions import Error
-from rdflib.serializer import Serializer
 from .turtle import RecursiveSerializer
-from rdflib.namespace import RDF, RDFS
+from rdflib.namespace import RDF
 
-__all__ = ["RecursiveSerializer", "TurtleSerializer2"]
-
-
-def _object_comparator(a, b):
-    """
-    for nice clean output we sort the objects of triples,
-    some of them are literals,
-    these are sorted according to the sort order of the underlying python objects
-    in py3 not all things are comparable.
-    This falls back on comparing string representations when not.
-    """
-
-    try:
-        if a > b:
-            return 1
-        if a < b:
-            return -1
-        return 0
-
-    except TypeError:
-        a = str(a)
-        b = str(b)
-        return (a > b) - (a < b)
-
+__all__ = ["TurtleSerializer2"]
 
 SUBJECT = 0
 VERB = 1

--- a/test/test_turtle2.py
+++ b/test/test_turtle2.py
@@ -1,0 +1,196 @@
+from rdflib import Graph, Namespace, Literal
+from rdflib.namespace import RDF, RDFS, XSD
+
+EX = Namespace("https://example.com/")
+
+def test_turtle2():
+    g = Graph()
+
+    g.parse(data="""
+        @prefix ex: <http://example.org/> .
+        @prefix ex2: <http://example2.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <http://something.com/a>
+            a ex:Thing , ex:OtherThing ;
+            ex:name "Thing", "Other Thing"@en , "もの"@ja , "rzecz"@pl ;
+            ex:singleValueProp "propval" ;
+            ex:multiValueProp "propval 1" ;
+            ex:multiValueProp "propval 2" ;
+            ex:multiValueProp "propval 3" ;
+            ex:multiValueProp "propval 4" ;
+            ex:bnObj [
+                ex:singleValueProp "propval" ;
+                ex:multiValueProp "propval 1" ;
+                ex:multiValueProp "propval 2" ;
+                ex:bnObj [
+                    ex:singleValueProp "propval" ;
+                    ex:multiValueProp "propval 1" ;
+                    ex:multiValueProp "propval 2" ;
+                    ex:bnObj [
+                        ex:singleValueProp "propval" ;
+                        ex:multiValueProp "propval 1" ;
+                        ex:multiValueProp "propval 2" ;
+                    ] ,
+                    [
+                        ex:singleValueProp "propval" ;
+                        ex:multiValueProp "propval 1" ;
+                        ex:multiValueProp "propval 2" ;
+                    ] ,
+                    [
+                        ex:singleValueProp "propval" ;
+                        ex:multiValueProp "propval 1" ;
+                        ex:multiValueProp "propval 2" ;
+                    ] ;
+                ] ;
+            ] ;
+        .
+
+        ex:b
+            rdf:type ex:Thing ;
+            ex:name "B" ;
+            ex2:name "B" .
+
+        ex:c
+            rdf:type ex:Thing ;
+            ex:name "C" ;
+            ex:lst2 (
+                ex:one
+                ex:two
+                ex:three
+            ) ;
+            ex:lst (
+                ex:one
+                ex:two
+                ex:three
+            ) ,
+            (
+                ex:four
+                ex:fize
+                ex:six
+            ) ;
+            ex:bnObj [
+                ex:lst (
+                    ex:one
+                    ex:two
+                    ex:three
+                ) ,
+                (
+                    ex:four
+                    ex:fize
+                    ex:six
+                ) ;
+            ] .
+        """, format="turtle")
+    str = g.serialize(format="turtle2")
+    lines = str.split("\n")
+
+    assert "ex:b" in lines
+    assert "    a ex:Thing ;" in lines
+    assert """    ex2:name "B" ;
+.""" in str
+    assert """                (
+                    ex:one
+                    ex:two
+                    ex:three
+                ) ,""" in str
+    assert '    ex:singleValueProp "propval" ;' in lines
+
+
+    expected_str = """PREFIX ex: <http://example.org/>
+PREFIX ex2: <http://example2.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+ex:b
+    a ex:Thing ;
+    ex:name "B" ;
+    ex2:name "B" ;
+.
+
+ex:c
+    a ex:Thing ;
+    ex:bnObj [
+            ex:lst
+                (
+                    ex:one
+                    ex:two
+                    ex:three
+                ) ,
+                (
+                    ex:four
+                    ex:fize
+                    ex:six
+                )
+        ] ;
+    ex:lst
+        (
+            ex:four
+            ex:fize
+            ex:six
+        ) ,
+        (
+            ex:one
+            ex:two
+            ex:three
+        ) ;
+    ex:lst2 (
+            ex:one
+            ex:two
+            ex:three
+        ) ;
+    ex:name "C" ;
+.
+
+<http://something.com/a>
+    a
+        ex:OtherThing ,
+        ex:Thing ;
+    ex:bnObj [
+            ex:bnObj [
+                    ex:bnObj
+                        [
+                            ex:multiValueProp
+                                "propval 1" ,
+                                "propval 2" ;
+                            ex:singleValueProp "propval"
+                        ] ,
+                        [
+                            ex:multiValueProp
+                                "propval 1" ,
+                                "propval 2" ;
+                            ex:singleValueProp "propval"
+                        ] ,
+                        [
+                            ex:multiValueProp
+                                "propval 1" ,
+                                "propval 2" ;
+                            ex:singleValueProp "propval"
+                        ] ;
+                    ex:multiValueProp
+                        "propval 1" ,
+                        "propval 2" ;
+                    ex:singleValueProp "propval"
+                ] ;
+            ex:multiValueProp
+                "propval 1" ,
+                "propval 2" ;
+            ex:singleValueProp "propval"
+        ] ;
+    ex:multiValueProp
+        "propval 1" ,
+        "propval 2" ,
+        "propval 3" ,
+        "propval 4" ;
+    ex:name
+        "Thing" ,
+        "Other Thing"@en ,
+        "もの"@ja ,
+        "rzecz"@pl ;
+    ex:singleValueProp "propval" ;
+.
+
+"""
+
+    assert str == expected_str
+

--- a/test/test_turtle2.py
+++ b/test/test_turtle2.py
@@ -1,3 +1,5 @@
+# tests for the turtle2 serializer
+
 from rdflib import Graph
 
 
@@ -199,3 +201,7 @@ ex:c
 """
 
     assert s == expected_s
+
+    # re-parse test
+    g2 = Graph().parse(data=s)  # turtle
+    assert len(g2) == len(g)

--- a/test/test_turtle2.py
+++ b/test/test_turtle2.py
@@ -1,18 +1,17 @@
-from rdflib import Graph, Namespace, Literal
-from rdflib.namespace import RDF, RDFS, XSD
+from rdflib import Graph
 
-EX = Namespace("https://example.com/")
 
 def test_turtle2():
     g = Graph()
 
-    g.parse(data="""
-        @prefix ex: <http://example.org/> .
-        @prefix ex2: <http://example2.org/> .
+    g.parse(
+        data="""
+        @prefix ex: <https://example.org/> .
+        @prefix ex2: <https://example2.org/> .
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://something.com/a>
+        <https://something.com/a>
             a ex:Thing , ex:OtherThing ;
             ex:name "Thing", "Other Thing"@en , "もの"@ja , "rzecz"@pl ;
             ex:singleValueProp "propval" ;
@@ -82,24 +81,31 @@ def test_turtle2():
                     ex:six
                 ) ;
             ] .
-        """, format="turtle")
-    str = g.serialize(format="turtle2")
-    lines = str.split("\n")
+        """,
+        format="turtle",
+    )
+    s = g.serialize(format="turtle2")
+    lines = s.split("\n")
 
     assert "ex:b" in lines
     assert "    a ex:Thing ;" in lines
-    assert """    ex2:name "B" ;
-.""" in str
-    assert """                (
+    assert (
+        """    ex2:name "B" ;
+."""
+        in s
+    )
+    assert (
+        """                (
                     ex:one
                     ex:two
                     ex:three
-                ) ,""" in str
+                ) ,"""
+        in s
+    )
     assert '    ex:singleValueProp "propval" ;' in lines
 
-
-    expected_str = """PREFIX ex: <http://example.org/>
-PREFIX ex2: <http://example2.org/>
+    expected_s = """PREFIX ex: <https://example.org/>
+PREFIX ex2: <https://example2.org/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 ex:b
@@ -142,7 +148,7 @@ ex:c
     ex:name "C" ;
 .
 
-<http://something.com/a>
+<https://something.com/a>
     a
         ex:OtherThing ,
         ex:Thing ;
@@ -192,5 +198,4 @@ ex:c
 
 """
 
-    assert str == expected_str
-
+    assert s == expected_s


### PR DESCRIPTION
This is a slightly improved, or at least changed, Turtle serializer that does more indenting and new lining.

In particular it:

* uses PREFIX instead of @prefix
* uses BASE instead of @base
* adds a new line at RDF.type, or 'a'
* adds a newline and an indent for all triples with more than one object (object list)
* adds a new line and ';' for the last triple in a set with '.'
    on the start of the next line
* uses default encoding (encode()) is used instead of "latin-1"

This serializer is called with `g.serialize(format="turtle2")`

Here is a comparison of turtle v. turtle2 outputs:

```
@prefix ex: <https://example.org/> .
@prefix ex2: <https://example2.org/> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

ex:b a ex:Thing ;
    ex:name "B" ;
    ex2:name "B" .

ex:c a ex:Thing ;
    ex:bnObj [ ex:lst ( ex:one ex:two ex:three ),
                ( ex:four ex:fize ex:six ) ] ;
    ex:lst ( ex:one ex:two ex:three ),
        ( ex:four ex:fize ex:six ) ;
    ex:lst2 ( ex:one ex:two ex:three ) ;
    ex:name "C" .

```

turtle2:

```
PREFIX ex: <https://example.org/>
PREFIX ex2: <https://example2.org/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

ex:b
    a ex:Thing ;
    ex:name "B" ;
    ex2:name "B" ;
.

ex:c
    a ex:Thing ;
    ex:bnObj [
            ex:lst
                (
                    ex:one
                    ex:two
                    ex:three
                ) ,
                (
                    ex:four
                    ex:fize
                    ex:six
                )
        ] ;
    ex:lst
        (
            ex:one
            ex:two
            ex:three
        ) ,
        (
            ex:four
            ex:fize
            ex:six
        ) ;
    ex:lst2 (
            ex:one
            ex:two
            ex:three
        ) ;
    ex:name "C" ;
.

```