### PR TITLE
Fix typing of create_input_source

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -16,7 +16,7 @@ import pathlib
 import sys
 
 from io import BytesIO, TextIOBase, TextIOWrapper, StringIO, BufferedIOBase
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from urllib.request import Request
 from urllib.request import url2pathname
@@ -258,7 +258,7 @@ def create_input_source(
     publicID=None,
     location=None,
     file=None,
-    data: Optional[Union[str, bytes, bytearray]] = None,
+    data: Optional[Union[str, bytes, bytearray, Dict[Any, Any]]] = None,
     format=None,
 ):
     """


### PR DESCRIPTION
Change the type of `data` parameter to also allow values of `Dict` type
as these are used with `PythonInputSource`.

NOTE: This fixes build failure on master.
