### PR TITLE
Fix Graph.parse URL handling on windows

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -307,10 +307,13 @@ def create_input_source(
 
 
 def _create_input_source_from_location(file, format, input_source, location):
-    # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145
-    path = pathlib.Path(location)
-    if path.exists():
-        location = path.absolute().as_uri()
+    # Fix for Windows problem https://github.com/RDFLib/rdflib/issues/145 and
+    # https://github.com/RDFLib/rdflib/issues/1430
+    # NOTE: using pathlib.Path.exists on a URL fails on windows as it is not a
+    # valid path. However os.path.exists() returns false for a URL on windows
+    # which is why it is being used instead.
+    if os.path.exists(location):
+        location = pathlib.Path(location).absolute().as_uri()
 
     base = pathlib.Path.cwd().as_uri()
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -9,8 +9,13 @@ from urllib.error import URLError, HTTPError
 from rdflib import URIRef, Graph, plugin
 from rdflib.exceptions import ParserError
 from rdflib.plugin import PluginException
+from rdflib.namespace import Namespace
 
 from nose.exc import SkipTest
+
+from pathlib import Path
+
+from test.testutils import GraphHelper
 
 
 class GraphTestCase(unittest.TestCase):
@@ -325,6 +330,20 @@ class GraphTestCase(unittest.TestCase):
         except (URLError, HTTPError):
             # this endpoint is currently not available, ignore this test.
             pass
+
+    def test_parse_file_uri(self):
+        EG = Namespace("http://example.org/#")
+        g = Graph()
+        g.parse(Path("./test/nt/simple-04.nt").absolute().as_uri())
+        triple_set = GraphHelper.triple_set(g)
+        self.assertEqual(
+            triple_set,
+            {
+                (EG["Subject"], EG["predicate"], EG["ObjectP"]),
+                (EG["Subject"], EG["predicate"], EG["ObjectQ"]),
+                (EG["Subject"], EG["predicate"], EG["ObjectR"]),
+            },
+        )
 
     def testTransitive(self):
         person = URIRef("ex:person")


### PR DESCRIPTION
Using `pathlib.Path("http://example.com/").exists()` on windows causes an exception as a URL
is not a valid path, while `os.path.exists("http://example.com/")` just
returns false.

This patch reverts _create_input_source_from_location to using
`os.path.exists()` instead of pathlib.Path to make it possible to parse
graphs from http URLs on windows.

Fixes #1430

## Proposed Changes

  - use `os.path.exists()` instead of `pathlib.Path().exists()` as the former returns false for URLs on windows while the latter rasies an exception.
