### PR TITLE
Undefined name: INVALID_CONTEXT_ENTRY

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -34,7 +34,11 @@ from .keys import (
     VERSION,
     VOCAB,
 )
-from .errors import INVALID_REMOTE_CONTEXT, RECURSIVE_CONTEXT_INCLUSION
+from .errors import (
+    INVALID_CONTEXT_ENTRY,
+    INVALID_REMOTE_CONTEXT,
+    RECURSIVE_CONTEXT_INCLUSION,
+)
 from .util import source_to_json, urljoin, urlsplit, split_iri, norm_url
 
 

--- a/rdflib/plugins/shared/jsonld/errors.py
+++ b/rdflib/plugins/shared/jsonld/errors.py
@@ -5,5 +5,6 @@ class JSONLDException(ValueError):
 
 
 # http://www.w3.org/TR/json-ld-api/#idl-def-JsonLdErrorCode.{code-message}
-RECURSIVE_CONTEXT_INCLUSION = JSONLDException("recursive context inclusion")
+INVALID_CONTEXT_ENTRY = JSONLDException("invalid context entry")
 INVALID_REMOTE_CONTEXT = JSONLDException("invalid remote context")
+RECURSIVE_CONTEXT_INCLUSION = JSONLDException("recursive context inclusion")


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./rdflib/rdflib/plugins/shared/jsonld/context.py:420:23: F821 undefined name 'INVALID_CONTEXT_ENTRY'
                raise INVALID_CONTEXT_ENTRY
                      ^
./rdflib/rdflib/plugins/shared/jsonld/context.py:426:23: F821 undefined name 'INVALID_CONTEXT_ENTRY'
                raise INVALID_CONTEXT_ENTRY
                      ^
```
## Proposed Changes

  - Define INVALID_CONTEXT_ENTRY which is currently an ___undefined name___ raised on lines 424 and 430.