### PR TITLE
Use assertTrue instead of assert_ for python 3.11 compatibility.

### DIFF
--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -42,7 +42,7 @@ class NamespaceTest(unittest.TestCase):
         prefix = "http://jörn.loves.encoding.problems/"
         ns = Namespace(prefix)
         self.assertEqual(ns, str(prefix))
-        self.assert_(ns["jörn"].startswith(ns))
+        self.assertTrue(ns["jörn"].startswith(ns))
 
 
 class ClosedNamespaceTest(unittest.TestCase):


### PR DESCRIPTION
## Proposed Changes

  - Use assertTrue instead of assert_ for python 3.11 compatibility. The deprecated aliases were removed in Python 3.11 in python/cpython#28268
