### PR TITLE
add test of ConjunctiveGraph operators

### DIFF
--- a/test/consistent_test_data/sportquads.trig
+++ b/test/consistent_test_data/sportquads.trig
@@ -1,0 +1,21 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.org/graph/> .
+@prefix ont: <http://example.com/ontology/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:students {
+    <http://example.com/resource/student_10> a ont:Student ;
+        foaf:name "Venus Williams" .
+
+    <http://example.com/resource/student_20> a ont:Student ;
+        foaf:name "Demi Moore" .
+}
+
+ex:sports {
+    <http://example.com/resource/sport_100> a ont:Sport ;
+        rdfs:label "Tennis" .
+}
+
+ex:practise {
+    <http://example.com/resource/student_10> ont:practises <http://example.com/resource/sport_100> .
+}

--- a/test/test_conjunctivegraph_operator_combinations.py
+++ b/test/test_conjunctivegraph_operator_combinations.py
@@ -6,16 +6,16 @@ from rdflib import (
 )
 
 
-michel = URIRef("urn:x-rdflib:michel")
-tarek = URIRef("urn:x-rdflib:tarek")
-bob = URIRef("urn:x-rdflib:bob")
-likes = URIRef("urn:x-rdflib:likes")
-hates = URIRef("urn:x-rdflib:hates")
-pizza = URIRef("urn:x-rdflib:pizza")
-cheese = URIRef("urn:x-rdflib:cheese")
+michel = URIRef("urn:example:michel")
+tarek = URIRef("urn:example:tarek")
+bob = URIRef("urn:example:bob")
+likes = URIRef("urn:example:likes")
+hates = URIRef("urn:example:hates")
+pizza = URIRef("urn:example:pizza")
+cheese = URIRef("urn:example:cheese")
 
-c1 = URIRef("urn:x-rdflib:context-1")
-c2 = URIRef("urn:x-rdflib:context-2")
+c1 = URIRef("urn:example:context-1")
+c2 = URIRef("urn:example:context-2")
 
 sportquadstrig = open(
     os.path.join(os.path.dirname(__file__), "consistent_test_data", "sportquads.trig")

--- a/test/test_conjunctivegraph_operator_combinations.py
+++ b/test/test_conjunctivegraph_operator_combinations.py
@@ -1,0 +1,123 @@
+import os
+from rdflib import (
+    Graph,
+    ConjunctiveGraph,
+    URIRef,
+)
+
+
+michel = URIRef("urn:x-rdflib:michel")
+tarek = URIRef("urn:x-rdflib:tarek")
+bob = URIRef("urn:x-rdflib:bob")
+likes = URIRef("urn:x-rdflib:likes")
+hates = URIRef("urn:x-rdflib:hates")
+pizza = URIRef("urn:x-rdflib:pizza")
+cheese = URIRef("urn:x-rdflib:cheese")
+
+c1 = URIRef("urn:x-rdflib:context-1")
+c2 = URIRef("urn:x-rdflib:context-2")
+
+sportquadstrig = open(
+    os.path.join(os.path.dirname(__file__), "consistent_test_data", "sportquads.trig")
+).read()
+
+
+def test_operators_with_conjunctivegraph_and_graph():
+
+    cg = ConjunctiveGraph()
+    cg.add((tarek, likes, pizza))
+    cg.add((tarek, likes, michel))
+
+    g = Graph()
+    g.add([tarek, likes, pizza])
+    g.add([tarek, likes, cheese])
+
+    assert len(cg + g) == 3  # adds cheese as liking
+
+    assert len(cg - g) == 1  # removes pizza
+
+    assert len(cg * g) == 1  # only pizza
+
+    assert len(cg ^ g) == 2  # removes pizza, adds cheese
+
+
+def test_reversed_operators_with_conjunctivegraph_and_graph():
+
+    cg = ConjunctiveGraph()
+    cg.add((tarek, likes, pizza))
+    cg.add((tarek, likes, michel))
+
+    g = Graph()
+    g.add([tarek, likes, pizza])
+    g.add([tarek, likes, cheese])
+
+    assert len(g + cg) == 3  # adds cheese as liking
+
+    assert len(g - cg) == 1  # removes pizza
+
+    assert len(g * cg) == 1  # only pizza
+
+    assert len(g ^ cg) == 2  # removes pizza, adds cheese
+
+
+def test_reversed_operators_with_conjunctivegraph_with_contexts_and_graph():
+
+    cg = ConjunctiveGraph()
+    cg.add((tarek, likes, pizza))
+    cg.add((tarek, likes, michel))
+    cg.parse(data=sportquadstrig, format="trig")
+
+    g = Graph()
+    g.add([tarek, likes, pizza])
+    g.add([tarek, likes, cheese])
+
+    assert len(g + cg) == 10  # adds cheese as liking plus sevenquads
+
+    assert len(list((g + cg).triples((None, None, None)))) == 10
+
+    assert len(g - cg) == 1  # removes pizza
+
+    assert len(g * cg) == 1  # only pizza
+
+    assert len(g ^ cg) == 9  # removes pizza, adds cheese and sevenquads
+
+
+def test_operators_with_two_conjunctivegraphs():
+
+    cg1 = ConjunctiveGraph()
+    cg1.add([tarek, likes, pizza])
+    cg1.add([tarek, likes, michel])
+
+    cg2 = ConjunctiveGraph()
+    cg2.add([tarek, likes, pizza])
+    cg2.add([tarek, likes, cheese])
+
+    assert len(cg1 + cg2) == 3  # adds cheese as liking
+
+    assert len(cg1 - cg2) == 1  # removes pizza from cg1
+
+    assert len(cg1 * cg2) == 1  # only pizza
+
+    assert len(cg1 + cg2) == 3  # adds cheese as liking
+
+    assert len(cg1 ^ cg2) == 2  # removes pizza, adds cheese
+
+
+def test_operators_with_two_conjunctivegraphs_one_with_contexts():
+
+    cg1 = ConjunctiveGraph()
+    cg1.add([tarek, likes, pizza])
+    cg1.add([tarek, likes, michel])
+
+    cg2 = ConjunctiveGraph()
+    cg2.add([tarek, likes, pizza])
+    cg2.add([tarek, likes, cheese])
+    cg2.parse(data=sportquadstrig, format="trig")
+
+    assert len(cg1 + cg2) == 10  # adds cheese as liking and all seven quads
+
+    assert len(cg1 - cg2) == 1  # removes pizza
+
+    assert len(cg1 * cg2) == 1  # only pizza
+
+    assert len(cg1 ^ cg2) == 9  # removes pizza


### PR DESCRIPTION
Although this is a byproduct of the identifier-as-context PR, I'm splitting this off as a separate PR in order to clarify the situation w.r.t issue #225 and establish a pattern for a similar approach to Dataset operators.

## Proposed Changes

  - Add test of ConjunctiveGraph operator combinations

gromgull's ruminations in #225 remain pertinent to ConjunctiveGraph in terms of a set-theoretic perspective as well as Pythonic perspective.

> “Currently all operations are done on the default graph, i.e. if you add another graph, even if it's a conjunctive graph, all triples are added to the default graph. ... It may make sense to check if the other thing added is ALSO a conjunctive graph and merge the contexts:” 

I suspect that we have to read “added” and “merged” in an “amenable-to-operator” sense as  it doesn't seem to make sense for it to mean “copied”  and really it _can't_ because a dbpedia SPARQLStore can be a context. I think it also sheds a little light on the conceptual difference between ConjunctiveGraph and Dataset (in which adding doesn't imply adding to the default graph, except, of course, if your SPARQL endpoint has a different opinion).

Interestingly, the next set of observations (reformatted for re-presentaion) also seem to be based on an assumption that the contexts are all local :

> "all methods work against this default graph" - sounds good, but isn't quite true.
> 
> `len` will give you the length of the conjunction of all graphs; `contains` and `triples` will check for triples in all graphs; `remove` will remove from all graphs; `addN/quads` work on quads directly.
> 
> In fact, the only method to make use of the `default_context` was `add` (and `iadd` gets delegated to `add`). So `add` works on a single graph only, `remove` does not.
> So: `conjgraph += g1` and `conjgraph -= g1` may not be what you want (since `isub` will be delegated to `remove` which removes from ALL graphs).
> 
> I am not really sure what makes the most sense here. Adding `iadd/isub` that works for quads seems sensible, but breaks backwards compatibility in a fairly subtle way. I would postpone until rdflib 4.
> 
> I also do not like that `len` gives you the number of TRIPLES not of quads, but that is another issue.
