### PR TITLE
Fix pipeline triggers

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,6 +1,10 @@
 name: Validate
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
The pipeline was triggering twice for pull requests made from branches
in the main repo, once for the pull request and once for a push to the
branch.

This changes the trigger for push to only happen on master branch.