### PR TITLE
Increase fuseki start timeout from 15 to 30 seconds

### DIFF
--- a/with-fuseki.sh
+++ b/with-fuseki.sh
@@ -7,7 +7,7 @@ script_dirname="$( dirname -- "${0}" )"
 set -eo pipefail
 
 wait_http_okay() {
-    local timeout=15
+    local timeout=30
     for var in "${@}"
     do
         eval "local ${var}"


### PR DESCRIPTION
Fuseki quite regularly takes longer than 15 seconds to start on MacOS.

We could maybe later consider only running it on Linux as it is not
likely to result in platform specific errors.