### PR TITLE
rename arg LOVE to ns in rdfpipe

### DIFF
--- a/rdflib/tools/rdfpipe.py
+++ b/rdflib/tools/rdfpipe.py
@@ -187,8 +187,8 @@ def main():
     logging.basicConfig(level=loglevel)
 
     ns_bindings = {}
-    if opts.LOVE:
-        for ns_kw in opts.LOVE:
+    if opts.ns:
+        for ns_kw in opts.ns:
             pfx, uri = ns_kw.split("=")
             ns_bindings[pfx] = uri
 


### PR DESCRIPTION
Fixes `AttributeError: 'Values' object has no attribute 'LOVE'`

## Proposed Changes
 in rdfpipe
  - rename the LOVE attibute in opts to ns (proper name)
