### PR TITLE
Fix typing errors in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,6 @@ ignore_missing_imports = True
 disallow_subclassing_any = False
 warn_unreachable = True
 
-[mypy-test.*]
-# NOTE: Currently there are many type errors in tests, these should be fixed but
-# until they are fixed errors are ignored.
-ignore_errors = True
-
 [tool:pytest]
 addopts =
    --doctest-modules

--- a/test/earl.py
+++ b/test/earl.py
@@ -84,9 +84,12 @@ class EarlReport:
         self.asserter: Node
         asserter: Node
         if asserter_uri is not None or asserter_homepage is not None:
-            self.asserter = asserter = URIRef(
-                asserter_homepage if asserter_uri is None else asserter_uri
+            # cast to remove Optional because mypy is not smart enough to
+            # figure out that it won't be optional.
+            asserter_ref = cast(
+                str, asserter_homepage if asserter_uri is None else asserter_uri
             )
+            self.asserter = asserter = URIRef(asserter_ref)
             graph.add((asserter, RDF.type, FOAF.Person))
         else:
             self.asserter = asserter = BNode()

--- a/test/jsonld/test_context.py
+++ b/test/jsonld/test_context.py
@@ -3,6 +3,7 @@ JSON-LD Context Spec
 """
 
 from functools import wraps
+from typing import Any, Dict
 from rdflib.plugins.shared.jsonld.context import Context, Term
 from rdflib.plugins.shared.jsonld import context
 from rdflib.plugins.shared.jsonld import errors
@@ -129,7 +130,7 @@ def test_prefix_like_vocab():
 
 
 # Mock external sources loading
-SOURCES = {}
+SOURCES: Dict[str, Dict[str, Any]] = {}
 _source_to_json = context.source_to_json
 
 

--- a/test/jsonld/test_onedotone.py
+++ b/test/jsonld/test_onedotone.py
@@ -1,6 +1,7 @@
 from os import environ, chdir, getcwd, path as p
 import json
 import os
+from typing import Tuple
 
 
 import pytest
@@ -15,7 +16,7 @@ TC_BASE = "https://w3c.github.io/json-ld-api/tests/toRdf/"
 testsuite_dir = p.join(p.abspath(p.dirname(__file__)), "1.1")
 
 
-unsupported_tests = ("frame", "normalize")
+unsupported_tests: Tuple[str, ...] = ("frame", "normalize")
 unsupported_tests += (
     "error",
     "remote",
@@ -24,7 +25,7 @@ unsupported_tests += ("flatten", "compact", "expand")
 unsupported_tests += ("html",)
 unsupported_tests += ("fromRdf",)  # The JSON-LD 1.1 enhancement applies to parsing only
 
-known_bugs = (
+known_bugs: Tuple[str, ...] = (
     # TODO: Literal doesn't preserve representations
     "fromRdf/0002-in",
     # RDflib does not print Integer with scientific notation

--- a/test/jsonld/test_testsuite.py
+++ b/test/jsonld/test_testsuite.py
@@ -1,5 +1,6 @@
 from os import environ, chdir, getcwd, path as p
 import json
+from typing import Tuple
 
 import pytest
 import rdflib
@@ -8,7 +9,7 @@ from rdflib.term import URIRef
 from . import runner
 
 
-unsupported_tests = ("frame", "normalize")
+unsupported_tests: Tuple[str, ...] = ("frame", "normalize")
 unsupported_tests += (
     "error",
     "remote",

--- a/test/manifest.py
+++ b/test/manifest.py
@@ -1,8 +1,8 @@
-from typing import Iterable, List, NamedTuple, Optional, Tuple
+from typing import Iterable, List, NamedTuple, Optional, Tuple, Union, cast
 
 from rdflib import RDF, RDFS, Graph, Namespace
 from rdflib.namespace import DefinedNamespace
-from rdflib.term import Node, URIRef
+from rdflib.term import Identifier, Node, URIRef
 
 MF = Namespace("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#")
 QT = Namespace("http://www.w3.org/2001/sw/DataAccess/tests/test-query#")
@@ -42,15 +42,18 @@ class RDFT(DefinedNamespace):
 
 DAWG = Namespace("http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#")
 
+ResultType = Union[Identifier, Tuple[Identifier, List[Tuple[Identifier, Identifier]]]]
+GraphDataType = Union[List[Identifier], List[Tuple[Identifier, Identifier]]]
+
 
 class RDFTest(NamedTuple):
     uri: URIRef
     name: str
     comment: str
-    data: Node
-    graphdata: Optional[List[Node]]
-    action: Node
-    result: Optional[Node]
+    data: Identifier
+    graphdata: Optional[GraphDataType]
+    action: Identifier
+    result: Optional[ResultType]
     syntax: bool
 
 
@@ -102,29 +105,33 @@ def read_manifest(f, base=None, legacy=False) -> Iterable[Tuple[Node, URIRef, RD
                 name = g.value(e, MF.name)
                 comment = g.value(e, RDFS.comment)
                 data = None
-                graphdata = None
-                res = None
+                graphdata: Optional[GraphDataType] = None
+                res: Optional[ResultType] = None
                 syntax = True
 
                 if _type in (MF.QueryEvaluationTest, MF.CSVResultFormatTest):
                     a = g.value(e, MF.action)
                     query = g.value(a, QT.query)
                     data = g.value(a, QT.data)
-                    graphdata = list(g.objects(a, QT.graphData))
+                    # NOTE: Casting to identifier because g.objects return Node
+                    # but should probably return identifier instead.
+                    graphdata = list(
+                        cast(Iterable[Identifier], g.objects(a, QT.graphData))
+                    )
                     res = g.value(e, MF.result)
                 elif _type in (MF.UpdateEvaluationTest, UP.UpdateEvaluationTest):
                     a = g.value(e, MF.action)
                     query = g.value(a, UP.request)
                     data = g.value(a, UP.data)
-                    graphdata = []
+                    graphdata = cast(List[Tuple[Identifier, Identifier]], [])
                     for gd in g.objects(a, UP.graphData):
                         graphdata.append(
                             (g.value(gd, UP.graph), g.value(gd, RDFS.label))
                         )
 
                     r = g.value(e, MF.result)
-                    resdata = g.value(r, UP.data)
-                    resgraphdata = []
+                    resdata: Identifier = g.value(r, UP.data)
+                    resgraphdata: List[Tuple[Identifier, Identifier]] = []
                     for gd in g.objects(r, UP.graphData):
                         resgraphdata.append(
                             (g.value(gd, UP.graph), g.value(gd, RDFS.label))

--- a/test/test_issue200.py
+++ b/test/test_issue200.py
@@ -6,10 +6,7 @@ import unittest
 import pytest
 
 
-try:
-    from os import fork
-    from os import pipe
-except ImportError:
+if os.name == "nt":
     pytestmark = pytest.mark.skip(
         reason="No os.fork() and/or os.pipe() on this platform, skipping"
     )

--- a/test/test_rdfxml.py
+++ b/test/test_rdfxml.py
@@ -1,5 +1,6 @@
 import sys
 from encodings.utf_8 import StreamWriter
+from typing import ClassVar
 
 import unittest
 
@@ -170,6 +171,8 @@ class ParserTestCase(unittest.TestCase):
     store = "default"
     path = "store"
     slow = True
+
+    RDF_setting: ClassVar[bool]
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Also removed mypy config to ignore errors in tests.

This will make tests useful for determining if the typing of rdflib is
correct and sane and should also help detect if a change in rdflib
introduces typing errors in tests.