### PR TITLE
Fix for issue 893

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1948,6 +1948,15 @@ class Dataset(ConjunctiveGraph):
         )
         return pattern % self.store.__class__.__name__
 
+    def __reduce__(self):
+        return (type(self), (self.store, self.default_union))
+
+    def __getstate__(self):
+        return self.store, self.identifier, self.default_context, self.default_union
+
+    def __setstate__(self, state):
+        self.store, self.identifier, self.default_context, self.default_union = state
+
     def graph(self, identifier=None, base=None):
         if identifier is None:
             from rdflib.term import rdflib_skolem_genid

--- a/test/test_issue893.py
+++ b/test/test_issue893.py
@@ -1,0 +1,32 @@
+import pickle
+from rdflib.graph import Dataset
+from rdflib.namespace import Namespace
+
+
+def test_issue893_ds_unpickle():
+    example = Namespace("http://example.com#")
+
+    ds1 = Dataset()
+    one = ds1.graph(example.one)
+
+    one.add((example.dan, example.knows, example.lisa))
+    one.add((example.lisa, example.knows, example.dan))
+
+    two = ds1.graph(example.two)
+
+    two.add((example.ben, example.knows, example.lisa))
+    two.add((example.lisa, example.knows, example.ben))
+
+    assert set(ds1.quads((None, None, None, None))) == set(
+        ds1.quads((None, None, None, None))
+    )
+
+    picklestring = pickle.dumps(ds1)
+    ds2 = pickle.loads(picklestring)
+
+    for new_graph, graph in zip(ds2.graphs(), ds1.graphs()):
+        assert new_graph.identifier == graph.identifier
+        for new_triple, triple in zip(
+            new_graph.triples((None, None, None)), graph.triples((None, None, None))
+        ):
+            assert new_triple == triple

--- a/test/test_issue893.py
+++ b/test/test_issue893.py
@@ -29,4 +29,5 @@ def test_issue893_ds_unpickle():
         for new_triple, triple in zip(
             new_graph.triples((None, None, None)), graph.triples((None, None, None))
         ):
-            assert new_triple == triple
+            assert new_triple in graph.triples((None, None, None))
+            assert triple in new_graph.triples((None, None, None))


### PR DESCRIPTION
As iddan reports in issue #893 “`Dataset` is unpickeld as `ConjunctiveGraph` because it extends `ConjunctiveGraph` and inherits the `__reduce__()` method. It should be unpickled as `Dataset` instead.”

A fix was provided but unfortunately overlooked. Rectifying this oversight.