### PR TITLE
Fix BNode.skolemize() returning a URIRef instead of an RDFLibGenid.

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -446,7 +446,7 @@ class BNode(Identifier):
         if basepath is None:
             basepath = rdflib_skolem_genid
         skolem = "%s%s" % (basepath, str(self))
-        return URIRef(urljoin(authority, skolem))
+        return Genid(urljoin(authority, skolem))
 
 
 class Literal(Identifier):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -446,7 +446,7 @@ class BNode(Identifier):
         if basepath is None:
             basepath = rdflib_skolem_genid
         skolem = "%s%s" % (basepath, str(self))
-        return Genid(urljoin(authority, skolem))
+        return RDFLibGenid(urljoin(authority, skolem))
 
 
 class Literal(Identifier):

--- a/test/test_issue1404.py
+++ b/test/test_issue1404.py
@@ -1,0 +1,42 @@
+from rdflib import Graph, URIRef, FOAF
+from rdflib.term import RDFLibGenid
+from rdflib.compare import isomorphic
+
+
+def test_skolem_de_skolem_roundtrip():
+    """Test round-trip of skolemization/de-skolemization of data.
+
+    Issue: https://github.com/RDFLib/rdflib/issues/1404
+    """
+
+    ttl = '''
+    @prefix wd: <http://www.wikidata.org/entity/> .
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+    wd:Q1203 foaf:knows [ a foaf:Person;
+        foaf:name "Ringo" ].
+    '''
+
+    graph = Graph()
+    graph.parse(data=ttl, format='turtle')
+
+    query = {"subject": URIRef("http://www.wikidata.org/entity/Q1203"), "predicate": FOAF.knows}
+
+    # Save the original bnode id.
+    bnode_id = graph.value(**query)
+
+    skolemized_graph = graph.skolemize()
+
+    # Check the BNode is now an RDFLibGenid after skolemization.
+    skolem_bnode = skolemized_graph.value(**query)
+    assert type(skolem_bnode) == RDFLibGenid
+
+    # Check that the original bnode id exists somewhere in the uri.
+    assert bnode_id in skolem_bnode
+
+    # Check that the original data is not isomorphic with the skolemized data.
+    assert not isomorphic(graph, skolemized_graph)
+
+    # Check that the original graph data is the same as the de-skolemized data.
+    de_skolemized_graph = skolemized_graph.de_skolemize()
+    assert isomorphic(graph, de_skolemized_graph)


### PR DESCRIPTION
Fixes https://github.com/RDFLib/rdflib/issues/1404

## Proposed Changes

- Correctly return `RDFLibGenid` instead of `URIRef` as required by `Graph.de_skolemize()`.
- This fixes skolemize/de-skolemize round-trip which was previously completely broken.
- Add tests.

Why `RDFLibGenid` and not `Genid`? See `URIRef.de_skolemize()`.

https://github.com/RDFLib/rdflib/blob/327de4ecc9e7a9a7c73b55d1b59b6e1e600f64ed/rdflib/term.py#L308-L328

Essentially, `RDFLibGenid` will correctly grab the original blank node ID before skolemization.