### PR TITLE
Change python version used for mypy to 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ exclude_lines =
     if __name__==.__main__.:
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True
 disallow_subclassing_any = False


### PR DESCRIPTION
Support for python version 3.6 is dropped, and using 3.6 prevents
certain features from python 3.7 from being useable without type
failures.

Fixes #1513