### PR TITLE
Adapt for pytest and add back import of os in rdflib/parser.py

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -12,6 +12,7 @@ want to do so through the Graph class parse method.
 
 from typing import TYPE_CHECKING
 import codecs
+import os
 import pathlib
 import sys
 

--- a/test/jsonld/test_onedotone.py
+++ b/test/jsonld/test_onedotone.py
@@ -205,7 +205,7 @@ def get_test_suite_cases():
             ):
                 # Skip the JSON v1.0 tests
                 continue
-        if inputpath.endswith(".jsonld"):  # toRdf
+        if inputpath.endswith((".jldt", ".json", ".jsonld")):  # toRdf
             if expectedpath.endswith(".jsonld"):  # compact/expand/flatten
                 func = runner.do_test_json
             else:  # toRdf
@@ -222,28 +222,8 @@ def get_test_suite_cases():
 def global_state():
     old_cwd = getcwd()
     chdir(test_dir)
-    try:
-        for cat, num, inputpath, expectedpath, context, options in read_manifest(
-            skiptests
-        ):
-            if options:
-                if (
-                    SKIP_1_0_TESTS
-                    and "specVersion" in options
-                    and str(options["specVersion"]).lower() == "json-ld-1.0"
-                ):
-                    # Skip the JSON v1.0 tests
-                    continue
-            if inputpath.endswith((".jldt", ".json", ".jsonld")):  # toRdf
-                if expectedpath.endswith(".jsonld"):  # compact/expand/flatten
-                    func = runner.do_test_json
-                else:  # toRdf
-                    func = runner.do_test_parser
-            else:  # fromRdf
-                func = runner.do_test_serializer
-            yield func, TC_BASE, cat, num, inputpath, expectedpath, context, options
-    finally:
-        chdir(old_cwd)
+    yield
+    chdir(old_cwd)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
test/jsonld/test_onedotone.py got a bit messed up with a merge from
master. Looking at the original changes from @ashleysommer, all he did
was change a condition. This applies the same change but essentially
rebased on master.

For comparison see: https://github.com/RDFLib/rdflib/compare/ab31c5ed3772cb63806a4614ca4431e9bd7de8d3...c4b679ff6660f4287e7738c93c8c06072642ce1a

Also add back import os in rdflib/parser.py

This is now needed after https://github.com/RDFLib/rdflib/pull/1441 was
merged.