### PR TITLE
Revert error-raising change, enable Exception to be raised.

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -133,7 +133,7 @@ def join(here, there):
         return here + frag
 
     # join('mid:foo@example', '../foo') bzzt
-    if here[bcolonl + 1] != "/":
+    if here[bcolonl + 1 : bcolonl + 2] != "/":
         raise ValueError(
             "Base <%s> has no slash after "
             "colon - with relative '%s'." % (here, there)


### PR DESCRIPTION
Fixes #1216 in terms of not raising an error but the originally-intended Exception.
Doesn't address “But I was trying to get \<local:\> working, and also, I believe, \<local:Category\> is a perfectly good IRI.”

## Proposed Changes

  - Revert error-raising change, enable Exception to be raised.