### PR TITLE
Scale down CI checks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
   - apt-get update && apt-get install -y openjdk-11-jdk-headless
   - pip install --default-timeout 60 -r requirements.txt
   - pip install --default-timeout 60 -r requirements.dev.txt
+  - pip install --default-timeout 60 -r requirements.dev-extra.txt
   - pip install --default-timeout 60 coveralls && export HAS_COVERALLS=1
   - python setup.py install
   - black --config black.toml --check ./rdflib || true
@@ -44,13 +45,12 @@ steps:
 - name: test
   image: python:3.8
   commands:
-  - apt-get update && apt-get install -y openjdk-11-jdk-headless
   - pip install --default-timeout 60 -r requirements.txt
   - pip install --default-timeout 60 -r requirements.dev.txt
   - python setup.py install
   - black --config black.toml --check ./rdflib || true
   - flake8 --exit-zero rdflib
-  - ./with-fuseki.sh pytest -ra
+  - pytest -ra
 
 ---
 kind: pipeline
@@ -64,13 +64,12 @@ steps:
 - name: test
   image: python:3.9
   commands:
-  - apt-get update && apt-get install -y openjdk-11-jdk-headless
   - pip install --default-timeout 60 -r requirements.txt
   - pip install --default-timeout 60 -r requirements.dev.txt
   - python setup.py install
   - black --config black.toml --check ./rdflib || true
   - flake8 --exit-zero rdflib
-  - ./with-fuseki.sh pytest -ra
+  - pytest -ra
 
 ---
 kind: pipeline
@@ -84,10 +83,9 @@ steps:
 - name: test
   image: python:3.10
   commands:
-  - apt-get update && apt-get install -y openjdk-11-jdk-headless
   - pip install --default-timeout 60 -r requirements.txt
   - pip install --default-timeout 60 -r requirements.dev.txt
   - python setup.py install
   - black --config black.toml --check ./rdflib | true
   - flake8 --exit-zero rdflib
-  - ./with-fuseki.sh pytest -ra
+  - pytest -ra

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,17 +16,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - {
+              python-version: "3.7",
+              os: ubuntu-latest,
+              extensive-tests: true,
+            }
     steps:
       - uses: actions/checkout@v2
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - uses: actions/setup-java@v2
+        if: ${{ matrix.extensive-tests }}
         with:
           distribution: "temurin"
           java-version: "17"
@@ -55,8 +61,13 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          # bash .travis.fuseki_install_optional.sh
           pip install --default-timeout 60 -r requirements.txt
+          pip install --default-timeout 60 -r requirements.dev.txt
+          python setup.py install
+      - name: Install extra dev dependencies
+        if: ${{ matrix.extensive-tests }}
+        shell: bash
+        run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]
           then
               sudo apt-get install -y libdb-dev
@@ -65,18 +76,17 @@ jobs:
               brew install berkeley-db@4
               export BERKELEYDB_DIR=$(brew --prefix berkeley-db@4)
           fi
-          pip install --default-timeout 60 -r requirements.dev.txt
-          pip install networkx
-          python setup.py install
+          pip install --default-timeout 60 -r requirements.dev-extra.txt
       - name: Validate
         shell: bash
         run: |
+          test_harness=()
+          if "${{ matrix.extensive-tests || false }}" && [ "${{ matrix.os }}" != "windows-latest" ]
+          then
+            1>&2 echo "Running with fuseki"
+            test_harness+="./with-fuseki.sh"
+          fi
           black --config black.toml --check ./rdflib || true
           flake8 --exit-zero rdflib
           mypy --show-error-context --show-error-codes
-          if [ "${{ matrix.os }}" == "windows-latest" ]
-          then
-            pytest -ra --cov
-          else
-            ./with-fuseki.sh pytest -ra --cov
-          fi
+          "${test_harness[@]}" pytest -ra --cov

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -44,16 +44,27 @@ Running tests
 
 To run RDFLib's test suite with `pytest <https://docs.pytest.org/en/latest/>`_:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ pip install -r requirements.txt -r requirements.dev.txt
    $ pytest
 
 Specific tests can be run by file name. For example:
 
-.. code-block:: bash
+.. code-block:: console
 
   $ pytest test/test_graph.py
+
+For more extensive tests, including tests for the `berkleydb
+<https://www.oracle.com/database/technologies/related/berkeleydb.html>`_
+backend, install the requirements from ``requirements.dev-extra.txt`` before
+executing the tests.
+
+.. code-block:: console
+
+   $ pip install -r requirements.txt -r requirements.dev.txt
+   $ pip install -r requirements.dev-extra.txt
+   $ pytest
 
 Writing tests
 ~~~~~~~~~~~~~

--- a/requirements.dev-extra.txt
+++ b/requirements.dev-extra.txt
@@ -1,0 +1,2 @@
+berkeleydb
+networkx

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,3 @@
-berkeleydb; platform_system != "Windows"
 black==21.9b0
 coverage
 doctest-ignore-unicode==0.1.2


### PR DESCRIPTION
Only perform tests for networkx, berkeleydb and fuseki on Linux
using Python 3.7.

Also:
- include python 3.10 in github test matrix.
- move networkx and berkeleydb to `requirements.dev-extra.txt` so they
  can be installed seperately and add information about this to
  `developers.rst`.

Based on discussion from:
- https://github.com/RDFLib/rdflib/pull/1516