### PR TITLE
Quench nt test userwarn

### DIFF
--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -68,8 +68,7 @@ class JsonLDSerializer(Serializer):
         encoding = encoding or "utf-8"
         if encoding not in ("utf-8", "utf-16"):
             warnings.warn(
-                "JSON should be encoded as unicode. "
-                + "Given encoding was: %s" % encoding
+                "JSON should be encoded as unicode. " f"Given encoding was: {encoding}"
             )
 
         context_data = kwargs.get("context")

--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -31,8 +31,8 @@ class NQuadsSerializer(Serializer):
             warnings.warn("NQuadsSerializer does not support base.")
         if encoding is not None and encoding.lower() != self.encoding.lower():
             warnings.warn(
-                "NQuadsSerializer does not use custom encoding."
-                + "Given encoding was: %s" % encoding
+                "NQuadsSerializer does not use custom encoding. "
+                f"Given encoding was: {encoding}"
             )
         encoding = self.encoding
         for context in self.store.contexts():

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -34,8 +34,8 @@ class NTSerializer(Serializer):
             warnings.warn("NTSerializer does not support base.")
         if encoding != "utf-8":
             warnings.warn(
-                "NTSerializer always uses UTF-8 encoding."
-                + "Given encoding was: %s" % encoding
+                "NTSerializer always uses UTF-8 encoding. "
+                f"Given encoding was: {encoding}"
             )
 
         for triple in self.store:

--- a/test/test_finalnewline.py
+++ b/test/test_finalnewline.py
@@ -6,7 +6,6 @@ def testFinalNewline():
     """
     http://code.google.com/p/rdflib/issues/detail?id=5
     """
-    import sys
 
     graph = ConjunctiveGraph()
     graph.add(
@@ -19,8 +18,8 @@ def testFinalNewline():
 
     failed = set()
     for p in rdflib.plugin.plugins(None, rdflib.plugin.Serializer):
-        v = graph.serialize(format=p.name, encoding="latin-1")
-        lines = v.split("\n".encode("latin-1"))
+        v = graph.serialize(format=p.name, encoding="utf-8")
+        lines = v.split("\n".encode("utf-8"))
         if b"\n" not in v or (lines[-1] != b""):
             failed.add(p.name)
     # JSON-LD does not require a final newline (because JSON doesn't)

--- a/test/test_nquads.py
+++ b/test/test_nquads.py
@@ -60,7 +60,7 @@ class NQuadsParserTest(unittest.TestCase):
         g.get_context(uri1).add((bob, likes, pizza))
         g.get_context(uri2).add((bob, likes, pizza))
 
-        s = g.serialize(format="nquads", encoding="latin-1")
+        s = g.serialize(format="nquads", encoding="utf-8")
         self.assertEqual(len([x for x in s.split(b"\n") if x.strip()]), 2)
 
         g2 = ConjunctiveGraph()

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -1,5 +1,5 @@
 import unittest
-from rdflib import Graph, URIRef
+from rdflib import Graph, URIRef, Literal
 from tempfile import TemporaryDirectory
 from pathlib import Path, PurePath
 
@@ -10,7 +10,7 @@ class TestSerialize(unittest.TestCase):
         graph = Graph()
         subject = URIRef("example:subject")
         predicate = URIRef("example:predicate")
-        object = URIRef("example:object")
+        object = Literal("日本語の表記体系", lang="jpx")
         self.triple = (
             subject,
             predicate,
@@ -23,7 +23,7 @@ class TestSerialize(unittest.TestCase):
     def test_serialize_to_purepath(self):
         with TemporaryDirectory() as td:
             tfpath = PurePath(td) / "out.nt"
-            self.graph.serialize(destination=tfpath, format="nt")
+            self.graph.serialize(destination=tfpath, format="nt", encoding="utf-8")
             graph_check = Graph()
             graph_check.parse(source=tfpath, format="nt")
 
@@ -32,7 +32,7 @@ class TestSerialize(unittest.TestCase):
     def test_serialize_to_path(self):
         with TemporaryDirectory() as td:
             tfpath = Path(td) / "out.nt"
-            self.graph.serialize(destination=tfpath, format="nt")
+            self.graph.serialize(destination=tfpath, format="nt", encoding="utf-8")
             graph_check = Graph()
             graph_check.parse(source=tfpath, format="nt")
 
@@ -40,7 +40,9 @@ class TestSerialize(unittest.TestCase):
 
     def test_serialize_to_neturl(self):
         with self.assertRaises(ValueError) as raised:
-            self.graph.serialize(destination="http://example.com/", format="nt")
+            self.graph.serialize(
+                destination="http://example.com/", format="nt", encoding="utf-8"
+            )
         self.assertIn("destination", f"{raised.exception}")
 
     def test_serialize_to_fileurl(self):
@@ -49,7 +51,7 @@ class TestSerialize(unittest.TestCase):
             tfurl = tfpath.as_uri()
             self.assertRegex(tfurl, r"^file:")
             self.assertFalse(tfpath.exists())
-            self.graph.serialize(destination=tfurl, format="nt")
+            self.graph.serialize(destination=tfurl, format="nt", encoding="utf-8")
             self.assertTrue(tfpath.exists())
             graph_check = Graph()
             graph_check.parse(source=tfpath, format="nt")


### PR DESCRIPTION
Fed up with seeing Serializer Userwarnings in the test output. Is the `latin-1` format testing anything specific? Can it be simply swapped out for `utf-8` or am I missing something? (I'm not strong on the parse/serializer side of things).