### PR TITLE
Don't update `SUFFIX_FORMAT_MAP` in `plugins/parsers/jsonld.py`

### DIFF
--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -69,17 +69,6 @@ from ..shared.jsonld.keys import (
 
 __all__ = ["JsonLDParser", "to_rdf"]
 
-
-# Add jsonld suffix so RDFLib can guess format from file name
-try:
-    from rdflib.util import SUFFIX_FORMAT_MAP
-
-    if "jsonld" not in SUFFIX_FORMAT_MAP:
-        SUFFIX_FORMAT_MAP["jsonld"] = "application/ld+json"
-except ImportError:
-    pass
-
-
 TYPE_TERM = Term(str(RDF.type), TYPE, VOCAB)  # type: ignore[call-arg]
 
 ALLOW_LISTS_OF_LISTS = True  # NOTE: Not allowed in JSON-LD 1.0


### PR DESCRIPTION
`jsonld` will already be in `SUFFIX_FORMAT_MAP`, so the code being
removed here should have no effect.

There are already tests for this and the tests would fail of the removed
code did anything, see:

https://github.com/RDFLib/rdflib/blob/b2fdaf5a1f45c09694dbd8925ab6b6dee84436b4/test/test_parse_file_guess_format.py#L23-L34