### PR TITLE
Black rdflib except for rdflib/namespace/_GEO.py

### DIFF
--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -39,7 +39,7 @@ def source_to_json(source):
         if isinstance(stream, TextIOBase):
             use_stream = stream
         else:
-            use_stream = TextIOWrapper(stream, encoding='utf-8')
+            use_stream = TextIOWrapper(stream, encoding="utf-8")
         return json.load(use_stream)
     finally:
         stream.close()

--- a/rdflib/tools/defined_namespace_creator.py
+++ b/rdflib/tools/defined_namespace_creator.py
@@ -93,7 +93,7 @@ def get_target_namespace_elements(g, target_namespace):
 
     elements_strs = []
     for e in elements:
-        desc = e[1].replace('\n', ' ')
+        desc = e[1].replace("\n", " ")
         elements_strs.append(
             f"    {e[0].replace(args.target_namespace, '')}: URIRef  # {desc}\n"
         )
@@ -148,14 +148,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        '-f',
+        "-f",
         "--fail",
-        dest='fail',
-        action='store_true',
+        dest="fail",
+        action="store_true",
         help="Whether (true) or not (false) to mimic ClosedNamespace and fail on "
         "non-element use",
     )
-    parser.add_argument('--no-fail', dest='fail', action='store_false')
+    parser.add_argument("--no-fail", dest="fail", action="store_false")
     parser.set_defaults(feature=False)
 
     args = parser.parse_args()


### PR DESCRIPTION
Probably we should ingore generated namespaces in black or format them
on generation, or mark them for ignoring by formatter. Will look at that
later.