### PR TITLE
Forbid truthy values for lang when initializing Literal

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -547,7 +547,7 @@ class Literal(Identifier):
                 "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
             )
 
-        if lang and not _is_valid_langtag(lang):
+        if lang is not None and not _is_valid_langtag(lang):
             raise ValueError("'%s' is not a valid language tag!" % lang)
 
         if datatype:

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -1,10 +1,13 @@
 from decimal import Decimal
+from typing import Any, Optional, Type
 import unittest
 import datetime
 
 import rdflib  # needed for eval(repr(...)) below
 from rdflib.term import Literal, URIRef, _XSD_DOUBLE, bind, _XSD_BOOLEAN
 from rdflib.namespace import XSD
+
+import pytest
 
 
 class TestLiteral(unittest.TestCase):
@@ -42,15 +45,39 @@ class TestLiteral(unittest.TestCase):
         self.assertEqual(l.datatype, rdflib.XSD["boolean"])
 
 
+class TestNewPT:
+    # NOTE: TestNewPT is written for pytest so that pytest features like
+    # parametrize can be used.
+    # New tests should be added here instead of in TestNew.
+    @pytest.mark.parametrize(
+        "lang, exception_type",
+        [
+            ({}, TypeError),
+            ([], TypeError),
+            (1, TypeError),
+            (b"en", TypeError),
+            ("999", ValueError),
+            ("-", ValueError),
+        ],
+    )
+    def test_cant_pass_invalid_lang(
+        self,
+        lang: Any,
+        exception_type: Type[Exception],
+    ):
+        """
+        Construction of Literal fails if the language tag is invalid.
+        """
+        with pytest.raises(exception_type):
+            Literal("foo", lang=lang)
+
+
 class TestNew(unittest.TestCase):
+    # NOTE: Please use TestNewPT for new tests instead of this which is written
+    # for unittest.
     def testCantPassLangAndDatatype(self):
         self.assertRaises(
             TypeError, Literal, "foo", lang="en", datatype=URIRef("http://example.com/")
-        )
-
-    def testCantPassInvalidLang(self):
-        self.assertRaises(
-            ValueError, Literal, "foo", lang="999"
         )
 
     def testFromOtherLiteral(self):


### PR DESCRIPTION
With the proposed change, an exception will be raised when `lang` is a truthy value. I found this quite confusing when messing around with the library that `Literal("Hello", lang={})` was somehow considered a valid language tag.