### PR TITLE
Allow parse of RDF from URL with all RDF Media Types

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -204,10 +204,9 @@ class URLInputSource(InputSource):
             from rdflib.plugin import plugins
 
             acc = []
-            for p in plugins():
-                if p.kind == Parser:  # only get parsers
-                    if "/" in p.name:  # all Media Types known have a / in them
-                        acc.append(p.name)
+            for p in plugins(kind=Parser):  # only get parsers
+                if "/" in p.name:  # all Media Types known have a / in them
+                    acc.append(p.name)
 
             myheaders["Accept"] = ", ".join(acc)
 

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -181,23 +181,35 @@ class URLInputSource(InputSource):
 
         # copy headers to change
         myheaders = dict(headers)
-        if format == "application/rdf+xml":
+        if format == "xml":
             myheaders["Accept"] = "application/rdf+xml, */*;q=0.1"
         elif format == "n3":
             myheaders["Accept"] = "text/n3, */*;q=0.1"
-        elif format == "turtle":
-            myheaders["Accept"] = "text/turtle,application/x-turtle, */*;q=0.1"
+        elif format in ["turtle" or "ttl"]:
+            myheaders["Accept"] = "text/turtle, application/x-turtle, */*;q=0.1"
         elif format == "nt":
             myheaders["Accept"] = "text/plain, */*;q=0.1"
+        elif format == "trig":
+            myheaders["Accept"] = "application/trig, */*;q=0.1"
+        elif format == "trix":
+            myheaders["Accept"] = "application/trix, */*;q=0.1"
         elif format == "json-ld":
             myheaders[
                 "Accept"
             ] = "application/ld+json, application/json;q=0.9, */*;q=0.1"
         else:
-            myheaders["Accept"] = (
-                "application/rdf+xml,text/rdf+n3;q=0.9,"
-                + "application/xhtml+xml;q=0.5, */*;q=0.1"
-            )
+            # if format not given, create an Accept header from all registered
+            # parser Media Types
+            from rdflib.parser import Parser
+            from rdflib.plugin import plugins
+
+            acc = []
+            for p in plugins():
+                if p.kind == Parser:  # only get parsers
+                    if "/" in p.name:  # all Media Types known have a / in them
+                        acc.append(p.name)
+
+            myheaders["Accept"] = ", ".join(acc)
 
         req = Request(system_id, None, myheaders)
 

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -185,7 +185,7 @@ class URLInputSource(InputSource):
             myheaders["Accept"] = "application/rdf+xml, */*;q=0.1"
         elif format == "n3":
             myheaders["Accept"] = "text/n3, */*;q=0.1"
-        elif format in ["turtle" or "ttl"]:
+        elif format in ["turtle", "ttl"]:
             myheaders["Accept"] = "text/turtle, application/x-turtle, */*;q=0.1"
         elif format == "nt":
             myheaders["Accept"] = "text/plain, */*;q=0.1"

--- a/test/test_graph_http.py
+++ b/test/test_graph_http.py
@@ -68,7 +68,7 @@ class ContentNegotiationHandler(BaseHTTPRequestHandler):
         elif "text/n3" in ct:
             rct = "text/n3"
             content = n3testdoc
-        elif 'application/trig' in ct:
+        elif "application/trig" in ct:
             rct = "application/trig"
             content = ttltestdoc
         elif "text/plain" in ct or "application/n-triples" in ct:

--- a/test/test_graph_http.py
+++ b/test/test_graph_http.py
@@ -30,6 +30,24 @@ n3testdoc = """@prefix : <http://example.org/> .
 
 nttestdoc = "<http://example.org/a> <http://example.org/b> <http://example.org/c> .\n"
 
+ttltestdoc = """@prefix : <http://example.org/> .
+
+            :a :b :c .
+            """
+
+jsonldtestdoc = """
+                [
+                  {
+                    "@id": "http://example.org/a",
+                    "http://example.org/b": [
+                      {
+                        "@id": "http://example.org/c"
+                      }
+                    ]
+                  }
+                ]
+                """
+
 
 class ContentNegotiationHandler(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -40,7 +58,7 @@ class ContentNegotiationHandler(BaseHTTPRequestHandler):
         acs = self.headers["Accept"].split(",")
         acq = [x.split(";") for x in acs if ";" in x]
         acn = [(x, "q=1") for x in acs if ";" not in x]
-        acs = [(x[0], float(x[1].strip()[2:])) for x in acq + acn]
+        acs = [(x[0].strip(), float(x[1].strip()[2:])) for x in acq + acn]
         ac = sorted(acs, key=lambda x: x[1])
         ct = ac[-1]
 
@@ -50,9 +68,18 @@ class ContentNegotiationHandler(BaseHTTPRequestHandler):
         elif "text/n3" in ct:
             rct = "text/n3"
             content = n3testdoc
-        elif "text/plain" in ct:
+        elif 'application/trig' in ct:
+            rct = "application/trig"
+            content = ttltestdoc
+        elif "text/plain" in ct or "application/n-triples" in ct:
             rct = "text/plain"
             content = nttestdoc
+        elif "application/ld+json" in ct:
+            rct = "application/ld+json"
+            content = jsonldtestdoc
+        else:  # "text/turtle" in ct:
+            rct = "text/turtle"
+            content = ttltestdoc
 
         self.send_header("Content-type", rct)
         self.end_headers()
@@ -66,7 +93,7 @@ class TestGraphHTTP(unittest.TestCase):
     def test_content_negotiation(self) -> None:
         EG = Namespace("http://example.org/")
         expected = Graph()
-        expected.add((EG["a"], EG["b"], EG["c"]))
+        expected.add((EG.a, EG.b, EG.c))
         expected_triples = GraphHelper.triple_set(expected)
 
         with ctx_http_server(ContentNegotiationHandler) as server:
@@ -76,6 +103,19 @@ class TestGraphHTTP(unittest.TestCase):
                 graph = Graph()
                 graph.parse(url, format=format)
                 self.assertEqual(expected_triples, GraphHelper.triple_set(graph))
+
+    def test_content_negotiation_no_format(self) -> None:
+        EG = Namespace("http://example.org/")
+        expected = Graph()
+        expected.add((EG.a, EG.b, EG.c))
+        expected_triples = GraphHelper.triple_set(expected)
+
+        with ctx_http_server(ContentNegotiationHandler) as server:
+            (host, port) = server.server_address
+            url = f"http://{host}:{port}/foo"
+            graph = Graph()
+            graph.parse(url)
+            self.assertEqual(expected_triples, GraphHelper.triple_set(graph))
 
     def test_source(self) -> None:
         EG = Namespace("http://example.org/")

--- a/test/test_rdfxml.py
+++ b/test/test_rdfxml.py
@@ -117,11 +117,6 @@ def _testPositive(uri, manifest):
         write(inDoc)
         write("' failed with")
         raise pe
-        try:
-            write(type(pe))
-        except:
-            write("sorry could not dump out error.")
-        result = 1
     else:
         if not store.isomorphic(expected):
             write("""Failed: '%s'""" % uri)


### PR DESCRIPTION
Current `parse(location=???)` only handles a few Media Types. This update allows all known RDF Media Types to be received and parsed.

A new test is included to show that `parse(location=???)` without a format given works too.