### PR TITLE
Make unregister_custom_function idempotent

### DIFF
--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -612,11 +612,17 @@ def custom_function(uri, override=False, raw=False):
     return decorator
 
 
-def unregister_custom_function(uri, func):
-    if _CUSTOM_FUNCTIONS.get(uri, (None, None))[0] != func:
-        warnings.warn("This function is not registered as %s" % uri.n3())
-    else:
+def unregister_custom_function(uri, func=None):
+    """
+    The 'func' argument is included for compatibility with existing code.
+    A previous implementation checked that the function associated with
+    the given uri was actually 'func', but this is not necessary as the
+    uri should uniquely identify the function.
+    """
+    if _CUSTOM_FUNCTIONS.get(uri):
         del _CUSTOM_FUNCTIONS[uri]
+    else:
+        warnings.warn("This function is not registered as %s" % uri.n3())
 
 
 def Function(e, ctx):

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -13,6 +13,7 @@ import random
 import uuid
 import hashlib
 import datetime as py_datetime  # naming conflict with function within this module
+import warnings
 
 from functools import reduce
 
@@ -613,8 +614,9 @@ def custom_function(uri, override=False, raw=False):
 
 def unregister_custom_function(uri, func):
     if _CUSTOM_FUNCTIONS.get(uri, (None, None))[0] != func:
-        raise ValueError("This function is not registered as %s" % uri.n3())
-    del _CUSTOM_FUNCTIONS[uri]
+        warnings.warn("This function is not registered as %s" % uri.n3())
+    else:
+        del _CUSTOM_FUNCTIONS[uri]
 
 
 def Function(e, ctx):

--- a/test/test_issue274.py
+++ b/test/test_issue274.py
@@ -189,7 +189,7 @@ class TestCustom(TestCase):
 
     def test_wrong_unregister_warns(self):
         with pytest.warns(UserWarning):
-            unregister_custom_function(EX.f, lambda x, y: None)
+            unregister_custom_function(EX.notexist)
 
     def test_f(self):
         res = query("""SELECT (ex:f(42, "hello") as ?x) {}""")

--- a/test/test_issue274.py
+++ b/test/test_issue274.py
@@ -187,7 +187,7 @@ class TestCustom(TestCase):
     def test_register_override(self):
         register_custom_function(EX.f, self.f, override=True)
 
-    def test_wrong_unregister_fails(self):
+    def test_wrong_unregister_warns(self):
         with pytest.warns(UserWarning):
             unregister_custom_function(EX.f, lambda x, y: None)
 

--- a/test/test_issue274.py
+++ b/test/test_issue274.py
@@ -1,5 +1,6 @@
 from .testutils import eq_
 from unittest import TestCase
+import pytest
 
 from rdflib import BNode, Graph, Literal, Namespace, RDFS, XSD
 from rdflib.plugins.sparql.operators import (
@@ -187,7 +188,7 @@ class TestCustom(TestCase):
         register_custom_function(EX.f, self.f, override=True)
 
     def test_wrong_unregister_fails(self):
-        with self.assertRaises(ValueError):
+        with pytest.warns(UserWarning):
             unregister_custom_function(EX.f, lambda x, y: None)
 
     def test_f(self):


### PR DESCRIPTION
Fixes #1492 

## Proposed Changes

  - Replace the raised exception with a new warning; `unregister_custom_function` can now be called multiple times on the same function (idempotent)
  - Adjust the `issue 274` test by checking that the warning is raised, rather than the exception