### PR TITLE
added three tests to cover changes made by the pull request #1361

### DIFF
--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -848,7 +848,7 @@ def translateAlgebra(query_algebra: Query):
         with open("query.txt", "w") as file:
             file.write(filedata)
 
-    aggr_vars = collections.defaultdict(list)
+    aggr_vars = collections.defaultdict(list)  # type: dict
 
     def convert_node_arg(node_arg):
         if isinstance(node_arg, Identifier):

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -854,7 +854,6 @@ def translateAlgebra(query_algebra: Query):
         if isinstance(node_arg, Identifier):
             if node_arg in aggr_vars.keys():
                 grp_var = aggr_vars[node_arg].pop(0).n3()
-                logging.debug(grp_var)
                 return grp_var
             else:
                 return node_arg.n3()

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -852,13 +852,12 @@ def translateAlgebra(query_algebra: Query):
 
     def convert_node_arg(node_arg):
         if isinstance(node_arg, Identifier):
-            if node_arg.n3() in aggr_vars.keys():
-                grp_var = aggr_vars[node_arg.n3()].pop(0)
+            if node_arg in aggr_vars.keys():
+                grp_var = aggr_vars[node_arg].pop(0).n3()
                 logging.debug(grp_var)
                 return grp_var
             else:
                 return node_arg.n3()
-            # return node_arg.n3()
         elif isinstance(node_arg, CompValue):
             return "{" + node_arg.name + "}"
         elif isinstance(node_arg, Expr):
@@ -968,7 +967,7 @@ def translateAlgebra(query_algebra: Query):
                         raise ExpressionNotCoveredException(
                             "This expression might not be covered yet."
                         )
-                    aggr_vars[convert_node_arg(agg_func.res)].append(convert_node_arg(agg_func.vars))
+                    aggr_vars[agg_func.res].append(agg_func.vars)
 
                     agg_func_name = agg_func.name.split('_')[1]
                     distinct = ""

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -6,7 +6,6 @@ http://www.w3.org/TR/sparql11-query/#sparqlQuery
 """
 
 import functools
-import logging
 import operator
 import collections
 

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -1304,7 +1304,6 @@ def translateAlgebra(query_algebra: Query):
                 )
             elif node.name.endswith("Builtin_CONCAT"):
                 expr = "CONCAT({vars})".format(
-                    #vars=", ".join(elem.n3() for elem in node.arg)
                     vars=", ".join(convert_node_arg(elem) for elem in node.arg)
                 )
                 replace("{Builtin_CONCAT}", expr)

--- a/test/test_translate_algebra.py
+++ b/test/test_translate_algebra.py
@@ -119,6 +119,16 @@ algebra_tests = [
         'Test if "group" gets properly translated into the query text.',
     ),
     AlgebraTest(
+        "test_graph_patterns__group_and_substr",
+        'Test if a query with a variable that is used in the "GROUP BY" clause '
+        'and in the SUBSTR function gets properly translated into the query text.',
+    ),
+    AlgebraTest(
+        "test_graph_patterns__group_and_nested_concat",
+        'Test if a query with a nested concat expression in the select clause which '
+        'uses a group variable gets properly translated into the query text.',
+    ),
+    AlgebraTest(
         "test_graph_patterns__having",
         'Test if "having" gets properly translated into the query text.',
     ),
@@ -266,7 +276,7 @@ def test_all_files_used(data_path: Path) -> None:
 @pytest.mark.parametrize("test_spec", [test.pytest_param() for test in algebra_tests])
 def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
     """
-    Query remains the same over two successuive parse and translate cycles.
+    Query remains the same over two successive parse and translate cycles.
     """
     query_text = (data_path / test_spec.filename).read_text()
 

--- a/test/test_translate_algebra.py
+++ b/test/test_translate_algebra.py
@@ -284,14 +284,17 @@ def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
     query_tree = parser.parseQuery(query_text)
     query_algebra = algebra.translateQuery(query_tree)
     query_from_algebra = translateAlgebra(query_algebra)
-    logging.debug(query_from_algebra)
+    logging.debug(
+        "query_from_query_from_algebra = \n%s",
+        query_from_algebra,
+    )
 
     query_tree_2 = parser.parseQuery(query_from_algebra)
     query_algebra_2 = algebra.translateQuery(query_tree_2)
     query_from_query_from_algebra = translateAlgebra(query_algebra_2)
     logging.debug(
         "query_from_query_from_algebra = \n%s",
-        _format_query(query_from_query_from_algebra),
+        query_from_query_from_algebra,
     )
     assert (
         query_from_algebra == query_from_query_from_algebra

--- a/test/test_translate_algebra.py
+++ b/test/test_translate_algebra.py
@@ -284,6 +284,7 @@ def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
     query_tree = parser.parseQuery(query_text)
     query_algebra = algebra.translateQuery(query_tree)
     query_from_algebra = translateAlgebra(query_algebra)
+    logging.debug(query_from_algebra)
 
     query_tree_2 = parser.parseQuery(query_from_algebra)
     query_algebra_2 = algebra.translateQuery(query_tree_2)
@@ -296,6 +297,6 @@ def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
         query_from_algebra == query_from_query_from_algebra
     ), f"failed expectation: {test_spec.description}"
 
-    # TODO: Execute the raw query (query_text) and the reconstitued query
+    # TODO: Execute the raw query (query_text) and the reconstituted query
     # (query_from_query_from_algebra) against a well defined graph and ensure
     # they yield the same result.

--- a/test/translate_algebra/test_functions__functions_on_strings.txt
+++ b/test/translate_algebra/test_functions__functions_on_strings.txt
@@ -12,6 +12,7 @@ select
 (concat("foo"@en, "bar"@en) as ?concat)
 (replace("abcd", "b", "Z") as ?replace)
 (regex(substr("foobar", 4), "bar", "bar") as ?regex)
+(regex(substr("foobar", 4, 1), "b", "b") as ?regex2)
 where {
 	?s ?p ?o .
     FILTER langMatches(lang(?o), "EN" )

--- a/test/translate_algebra/test_graph_patterns__group_and_nested_concat.txt
+++ b/test/translate_algebra/test_graph_patterns__group_and_nested_concat.txt
@@ -1,0 +1,7 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT
+(concat(str(?a), concat("foo"@en, "bar"@en)) as ?nested_concat)
+WHERE {
+  ?a rdf:value ?val .
+} GROUP BY ?a

--- a/test/translate_algebra/test_graph_patterns__group_and_substr.txt
+++ b/test/translate_algebra/test_graph_patterns__group_and_substr.txt
@@ -1,0 +1,6 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (SUM(?val) AS ?sum) (COUNT(?a) AS ?count) (SUBSTR(?a, 4, 1) as ?a_substr)
+WHERE {
+  ?a rdf:value ?val .
+} GROUP BY ?a

--- a/test/translate_algebra/test_graph_patterns__group_and_substr.txt
+++ b/test/translate_algebra/test_graph_patterns__group_and_substr.txt
@@ -1,6 +1,9 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-SELECT (SUM(?val) AS ?sum) (COUNT(?a) AS ?count) (SUBSTR(?a, 4, 1) as ?a_substr)
+SELECT
+(SUM(?val) AS ?sum)
+(COUNT(?a) AS ?count)
+(SUBSTR(?a, 4, 1) as ?a_substr)
 WHERE {
   ?a rdf:value ?val .
 } GROUP BY ?a

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ setenv =
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
-[pytest]
-log_cli = 1
-log_cli_level = DEBUG
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S
+#[pytest]
+#log_cli = 1
+#log_cli_level = DEBUG
+#log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+#log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,9 @@ setenv =
     PYTHONHASHSEED = 0
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[pytest]
+log_cli = 1
+log_cli_level = DEBUG
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [pytest]
-log_cli = 1
-log_cli_level = DEBUG
+# log_cli = true
+# log_cli_level = DEBUG
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ setenv =
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
-#[pytest]
-#log_cli = 1
-#log_cli_level = DEBUG
-#log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-#log_cli_date_format=%Y-%m-%d %H:%M:%S
+[pytest]
+log_cli = 1
+log_cli_level = DEBUG
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S


### PR DESCRIPTION
# Fixes
SUBSTR: The 'length' parameter was not included. Now it is
SUBSTR: Did not work with group variables. E.g. when ?x was used in group by and in substr, ?x would appear as __aggr_1 in Builtin_substr in the query algebra tree. Group variables in built in functions are now replaced properly
CONCAT: Nested expressions with group variables in CONCAT are now translated properly
function header: The parameter query_algebra is not optional anymore

# Changes
algebra.py: copied the code from algebra in PR #1361 and made another correction in the Builtin_SUBSTR section so that nested arguments are resolved correctly.
test_functions__functions_on_srings.txt: one line was added in the select clause to test the substr function with the position and length parameter. 
test_graph_patterns__group_and_substr.txt: Added a group variable (from the group by clause) in the substr function of the select clause to test whether such queries get properly translated.
test_graph_patterns__group_and_nested_concat.txt: added a nested concat expression with a group variable. This test fails with a TypeError.



  -
  -
  -
