### PR TITLE
Add type annotations to constructor parameters in Literal

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -63,7 +63,7 @@ from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 from decimal import Decimal
-from typing import TYPE_CHECKING, Dict, Callable, Optional, Union, Type
+from typing import TYPE_CHECKING, Any, Dict, Callable, Optional, Union, Type
 
 if TYPE_CHECKING:
     from .paths import AlternativePath, InvPath, NegatedPath, SequencePath, Path
@@ -532,14 +532,16 @@ class Literal(Identifier):
 
     """
 
+    _value: Any
+
     __slots__ = ("_language", "_datatype", "_value")
 
     def __new__(
         cls,
-        lexical_or_value,
+        lexical_or_value: Any,
         lang: Optional[str] = None,
-        datatype=None,
-        normalize=None,
+        datatype: Optional[str] = None,
+        normalize: Optional[bool] = None,
     ):
 
         if lang == "":
@@ -602,7 +604,7 @@ class Literal(Identifier):
             lexical_or_value = _strip_and_collapse_whitespace(lexical_or_value)
 
         try:
-            inst = str.__new__(cls, lexical_or_value)
+            inst: Literal = str.__new__(cls, lexical_or_value)
         except UnicodeDecodeError:
             inst = str.__new__(cls, lexical_or_value, "utf-8")
 

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -87,7 +87,7 @@ def _is_valid_uri(uri):
 _lang_tag_regex = compile("^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")
 
 
-def _is_valid_langtag(tag):
+def _is_valid_langtag(tag: str):
     return bool(_lang_tag_regex.match(tag))
 
 
@@ -534,7 +534,13 @@ class Literal(Identifier):
 
     __slots__ = ("_language", "_datatype", "_value")
 
-    def __new__(cls, lexical_or_value, lang=None, datatype=None, normalize=None):
+    def __new__(
+        cls,
+        lexical_or_value,
+        lang: Optional[str] = None,
+        datatype=None,
+        normalize=None,
+    ):
 
         if lang == "":
             lang = None  # no empty lang-tags in RDF
@@ -630,7 +636,7 @@ class Literal(Identifier):
         return self._value
 
     @property
-    def language(self):
+    def language(self) -> Optional[str]:
         return self._language
 
     @property


### PR DESCRIPTION
@gjhiggins From your comment here https://github.com/RDFLib/rdflib/pull/1494#issuecomment-991124245, I opted to go for type annotations instead of explicit exceptions. I guess the difference between cleaner code by just having type annotations with no explicit runtime checks and having more code with explicit runtime checks is a subjective one, so I'd be interested to hear what you think. Again, just pulled this out into a separate PR as I feel it's out of the scope of the other PR.

Also, the base branch for this should be #1494, but I'm not sure how to do that in GitHub when both the branches are upstream.