### PR TITLE
Overdue restoration of functools total_order decorator.

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -181,6 +181,7 @@ No vars specified:
 """
 
 
+from functools import total_ordering
 from rdflib.term import URIRef, Node
 from typing import Union, Callable
 
@@ -192,6 +193,7 @@ OneOrMore = "+"
 ZeroOrOne = "?"
 
 
+@total_ordering
 class Path(object):
 
     __or__: Callable[["Path", Union["URIRef", "Path"]], "AlternativePath"]
@@ -203,34 +205,12 @@ class Path(object):
     def eval(self, graph, subj=None, obj=None):
         raise NotImplementedError()
 
-    def __hash__(self):
-        return hash(repr(self))
-
-    def __eq__(self, other):
-        return repr(self) == repr(other)
-
     def __lt__(self, other):
         if not isinstance(other, (Path, Node)):
             raise TypeError(
                 "unorderable types: %s() < %s()" % (repr(self), repr(other))
             )
         return repr(self) < repr(other)
-
-    def __le__(self, other):
-        if not isinstance(other, (Path, Node)):
-            raise TypeError(
-                "unorderable types: %s() < %s()" % (repr(self), repr(other))
-            )
-        return repr(self) <= repr(other)
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __gt__(self, other):
-        return not self <= other
-
-    def __ge__(self, other):
-        return not self < other
 
 
 class InvPath(Path):


### PR DESCRIPTION
Fixes #685:
"When we ditch 2.6 support, undo this: https://github.com/RDFLib/rdflib/commit/25bfa5bd1f200dae993cddf21cc8726d6db00c63"

## Proposed Changes

  - Restore use of functools `total_order` in [`paths.py`](https://github.com/RDFLib/rdflib/blob/ed4c0212bd9b26931e5cb2112e61addf121dca39/rdflib/paths.py#L206)
  - Remove code added in https://github.com/RDFLib/rdflib/commit/25bfa5bd1f200dae993cddf21cc8726d6db00c63
