### PR TITLE
Remove deprecated Statement class

### DIFF
--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -158,7 +158,6 @@ class Store(object):
             from rdflib.term import Literal
             from rdflib.graph import Graph, QuotedGraph
             from rdflib.term import Variable
-            from rdflib.term import Statement
 
             self.__node_pickler = np = NodePickler()
             np.register(self, "S")
@@ -168,7 +167,6 @@ class Store(object):
             np.register(Graph, "G")
             np.register(QuotedGraph, "Q")
             np.register(Variable, "V")
-            np.register(Statement, "s")
         return self.__node_pickler
 
     node_pickler = property(__get_node_pickler)

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -32,7 +32,6 @@ __all__ = [
     "BNode",
     "Literal",
     "Variable",
-    "Statement",
 ]
 
 import logging
@@ -1737,24 +1736,6 @@ class Variable(Identifier):
 
     def __reduce__(self):
         return (Variable, (str(self),))
-
-
-class Statement(Node, tuple):
-    def __new__(cls, triple, context):
-        subject, predicate, object = triple
-        warnings.warn(
-            "Class Statement is deprecated, and will be removed in "
-            + "the future. If you use this please let rdflib-dev know!",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return tuple.__new__(cls, ((subject, predicate, object), context))
-
-    def __reduce__(self):
-        return (Statement, (self[0], self[1]))
-
-    def toPython(self):
-        return (self[0], self[1])
 
 
 # Nodes are ordered like this


### PR DESCRIPTION
Fixes #1158 

Per the issue, it was mentioned that this was supposed to be removed in v5.1.0 or v6.0.0, but it is still present in the codebase.

I'm not sure whether we need to wait for a major version to release this as it is _technically_ a breaking change — but as the issue mentioned, it's been deprecated for about 10 years at this point, so perhaps it's fine to remove it in a minor version. I have no strong opinions on this, just thought I'd bubble this up as I think it's well overdue for removal.