### PR TITLE
Fix JSON-LD data import adds trailing slashes to IRIs (#1443)

### DIFF
--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -59,6 +59,8 @@ def norm_url(base, url):
     >>> norm_url('http://example.org/', 'http://example.org//one')
     'http://example.org//one'
     """
+    if "://" in url:
+        return url
     parts = urlsplit(urljoin(base, url))
     path = normpath(parts[2])
     if sep != "/":

--- a/test/jsonld/test_util.py
+++ b/test/jsonld/test_util.py
@@ -1,0 +1,79 @@
+import unittest
+from typing import NamedTuple
+
+from rdflib.plugins.shared.jsonld.util import norm_url
+
+
+class URLTests(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_norm_url_xfail(self):
+        class TestSpec(NamedTuple):
+            base: str
+            url: str
+            result: str
+
+        tests = [
+            TestSpec(
+                "git+ssh://example.com:1231/some/thing/",
+                "a",
+                "git+ssh://example.com:1231/some/thing/a",
+            ),
+        ]
+
+        for test in tests:
+            (base, url, result) = test
+            with self.subTest(base=base, url=url):
+                self.assertEqual(norm_url(base, url), result)
+
+    def test_norm_url(self):
+        class TestSpec(NamedTuple):
+            base: str
+            url: str
+            result: str
+
+        tests = [
+            TestSpec("http://example.org/", "/one", "http://example.org/one"),
+            TestSpec("http://example.org/", "/one#", "http://example.org/one#"),
+            TestSpec("http://example.org/one", "two", "http://example.org/two"),
+            TestSpec("http://example.org/one/", "two", "http://example.org/one/two"),
+            TestSpec(
+                "http://example.org/",
+                "http://example.net/one",
+                "http://example.net/one",
+            ),
+            TestSpec(
+                "",
+                "1 2 3",
+                "1 2 3",
+            ),
+            TestSpec(
+                "http://example.org/",
+                "http://example.org//one",
+                "http://example.org//one",
+            ),
+            TestSpec("", "http://example.org", "http://example.org"),
+            TestSpec("", "http://example.org/", "http://example.org/"),
+            TestSpec("", "mailto:name@example.com", "mailto:name@example.com"),
+            TestSpec(
+                "http://example.org/",
+                "mailto:name@example.com",
+                "mailto:name@example.com",
+            ),
+            TestSpec("http://example.org/a/b/c", "../../z", "http://example.org/z"),
+            TestSpec("http://example.org/a/b/c", "../", "http://example.org/a/"),
+            TestSpec(
+                "",
+                "git+ssh://example.com:1231/some/thing",
+                "git+ssh://example.com:1231/some/thing",
+            ),
+            TestSpec(
+                "git+ssh://example.com:1231/some/thing",
+                "",
+                "git+ssh://example.com:1231/some/thing",
+            ),
+        ]
+
+        for test in tests:
+            (base, url, result) = test
+            with self.subTest(base=base, url=url):
+                self.assertEqual(norm_url(base, url), result)

--- a/test/jsonld/test_util.py
+++ b/test/jsonld/test_util.py
@@ -71,6 +71,16 @@ class URLTests(unittest.TestCase):
                 "",
                 "git+ssh://example.com:1231/some/thing",
             ),
+            TestSpec(
+                "http://example.com/RDFLib/rdflib",
+                "http://example.org",
+                "http://example.org",
+            ),
+            TestSpec(
+                "http://example.com/RDFLib/rdflib",
+                "http://example.org/",
+                "http://example.org/",
+            ),
         ]
 
         for test in tests:


### PR DESCRIPTION
In norm_url leave url alone if it already contains a scheme/protocol.

Fixes #1443 
