### PR TITLE
Drone: Add Python 3.10 to the testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,31 +34,61 @@ steps:
   - coveralls
 
 ---
-local Pipeline(name, image) = {
-  kind: pipeline
-  name: name
-  type: docker
-  platform:
-    os: linux
-    arch: amd64
-  steps: [
-    {
-      name: test
-      image: image
-      commands: [
-        "bash .travis.fuseki_install_optional.sh"
-        "pip install --default-timeout 60 -r requirements.txt -r requirements.dev.txt"
-        "python setup.py install"
-        "black --config black.toml --check ./rdflib | true"
-        "flake8 --exit-zero rdflib"
-        "PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42"
-      ]
-    }
-  ]
-};
+kind: pipeline
+name: python-3-8
+type: docker
+platform:
+  os: linux
+  arch: amd64
 
-[
-  Pipeline("python-3-8",  "python:3.8"),
-  Pipeline("python-3-9",  "python:3.9"),
-  Pipeline("python-3-10", "python:3.10"),
-]
+steps:
+- name: test
+  image: python:3.8
+  commands:
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - python setup.py install
+  - black --config black.toml --check ./rdflib | true
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42
+
+---
+kind: pipeline
+name: python-3-9
+type: docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: python:3.9
+  commands:
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - python setup.py install
+  - black --config black.toml --check ./rdflib | true
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42
+
+---
+kind: pipeline
+name: python-3-10
+type: docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: python:3.10
+  commands:
+  - bash .travis.fuseki_install_optional.sh
+  - pip install --default-timeout 60 -r requirements.txt
+  - pip install --default-timeout 60 -r requirements.dev.txt
+  - python setup.py install
+  - black --config black.toml --check ./rdflib | true
+  - flake8 --exit-zero rdflib
+  - PYTHONWARNINGS=default nosetests --with-timer --timer-top-n 42


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Add Python 3.10 to the testing

---

Nose is incompatible with Python 3.10 which has finally removed the alias between `collections` and `collections.abc`.
* Perhaps upgrade to https://docs.nose2.io or https://docs.pytest.org
```
  File "/usr/local/lib/python3.10/site-packages/nose/suite.py", line 106, in _set_tests
    if isinstance(tests, collections.Callable) and not is_suite:
AttributeError: module 'collections' has no attribute 'Callable'
```
https://docs.python.org/3/library/collections.abc.html#collections.abc.Callable