### PR TITLE
guess_format() cater for JSON-LD files ending .json-ld

### DIFF
--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -366,6 +366,7 @@ SUFFIX_FORMAT_MAP = {
     "trig": "trig",
     "json": "json-ld",
     "jsonld": "json-ld",
+    "json-ld": "json-ld",
 }
 
 

--- a/test/jsonld/file_ending_test_01.json
+++ b/test/jsonld/file_ending_test_01.json
@@ -1,0 +1,15 @@
+{
+  "@id": "",
+  "@type": "mf:Manifest",
+  "name": "JSON-LD Test Suite",
+  "description": "This manifest loads additional manifests for specific behavior tests for [JSON-LD 1.1 API](https://www.w3.org/TR/json-ld11-api/)",
+  "sequence": [
+    "compact-manifest.jsonld",
+    "expand-manifest.jsonld",
+    "flatten-manifest.jsonld",
+    "fromRdf-manifest.jsonld",
+    "remote-doc-manifest.jsonld",
+    "toRdf-manifest.jsonld",
+    "html-manifest.jsonld"
+  ]
+}

--- a/test/jsonld/file_ending_test_01.json-ld
+++ b/test/jsonld/file_ending_test_01.json-ld
@@ -1,0 +1,15 @@
+{
+  "@id": "",
+  "@type": "mf:Manifest",
+  "name": "JSON-LD Test Suite",
+  "description": "This manifest loads additional manifests for specific behavior tests for [JSON-LD 1.1 API](https://www.w3.org/TR/json-ld11-api/)",
+  "sequence": [
+    "compact-manifest.jsonld",
+    "expand-manifest.jsonld",
+    "flatten-manifest.jsonld",
+    "fromRdf-manifest.jsonld",
+    "remote-doc-manifest.jsonld",
+    "toRdf-manifest.jsonld",
+    "html-manifest.jsonld"
+  ]
+}

--- a/test/jsonld/file_ending_test_01.jsonld
+++ b/test/jsonld/file_ending_test_01.jsonld
@@ -1,0 +1,15 @@
+{
+  "@id": "",
+  "@type": "mf:Manifest",
+  "name": "JSON-LD Test Suite",
+  "description": "This manifest loads additional manifests for specific behavior tests for [JSON-LD 1.1 API](https://www.w3.org/TR/json-ld11-api/)",
+  "sequence": [
+    "compact-manifest.jsonld",
+    "expand-manifest.jsonld",
+    "flatten-manifest.jsonld",
+    "fromRdf-manifest.jsonld",
+    "remote-doc-manifest.jsonld",
+    "toRdf-manifest.jsonld",
+    "html-manifest.jsonld"
+  ]
+}

--- a/test/test_graph_http.py
+++ b/test/test_graph_http.py
@@ -7,7 +7,7 @@ import unittest
 
 
 """
-Test that correct content negoation headers are passed
+Test that correct content negotiation headers are passed
 by graph.parse
 """
 

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -13,6 +13,9 @@ class FileParserGuessFormatTest(unittest.TestCase):
     def test_jsonld(self):
         g = Graph()
         self.assertIsInstance(g.parse("test/jsonld/1.1/manifest.jsonld"), Graph)
+        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.json"), Graph)
+        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.json-ld"), Graph)
+        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.jsonld"), Graph)
 
     def test_ttl(self):
         g = Graph()


### PR DESCRIPTION
Allows RDFlib to guess the format of file ending `.json-ld`