### PR TITLE
Run translate_algebra tests from pytest

### DIFF
--- a/requirements.dev-extra.txt
+++ b/requirements.dev-extra.txt
@@ -1,2 +1,7 @@
 berkeleydb
 networkx
+
+# pandas and tabulate are in here for `test/translate_algebra` and should be
+# removed once those tests are all integrated into pytest.
+pandas
+tabulate

--- a/test/test_translate_algebra.py
+++ b/test/test_translate_algebra.py
@@ -1,0 +1,31 @@
+import pytest
+from pathlib import Path
+import sys
+
+
+try:
+    import pandas  # noqa: F401
+    import tabulate  # noqa: F401
+except ImportError:
+    pytestmark = pytest.mark.skip(
+        reason="No os.fork() and/or os.pipe() on this platform, skipping"
+    )
+
+
+def test_external() -> None:
+    """
+    Run the tests from the custom framework used in ``translate_algebra/``.
+    """
+
+    translate_algebra_path = Path(__file__).absolute().parent / "translate_algebra"
+    sys.path.append(f"{translate_algebra_path}")
+
+    # this will trigger the algebra tests
+    from .translate_algebra import main
+    from .translate_algebra.test_base import Test
+
+    test: Test
+    for test in main.t.tests:
+        assert (
+            test.yn_passed
+        ), f"test #{test.test_number} {test.test_name} failed: {test.tc_desc}"

--- a/test/translate_algebra/main.py
+++ b/test/translate_algebra/main.py
@@ -4,6 +4,7 @@ import rdflib.plugins.sparql.parser as parser
 import rdflib.plugins.sparql.algebra as algebra
 import sys
 import logging
+from pathlib import Path
 
 
 def _pprint_query(query: str):
@@ -48,7 +49,9 @@ class TestAlgebraToTest(TestExecution):
         if self.annotated_tests:
             test_name = test_name[2:]
 
-        self.query_text = open("test_data/{0}.txt".format(test_name), "r").read()
+        test_data_path = Path(__file__).absolute().parent / "test_data"
+        query_text_path = test_data_path / "{0}.txt".format(test_name)
+        self.query_text = query_text_path.read_text()
 
     def test_functions__functional_forms(self):
         query_tree = parser.parseQuery(self.query_text)

--- a/test/translate_algebra/test_base.py
+++ b/test/translate_algebra/test_base.py
@@ -104,7 +104,8 @@ class TestExecution:
         :return:
         """
         print("Executing tests ...")
-        logging.getLogger().setLevel(int(self.test_config.get("TEST", "log_level")))
+        if self.test_config.has_option("TEST", "log_level"):
+            logging.getLogger().setLevel(int(self.test_config.get("TEST", "log_level")))
 
         self.before_all_tests()
         test_prefix = "test_"


### PR DESCRIPTION
**WARNING**: Still in draft - just placing it here to share with @GreenfishK - likely it will be completely different for merging.

This change adds a single pytest test that just runs the tests from
the custom testing framework used in `test/translate_algebra`
and asserts that they all passed.

The next step will be convert those tests into pytest tests.

See also:
- #1451
