### PR TITLE
Add import of os

### DIFF
--- a/rdflib/extras/infixowl.py
+++ b/rdflib/extras/infixowl.py
@@ -39,7 +39,7 @@ We can then access the rdfs:subClassOf relationships
 
 This can also be used against already populated graphs:
 
->>> owlGraph = Graph().parse(OWL) #doctest: +SKIP
+>>> owlGraph = Graph().parse(str(OWL)) #doctest: +SKIP
 >>> namespace_manager.bind('owl', OWL, override=False) #doctest: +SKIP
 >>> owlGraph.namespace_manager = namespace_manager #doctest: +SKIP
 >>> list(Class(OWL.Class, graph=owlGraph).subClassOf) #doctest: +SKIP
@@ -846,9 +846,9 @@ def CastClass(c, graph=None):
                     else:
                         if p not in Restriction.restrictionKinds:
                             continue
-                        kwArgs[str(p.split(OWL)[-1])] = o
+                        kwArgs[str(p.split(str(OWL))[-1])] = o
             if not set(
-                [str(i.split(OWL)[-1]) for i in Restriction.restrictionKinds]
+                [str(i.split(str(OWL))[-1]) for i in Restriction.restrictionKinds]
             ).intersection(kwArgs):
                 raise MalformedClass("Malformed owl:Restriction")
             return Restriction(**kwArgs)

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -808,6 +808,7 @@ def translateAlgebra(query_algebra: Query):
     :return: The query form generated from the SPARQL 1.1 algebra tree for select queries.
 
     """
+    import os
 
     def overwrite(text):
         file = open("query.txt", "w+")


### PR DESCRIPTION
1.
```
File "../test_magic_set.py", line 64, in test_AdornLiteral
    res = translateAlgebra(translateQuery(parsed_query))
File ".../rdflib/plugins/sparql/algebra.py", line 1427, in translateAlgebra
    os.remove("query.txt")
name 'os' is not defined
```
2. infixowl throws an Exception when it tries to split the OWL Namespace object. (Would have preferred to raise a separate PR, was unaware that GH simply concatenates commits into a single PR).
## Proposed Changes

  - Add `import os`
  - Change `str(p.split(OWL)[-1])` to `str(p.split(str(OWL))[-1])` to avoid Exception.
  -
