### PR TITLE
Add `version` to docker-compose config for tests

### DIFF
--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   test-runner:
     build:


### PR DESCRIPTION
Running `make tests` results in the following error:
```
docker-compose -f docker-compose.tests.yml up test-runner
ERROR: The Compose file './docker-compose.tests.yml' is invalid because:
Unsupported config option for services: 'test-runner-coverage'
make: *** [Makefile:2: tests] Error 1
```
when running with `docker-compose` CLI version 1.x.x (pre-v2).

This adds the `version` to the config, which fixes the error. The `version` key is no longer required for `docker-compose` CLI version 2 and greater.

Ubuntu latest and LTS versions are all on docker-compose 1.x.x. 

See https://packages.ubuntu.com/search?keywords=docker-compose&searchon=names.

We should keep `version` in our docker-compose configs for a while.

## Proposed Changes

  - Add docker-compose.yml version to be compatible with docker-compose CLI pre-v2.

