### PR TITLE
Move pytest config from `tox.ini` to `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,9 @@ filterwarnings =
     ignore:Code. pytest_mock_example_attribute_that_shouldnt_exist is not defined in namespace .*:UserWarning
     # The below warning is a consequence of how pytest detects fixtures and how DefinedNamespace behaves when an undefined attribute is being accessed.
     ignore:Code. _pytestfixturefunction is not defined in namespace .*:UserWarning
+
+# log_cli = true
+# log_cli_level = DEBUG
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S
+

--- a/tox.ini
+++ b/tox.ini
@@ -45,9 +45,3 @@ setenv =
     PYTHONHASHSEED = 0
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
-
-[pytest]
-# log_cli = true
-# log_cli_level = DEBUG
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S


### PR DESCRIPTION
`tox.ini` is pretty noisy and I'm adding more stuff there for
pre-commit so I think to make things more manageable it is better ot
keep unrleated config in `setup.cfg`.