### PR TITLE
Allow hext to participate in RDF format roundtripping

### DIFF
--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -28,7 +28,7 @@ class HextuplesParser(Parser):
         # allowed to be "" but not None
         # all other "" values are treated as None
         ret1 = json.loads(line)
-        ret2 = [x if x != "" else None for x in json.loads(line)]
+        ret2 = [x if x != "" else None for x in ret1]
         if ret1[2] == "":
             ret2[2] = ""
         return ret2

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -5,7 +5,7 @@ handle contexts, i.e. multiple graphs.
 """
 import json
 
-from typing import List, Union, cast
+from typing import List, Union
 from rdflib.parser import Parser
 from rdflib import ConjunctiveGraph, URIRef, Literal, BNode
 import warnings

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -47,7 +47,7 @@ class HextuplesParser(Parser):
         if tup[0].startswith("_"):
             s = BNode(value=tup[0].replace("_:", ""))
         else:
-            s = cast(URIRef, URIRef(tup[0]))
+            s = URIRef(tup[0])
 
         # 2 - predicate
         p = URIRef(tup[1])

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -60,9 +60,7 @@ class HextuplesParser(Parser):
             o = BNode(value=tup[2].replace("_:", ""))
         else:  # literal
             if tup[4] is None:
-                o = cast(
-                    Literal,
-                    Literal(tup[2], datatype=URIRef(tup[3])))
+                o = Literal(tup[2], datatype=URIRef(tup[3]))
             else:
                 o = cast(
                     Literal,

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -62,9 +62,7 @@ class HextuplesParser(Parser):
             if tup[4] is None:
                 o = Literal(tup[2], datatype=URIRef(tup[3]))
             else:
-                o = cast(
-                    Literal,
-                    Literal(tup[2], lang=tup[4]))
+                o = Literal(tup[2], lang=tup[4])
 
         # 6 - context
         if tup[5] is not None:

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -55,7 +55,7 @@ class HextuplesParser(Parser):
         # 3 - value
         o: Union[URIRef, BNode, Literal]
         if tup[3] == "globalId":
-            o = cast(URIRef, URIRef(tup[2]))
+            o = URIRef(tup[2])
         elif tup[3] == "localId":
             o = BNode(value=tup[2].replace("_:", ""))
         else:  # literal

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -2,7 +2,7 @@
 HextuplesSerializer RDF graph serializer for RDFLib.
 See <https://github.com/ontola/hextuples> for details about the format.
 """
-from typing import IO, Optional, Union
+from typing import IO, Optional, Type, Union
 import json
 from rdflib.graph import Graph, ConjunctiveGraph
 from rdflib.term import Literal, URIRef, Node, BNode

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -3,6 +3,7 @@ HextuplesSerializer RDF graph serializer for RDFLib.
 See <https://github.com/ontola/hextuples> for details about the format.
 """
 from typing import IO, Optional, Union
+import json
 from rdflib.graph import Graph, ConjunctiveGraph
 from rdflib.term import Literal, URIRef, Node, BNode
 from rdflib.serializer import Serializer
@@ -20,6 +21,7 @@ class HextuplesSerializer(Serializer):
     def __init__(self, store: Union[Graph, ConjunctiveGraph]):
         self.default_context: Optional[Node]
         if isinstance(store, ConjunctiveGraph):
+            self.graph_type = ConjunctiveGraph
             self.contexts = list(store.contexts())
             if store.default_context:
                 self.default_context = store.default_context
@@ -27,6 +29,7 @@ class HextuplesSerializer(Serializer):
             else:
                 self.default_context = None
         else:
+            self.graph_type = Graph
             self.contexts = [store]
             self.default_context = None
 
@@ -101,14 +104,14 @@ class HextuplesSerializer(Serializer):
             else:
                 language = ""
 
-            return '["%s", "%s", "%s", "%s", "%s", "%s"]\n' % (
+            return json.dumps([
                 self._iri_or_bn(triple[0]),
                 triple[1],
                 value,
                 datatype,
                 language,
-                self._context(context),
-            )
+                self._context(context)
+            ]) + "\n"
         else:  # do not return anything for non-IRIs or BNs, e.g. QuotedGraph, Subjects
             return None
 
@@ -121,7 +124,7 @@ class HextuplesSerializer(Serializer):
             return None
 
     def _context(self, context):
-        if self.default_context is None:
+        if self.graph_type == Graph:
             return ""
         if context.identifier == "urn:x-rdflib:default":
             return ""

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -20,6 +20,7 @@ class HextuplesSerializer(Serializer):
 
     def __init__(self, store: Union[Graph, ConjunctiveGraph]):
         self.default_context: Optional[Node]
+        self.graph_type: Type[Graph]
         if isinstance(store, ConjunctiveGraph):
             self.graph_type = ConjunctiveGraph
             self.contexts = list(store.contexts())

--- a/test/test_parser_hext.py
+++ b/test/test_parser_hext.py
@@ -22,13 +22,30 @@ def test_small_string():
     assert len(d) == 10
 
 
+def test_small_string_cg():
+    s = """
+        ["http://example.com/s01", "http://example.com/a", "http://example.com/Type1", "globalId", "", ""]
+        ["http://example.com/s01", "http://example.com/label", "This is a Label", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", ""]
+        ["http://example.com/s01", "http://example.com/comment", "This is a comment", "http://www.w3.org/2001/XMLSchema#string", "", ""]
+        ["http://example.com/s01", "http://example.com/creationDate", "2021-12-01", "http://www.w3.org/2001/XMLSchema#date", "", ""]
+        ["http://example.com/s01", "http://example.com/creationTime", "2021-12-01T12:13:00", "http://www.w3.org/2001/XMLSchema#dateTime", "", ""]
+        ["http://example.com/s01", "http://example.com/age", "42", "http://www.w3.org/2001/XMLSchema#integer", "", ""]
+        ["http://example.com/s01", "http://example.com/trueFalse", "false", ",http://www.w3.org/2001/XMLSchema#boolean", "", ""]
+        ["http://example.com/s01", "http://example.com/op1", "http://example.com/o1", "globalId", "", ""]
+        ["http://example.com/s01", "http://example.com/op1", "http://example.com/o2", "globalId", "", ""]
+        ["http://example.com/s01", "http://example.com/op2", "http://example.com/o3", "globalId", "", ""]
+        """
+    d = ConjunctiveGraph().parse(data=s, format="hext")
+    assert len(d) == 10
+
+
 def test_small_file_singlegraph():
     d = Dataset().parse(Path(__file__).parent / "test_parser_hext_singlegraph.ndjson", format="hext")
     assert len(d) == 10
 
 
 def test_small_file_multigraph():
-    d = ConjunctiveGraph()
+    d = Dataset()
     assert len(d) == 0
     d.parse(
         Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
@@ -38,6 +55,26 @@ def test_small_file_multigraph():
 
     """There are 22 lines in the file test_parser_hext_multigraph.ndjson. When loaded
     into a Dataset, we get only 18 quads since the the dataset can contextualise
+    the triples and thus deduplicate 4."""
+    total_triples = 0
+    # count all the triples in the Dataset
+    for context in d.contexts():
+        for triple in context.triples((None, None, None)):
+            total_triples += 1
+    assert total_triples == 18
+
+
+def test_small_file_multigraph_cg():
+    d = ConjunctiveGraph()
+    assert len(d) == 0
+    d.parse(
+        Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
+        format="hext",
+        publicID=d.default_context.identifier
+    )
+
+    """There are 22 lines in the file test_parser_hext_multigraph.ndjson. When loaded
+    into a CG, we get only 18 quads since the the CG can contextualise
     the triples and thus deduplicate 4."""
     total_triples = 0
     # count all the triples in the Dataset

--- a/test/test_serializer_hext.py
+++ b/test/test_serializer_hext.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.absolute()))
-from rdflib import Dataset, Graph
+from rdflib import Dataset, Graph, ConjunctiveGraph
 import json
 
 
@@ -31,7 +31,7 @@ def test_hext_graph():
 
     g.parse(data=turtle_data, format="turtle")
     out = g.serialize(format="hext")
-    # note: cant' test for BNs in result as they will be different ever time
+    # note: can't test for BNs in result as they will be different every time
     testing_lines = [
         [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]'],
         [False, '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", ""]'],
@@ -45,6 +45,76 @@ def test_hext_graph():
         [False, '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", ""]'],
         [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", ""]'],
         [False, '["http://example.com/s1", "http://example.com/p8", "false", "http://www.w3.org/2001/XMLSchema#boolean", "", ""]'],
+    ]
+    for line in out.splitlines():
+        for test in testing_lines:
+            if test[1] in line:
+                test[0] = True
+
+    assert all([x[0] for x in testing_lines])
+
+
+def test_hext_cg():
+    """Tests ConjunctiveGraph data"""
+    d = ConjunctiveGraph()
+    trig_data = """
+            PREFIX ex: <http://example.com/>
+            PREFIX owl: <http://www.w3.org/2002/07/owl#>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+            ex:g1 {
+                ex:s1
+                    ex:p1 ex:o1 , ex:o2 ;
+                    ex:p2 [
+                        a owl:Thing ;
+                        rdf:value "thingy" ;
+                    ] ;
+                    ex:p3 "Object 3" , "Object 4 - English"@en ;
+                    ex:p4 "2021-12-03"^^xsd:date ;
+                    ex:p5 42 ;
+                    ex:p6 "42" ;
+                .
+            }
+
+            ex:g2 {
+                ex:s1
+                    ex:p1 ex:o1 , ex:o2 ;
+                .
+                ex:s11 ex:p11 ex:o11 , ex:o12 .
+            }
+
+            # default graph triples
+            ex:s1 ex:p1 ex:o1 , ex:o2 .
+            ex:s21 ex:p21 ex:o21 , ex:o22 .
+
+            # other default graph triples
+            {
+                ex:s1 ex:p1 ex:o1 , ex:o2 .
+            }
+           """
+    d.parse(data=trig_data, format="trig", publicID=d.default_context.identifier)
+    out = d.serialize(format="hext")
+    # note: cant' test for BNs in result as they will be different ever time
+    testing_lines = [
+        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o21", "globalId", "", ""]'],
+        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o22", "globalId", "", ""]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]'],
+        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o12", "globalId", "", "http://example.com/g2"]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g2"]'],
+        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o11", "globalId", "", "http://example.com/g2"]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g2"]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p2"'],
+        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
+        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", "http://example.com/g1"]'],
+        [False, '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
     ]
     for line in out.splitlines():
         for test in testing_lines:


### PR DESCRIPTION
Until now, HexTuples parsing & serializing could not participate in RDF format roundtripping due to numerous failures. well, I've solved them by:

* doing better JSON serializing
* allowing the test_roundtrip.py functions to conflate "" with ""^^xsd:string, for hext only
* skipping only 2 tests
* allowing HexT parsing to treat a value "" as value, not None