### PR TITLE
Undefined name: tmppath --> self.tmppath

### DIFF
--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -55,7 +55,7 @@ try:
 
         def tearDown(self):
             self.g.close()
-            shutil.rmtree(tmppath)
+            shutil.rmtree(self.tmppath)
 
         def testPychinko(self):
             rules = []


### PR DESCRIPTION
$ `  flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./rdflib/test/test_rules.py:58:27: F821 undefined name 'tmppath'
            shutil.rmtree(tmppath)
                          ^
```

## Proposed Changes

  - `tmppath` --> `self.tmppath`
