### PR TITLE
Add bindings for rdflib namespaces. Import DCAM.

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -348,7 +348,7 @@ class NamespaceManager(object):
         self.bind("owl", OWL)
         self.bind("prof", PROF)
         self.bind("prov", PROV)
-        self.bind("QB", QB)
+        self.bind("qb", QB)
         self.bind("rdf", RDF)
         self.bind("rdfs", RDFS)
         self.bind("schema", SDO)

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -333,10 +333,36 @@ class NamespaceManager(object):
         self.__trie = {}
         for p, n in self.namespaces():  # self.bind is not always called
             insert_trie(self.__trie, str(n))
-        self.bind("xml", XMLNS)
+
+        self.bind("brick", BRICK)
+        self.bind("csvw", CSVW)
+        self.bind("dc", DC)
+        self.bind("dcat", DCAT)
+        self.bind("dcmitype", DCMITYPE)
+        self.bind("dcterms", DCTERMS)
+        self.bind("dcam", DCAM)
+        self.bind("doap", DOAP)
+        self.bind("foaf", FOAF)
+        self.bind("odrl", ODRL2)
+        self.bind("org", ORG)
+        self.bind("owl", OWL)
+        self.bind("prof", PROF)
+        self.bind("prov", PROV)
+        self.bind("QB", QB)
         self.bind("rdf", RDF)
         self.bind("rdfs", RDFS)
+        self.bind("schema", SDO)
+        self.bind("sh", SH)
+        self.bind("skos", SKOS)
+        self.bind("sosa", SOSA)
+        self.bind("ssn", SSN)
+        self.bind("time", TIME)
+        self.bind("vann", VANN)
+        self.bind("void", VOID)
         self.bind("xsd", XSD)
+
+        # TODO: XMLNS is not a DefinedNamespace.
+        self.bind("xml", XMLNS)
 
     def __contains__(self, ref):
         # checks if a reference is in any of the managed namespaces with syntax
@@ -703,6 +729,7 @@ from rdflib.namespace._DC import DC
 from rdflib.namespace._DCAT import DCAT
 from rdflib.namespace._DCMITYPE import DCMITYPE
 from rdflib.namespace._DCTERMS import DCTERMS
+from rdflib.namespace._DCAM import DCAM
 from rdflib.namespace._DOAP import DOAP
 from rdflib.namespace._FOAF import FOAF
 from rdflib.namespace._ODRL2 import ODRL2

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -334,6 +334,7 @@ class NamespaceManager(object):
         for p, n in self.namespaces():  # self.bind is not always called
             insert_trie(self.__trie, str(n))
 
+        # DefinedNamespace bindings.
         self.bind("brick", BRICK)
         self.bind("csvw", CSVW)
         self.bind("dc", DC)
@@ -361,7 +362,7 @@ class NamespaceManager(object):
         self.bind("void", VOID)
         self.bind("xsd", XSD)
 
-        # TODO: XMLNS is not a DefinedNamespace.
+        # Namespace bindings.
         self.bind("xml", XMLNS)
 
     def __contains__(self, ref):

--- a/test/test_sparql_service.py
+++ b/test/test_sparql_service.py
@@ -76,7 +76,7 @@ def test_service_with_implicit_select():
     q = """select ?s ?p ?o
     where
     {
-      service <http://DBpedia.org/sparql>
+      service <https://DBpedia.org/sparql>
     {
       values (?s ?p ?o) {(<http://example.org/a> <http://example.org/b> 1) (<http://example.org/a> <http://example.org/b> 2)}
     }} limit 2"""
@@ -93,7 +93,7 @@ def test_service_with_implicit_select_and_prefix():
     select ?s ?p ?o
     where
     {
-      service <http://DBpedia.org/sparql>
+      service <https://DBpedia.org/sparql>
     {
       values (?s ?p ?o) {(ex:a ex:b 1) (<http://example.org/a> <http://example.org/b> 2)}
     }} limit 2"""
@@ -110,7 +110,7 @@ def test_service_with_implicit_select_and_base():
     select ?s ?p ?o
     where
     {
-      service <http://DBpedia.org/sparql>
+      service <https://DBpedia.org/sparql>
     {
       values (?s ?p ?o) {(<a> <b> 1) (<a> <b> 2)}
     }} limit 2"""
@@ -126,7 +126,7 @@ def test_service_with_implicit_select_and_allcaps():
     q = """SELECT ?s
     WHERE
     {
-      SERVICE <http://dbpedia.org/sparql>
+      SERVICE <https://dbpedia.org/sparql>
       {
         ?s <http://www.w3.org/2002/07/owl#sameAs> ?sameAs .
       }


### PR DESCRIPTION
Fixes https://github.com/RDFLib/rdflib/issues/1470

## Proposed Changes

  - Add bindings for rdflib namespaces.
  - Import `DCAM` to be available in the `namespace` package.
