### PR TITLE
Updated tox config to run mypy in default environment

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -64,6 +64,30 @@ Check types with `mypy <http://mypy-lang.org/>`_:
 
     python -m mypy --show-error-context --show-error-codes rdflib
 
+Using tox
+---------------------
+
+RDFLib has a `tox <https://tox.wiki/en/latest/index.html>`_ config file that
+makes it easier to run validation on all supported python versions.
+
+.. code-block:: bash
+
+    # install tox
+    pip install tox
+
+    # list tox environments that run by default
+    tox -e
+
+    # list all tox environments
+    tox -a
+
+    # run default environment for all python versions
+    tox
+
+    # run a specific environment
+    tox -e py37 # default environment with py37
+    tox -e py39-mypy # mypy environment with py39
+
 Writing documentation
 ---------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
-    py37,py38,py39
+    py37,py38,py39,py310
 
 [testenv]
 setenv =
     BERKELEYDB_DIR = /usr
 commands =
+    {envpython} -m mypy rdflib --show-error-context --show-error-codes
     {envpython} setup.py clean --all
     {envpython} setup.py build
     {envpython} -m pytest
@@ -26,9 +27,7 @@ deps =
 	-rrequirements.txt
 	-rrequirements.dev.txt
 
-[testenv:mypy]
-basepython =
-    python3.7
+[testenv:py3{7,8,9,10}-mypy]
 commands =
     {envpython} -m mypy rdflib --show-error-context --show-error-codes
 deps =


### PR DESCRIPTION
This is mainly so that the default tox environment mirrors the CI
checks.

Also:

* Added some notes about tox in `developers.rst`.
* Made the `mypy` tox environment run for all python versions.