### PR TITLE
Make the test pass on windows

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -23,6 +23,7 @@ import pathlib
 
 from io import BytesIO, BufferedIOBase
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 assert Literal  # avoid warning
 assert Namespace  # avoid warning
@@ -1130,7 +1131,7 @@ class Graph(Node):
             stream = os.fdopen(fd, "wb")
             serializer.serialize(stream, base=base, encoding=encoding, **args)
             stream.close()
-            dest = path if scheme == "file" else location
+            dest = url2pathname(path) if scheme == "file" else location
             if hasattr(shutil, "move"):
                 shutil.move(name, dest)
             else:

--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -12,8 +12,8 @@ else:
     except ImportError:
         import simplejson as json
 
-from os import sep
-from os.path import normpath
+from posixpath import sep
+from posixpath import normpath
 
 from urllib.parse import urljoin, urlsplit, urlunsplit
 

--- a/test/jsonld/test_onedotone.py
+++ b/test/jsonld/test_onedotone.py
@@ -1,5 +1,7 @@
 from os import environ, chdir, getcwd, path as p
 import json
+import os
+
 
 import pytest
 
@@ -135,6 +137,10 @@ known_bugs = (
     # TODO: Rdflib should silently reject bad predicate URIs
     "toRdf/wf02-in",
 )
+
+if os.name == "nt":
+    # nquad parser does not correctly handle unnormalized unicode on windows.
+    known_bugs += ("toRdf/js11-in", )
 
 TC_BASE = "https://w3c.github.io/json-ld-api/tests/"
 allow_lists_of_lists = True

--- a/test/test_csv2rdf.py
+++ b/test/test_csv2rdf.py
@@ -1,7 +1,7 @@
 import subprocess
 import unittest
 import sys
-from os import remove
+from os import remove, close
 from tempfile import mkstemp
 from pathlib import Path
 
@@ -29,7 +29,7 @@ class CSV2RDFTest(unittest.TestCase):
         self.assertIn("<http://example.org/props/zip>", completed.stdout)
 
     def test_csv2rdf_cli_fileout(self):
-        _, fname = mkstemp()
+        fh, fname = mkstemp()
         completed = subprocess.run(
             [
                 sys.executable,
@@ -43,4 +43,5 @@ class CSV2RDFTest(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         with open(fname) as f:
             self.assertGreater(len(f.readlines()), 0)
+        close(fh)
         remove(fname)

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -5,6 +5,7 @@ import re
 from rdflib import Graph, Literal, URIRef
 from rdflib.plugins.parsers import ntriples
 from urllib.request import urlopen
+from pathlib import Path
 
 from test import TEST_DIR
 
@@ -125,7 +126,7 @@ class NTTestCase(unittest.TestCase):
         self.assertTrue(res == None)
 
     def test_w3_ntriple_variants(self):
-        uri = "file://" + os.path.abspath(nt_file("test.ntriples"))
+        uri = Path(nt_file("test.ntriples")).absolute().as_uri()
 
         parser = ntriples.W3CNTriplesParser()
         u = urlopen(uri)

--- a/test/test_serialize.py
+++ b/test/test_serialize.py
@@ -1,6 +1,6 @@
 import unittest
 from rdflib import Graph, URIRef
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from pathlib import Path, PurePath
 
 
@@ -30,8 +30,8 @@ class TestSerialize(unittest.TestCase):
         self.assertEqual(self.triple, next(iter(graph_check)))
 
     def test_serialize_to_path(self):
-        with NamedTemporaryFile() as tf:
-            tfpath = Path(tf.name)
+        with TemporaryDirectory() as td:
+            tfpath = Path(td) / "out.nt"
             self.graph.serialize(destination=tfpath, format="nt")
             graph_check = Graph()
             graph_check.parse(source=tfpath, format="nt")

--- a/test/test_testutils.py
+++ b/test/test_testutils.py
@@ -1,0 +1,91 @@
+import os
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Optional
+from .testutils import file_uri_to_path
+
+import pytest
+
+
+def check(
+    file_uri: str,
+    expected_windows_path: Optional[str],
+    expected_posix_path: Optional[str],
+) -> None:
+    if expected_windows_path is not None:
+        expected_windows_path_object = PureWindowsPath(expected_windows_path)
+    if expected_posix_path is not None:
+        expected_posix_path_object = PurePosixPath(expected_posix_path)
+
+    if expected_windows_path is not None:
+        if os.name == "nt":
+            assert file_uri_to_path(file_uri) == expected_windows_path_object
+        assert (
+            file_uri_to_path(file_uri, PureWindowsPath) == expected_windows_path_object
+        )
+
+    if expected_posix_path is not None:
+        if os.name != "nt":
+            assert file_uri_to_path(file_uri) == expected_posix_path_object
+        assert file_uri_to_path(file_uri, PurePosixPath) == expected_posix_path_object
+
+
+@pytest.mark.parametrize(
+    "file_uri,expected_windows_path,expected_posix_path",
+    [
+        (
+            r"file:///C:/Windows/System32/Drivers/etc/hosts",
+            r"C:\Windows\System32\Drivers\etc\hosts",
+            r"/C:/Windows/System32/Drivers/etc/hosts",
+        ),
+        (
+            r"file:///C%3A/Windows/System32/Drivers/etc/hosts",
+            None,
+            r"/C:/Windows/System32/Drivers/etc/hosts",
+        ),
+        (
+            r"file:///C:/some%20dir/some%20file",
+            r"C:\some dir\some file",
+            r"/C:/some dir/some file",
+        ),
+        (
+            r"file:///C%3A/some%20dir/some%20file",
+            None,
+            r"/C:/some dir/some file",
+        ),
+        (
+            r"file:///C:/Python27/Scripts/pip.exe",
+            r"C:\Python27\Scripts\pip.exe",
+            r"/C:/Python27/Scripts/pip.exe",
+        ),
+        (
+            r"file:///C:/yikes/paths%20with%20spaces.txt",
+            r"C:\yikes\paths with spaces.txt",
+            r"/C:/yikes/paths with spaces.txt",
+        ),
+        (
+            r"file://localhost/c:/WINDOWS/clock.avi",
+            r"c:\WINDOWS\clock.avi",
+            r"/c:/WINDOWS/clock.avi",
+        ),
+        (r"file:///home/example/.profile", None, r"/home/example/.profile"),
+        (r"file:///c|/path/to/file", r"c:\path\to\file", r"/c|/path/to/file"),
+        (r"file:/c|/path/to/file", r"c:\path\to\file", r"/c|/path/to/file"),
+        (r"file:c|/path/to/file", r"c:\path\to\file", r"c|/path/to/file"),
+        (r"file:///c:/path/to/file", r"c:\path\to\file", r"/c:/path/to/file"),
+        (r"file:/c:/path/to/file", r"c:\path\to\file", r"/c:/path/to/file"),
+        (r"file:c:/path/to/file", r"c:\path\to\file", r"c:/path/to/file"),
+        (r"file:/path/to/file", None, r"/path/to/file"),
+        (r"file:///home/user/some%20file.txt", None, r"/home/user/some file.txt"),
+        (
+            r"file:///C:/some%20dir/some%20file.txt",
+            r"C:\some dir\some file.txt",
+            r"/C:/some dir/some file.txt",
+        ),
+    ],
+)
+def test_paths(
+    file_uri: str,
+    expected_windows_path: Optional[str],
+    expected_posix_path: Optional[str],
+) -> None:
+    check(file_uri, expected_windows_path, expected_posix_path)

--- a/test/test_turtle_w3c.py
+++ b/test/test_turtle_w3c.py
@@ -1,19 +1,22 @@
 """This runs the turtle tests for the W3C RDF Working Group's N-Quads
 test suite."""
 
-from typing import Callable, Dict
+import os
+from pathlib import Path
+from typing import Callable, Dict, Set
 from rdflib import Graph
-from rdflib.namespace import split_uri
+from rdflib.namespace import Namespace, split_uri
 from rdflib.compare import graph_diff, isomorphic
 from rdflib.term import Node, URIRef
 
 from test.manifest import RDFT, RDFTest, read_manifest
 import pytest
+from .testutils import file_uri_to_path
 
 verbose = False
 
 
-def turtle(test):
+def turtle(test: RDFTest):
     g = Graph()
 
     try:
@@ -43,7 +46,12 @@ def turtle(test):
                     print(t)
                 raise Exception("Graphs do not match!")
 
-            assert isomorphic(g, res), "graphs must be the same"
+            assert isomorphic(
+                g, res
+            ), "graphs must be the same, expected\n%s\n, got\n%s" % (
+                g.serialize(),
+                res.serialize(),
+            )
 
     except:
         if test.syntax:
@@ -57,10 +65,21 @@ testers: Dict[Node, Callable[[RDFTest], None]] = {
     RDFT.TestTurtleNegativeEval: turtle,
 }
 
+NAMESPACE = Namespace("http://www.w3.org/2013/TurtleTests/manifest.ttl#")
+EXPECTED_FAILURES: Dict[URIRef, str] = {}
+
+if os.name == "nt":
+    for test in ["literal_with_LINE_FEED", "turtle-subm-15", "turtle-subm-16"]:
+        EXPECTED_FAILURES[
+            NAMESPACE[test]
+        ] = "Issue with nt parser and line endings on windows"
+
 
 @pytest.mark.parametrize(
     "rdf_test_uri, type, rdf_test",
     read_manifest("test/w3c/turtle/manifest.ttl"),
 )
 def test_manifest(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
+    if rdf_test_uri in EXPECTED_FAILURES:
+        pytest.xfail(EXPECTED_FAILURES[rdf_test_uri])
     testers[type](rdf_test)

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -9,6 +9,7 @@ import random
 
 from contextlib import AbstractContextManager, contextmanager
 from typing import (
+    Callable,
     Iterable,
     List,
     Optional,
@@ -23,7 +24,7 @@ from typing import (
     cast,
     NamedTuple,
 )
-from urllib.parse import ParseResult, urlparse, parse_qs
+from urllib.parse import ParseResult, unquote, urlparse, parse_qs
 from traceback import print_exc
 from threading import Thread
 from http.server import BaseHTTPRequestHandler, HTTPServer, SimpleHTTPRequestHandler
@@ -36,6 +37,8 @@ from rdflib.term import Node
 from unittest.mock import MagicMock, Mock
 from urllib.error import HTTPError
 from urllib.request import urlopen
+from pathlib import PurePath, PureWindowsPath
+from nturl2path import url2pathname as nt_url2pathname
 
 if TYPE_CHECKING:
     import typing_extensions as te
@@ -469,3 +472,33 @@ def eq_(lhs, rhs, msg=None):
         assert lhs == rhs, msg
     else:
         assert lhs == rhs
+
+
+PurePathT = TypeVar("PurePathT", bound=PurePath)
+
+
+def file_uri_to_path(
+    file_uri: str,
+    path_class: Type[PurePathT] = PurePath,  # type: ignore[assignment]
+    url2pathname: Optional[Callable[[str], str]] = None,
+) -> PurePathT:
+    """
+    This function returns a pathlib.PurePath object for the supplied file URI.
+
+    :param str file_uri: The file URI ...
+    :param class path_class: The type of path in the file_uri. By default it uses
+        the system specific path pathlib.PurePath, to force a specific type of path
+        pass pathlib.PureWindowsPath or pathlib.PurePosixPath
+    :returns: the pathlib.PurePath object
+    :rtype: pathlib.PurePath
+    """
+    is_windows_path = isinstance(path_class(), PureWindowsPath)
+    file_uri_parsed = urlparse(file_uri)
+    if url2pathname is None:
+        if is_windows_path:
+            url2pathname = nt_url2pathname
+        else:
+            url2pathname = unquote
+    pathname = url2pathname(file_uri_parsed.path)
+    result = path_class(pathname)
+    return result


### PR DESCRIPTION
In rdflib:

- Fix rdflib.plugins.shared.jsonld.util.norm_url on Windows
  On windows normpath and sep is not appropriate for URLs, use posixpath
  so that the behaviour is consistent.

- Fix handling of file URIs in Graph.serialize on windows
  Should use url2pathname(path) to get a path from the path segment of
  URLs

In tests:

- Fix handling of file created by mkstemp
  Should first call os.close on the OS-level handle before removing the
  file.

- Fix how file URIs are created so they work properly on windows.

- Skip tests which are sensitive to unicode normalization and carriage
  return as these do not pass on windows (about 5 tests).

I would recommend merging #1461 after this so that we don't have regressions on Windows or MacOS.