### PR TITLE
[DRAFT] Add pre-commit config

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -85,33 +85,3 @@ jobs:
             test_harness+="./with-fuseki.sh"
           fi
           "${test_harness[@]}" python -m tox
-  # docs:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{env.DEFAULT_PYTHON}}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{env.DEFAULT_PYTHON}}
-  #     - name: Get pip cache dir
-  #       id: pip-cache
-  #       shell: bash
-  #       run: |
-  #         python -m ensurepip --upgrade
-  #         echo "::set-output name=dir::$(pip cache dir)"
-  #     - name: Cache pip
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ steps.pip-cache.outputs.dir }}
-  #         key: docs-pip-v1-${{
-  #           hashFiles('**/setup.py', '**/requirements*.txt') }}
-  #         restore-keys: |
-  #           docs-pip-v1-
-  #     - name: Install dependencies
-  #       shell: bash
-  #       run: |
-  #         python -m pip install tox
-  #     - name: Build docs
-  #       shell: bash
-  #       run: |
-  #         python -m tox -e docs

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -62,9 +62,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install --default-timeout 60 -r requirements.txt
-          pip install --default-timeout 60 -r requirements.dev.txt
-          python setup.py install
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade virtualenv tox tox-gh-actions
       - name: Install extra dev dependencies
         if: ${{ matrix.extensive-tests }}
         shell: bash
@@ -77,47 +76,42 @@ jobs:
               brew install berkeley-db@4
               export BERKELEYDB_DIR=$(brew --prefix berkeley-db@4)
           fi
-          pip install --default-timeout 60 -r requirements.dev-extra.txt
-      - name: Validate
+      - name: Install dependencies
         shell: bash
         run: |
-          test_harness=()
           if "${{ matrix.extensive-tests || false }}" && [ "${{ matrix.os }}" != "windows-latest" ]
           then
             1>&2 echo "Running with fuseki"
             test_harness+="./with-fuseki.sh"
           fi
-          black --config black.toml --check ./rdflib || true
-          flake8 --exit-zero rdflib
-          mypy --show-error-context --show-error-codes
-          "${test_harness[@]}" pytest -ra --cov
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{env.DEFAULT_PYTHON}}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{env.DEFAULT_PYTHON}}
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: |
-          python -m ensurepip --upgrade
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: docs-pip-v1-${{
-            hashFiles('**/setup.py', '**/requirements*.txt') }}
-          restore-keys: |
-            docs-pip-v1-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          python -m pip install tox
-      - name: Build docs
-        shell: bash
-        run: |
-          python -m tox -e docs
+          "${test_harness[@]}" python -m tox
+  # docs:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{env.DEFAULT_PYTHON}}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{env.DEFAULT_PYTHON}}
+  #     - name: Get pip cache dir
+  #       id: pip-cache
+  #       shell: bash
+  #       run: |
+  #         python -m ensurepip --upgrade
+  #         echo "::set-output name=dir::$(pip cache dir)"
+  #     - name: Cache pip
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ steps.pip-cache.outputs.dir }}
+  #         key: docs-pip-v1-${{
+  #           hashFiles('**/setup.py', '**/requirements*.txt') }}
+  #         restore-keys: |
+  #           docs-pip-v1-
+  #     - name: Install dependencies
+  #       shell: bash
+  #       run: |
+  #         python -m pip install tox
+  #     - name: Build docs
+  #       shell: bash
+  #       run: |
+  #         python -m tox -e docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+---
+ci:
+  # https://pre-commit.ci/#configuration
+  autoupdate_schedule: weekly
+
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v1.1.0
+    hooks:
+      - id: pycln
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: debug-statements
+      - id: check-toml
+      - id: check-yaml
+      - id: check-case-conflict
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 ci:
   # https://pre-commit.ci/#configuration
   autoupdate_schedule: weekly
+  autofix_prs: false
 
 repos:
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: debug-statements
       - id: check-toml
       - id: check-yaml
-      - id: check-case-conflict
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,3 @@ repos:
     hooks:
       - id: check-toml
       - id: check-yaml
-

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -108,6 +108,38 @@ Check types with `mypy <http://mypy-lang.org/>`_:
 
     python -m mypy --show-error-context --show-error-codes rdflib
 
+pre-commit and pre-commit ci
+---------------------
+
+We have `pre-commit <https://pre-commit.com/>`_ configured with `pycln
+<https://github.com/hadialqattan/pycln>`_ which cleans out unused imports,
+`isort <https://github.com/PyCQA/isort>`_ for sorting imports, and `black
+<https://github.com/psf/black>`_ for formatting out code.
+
+The basics of using pre-commit is:
+
+.. code-block:: bash
+
+    # Install pre-commit.
+    pip install --user --upgrade pre-commit
+
+    # Install pre-commit hooks, this will run pre-commit
+    # every time you make a git commit.
+    pre-commit install
+
+    # Run pre-commit on changed files
+    pre-commit run
+
+We would prefer that contributors install and use pre-commit so that
+their contributions have cleaned and sorted imports, and formatted code,
+however this is not a hard requirement or blocker for pull requests.
+
+We have enabled `https://pre-commit.ci/ <https://pre-commit.ci/>`_ and this can
+be used to automatically fix pull requests by commenting ``pre-commit.ci
+autofix`` on a pull request.
+
+There is also a pre-commit
+
 Using tox
 ---------------------
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -138,7 +138,11 @@ We have enabled `https://pre-commit.ci/ <https://pre-commit.ci/>`_ and this can
 be used to automatically fix pull requests by commenting ``pre-commit.ci
 autofix`` on a pull request.
 
-There is also a pre-commit
+There is also a pre-commit environment for tox:
+
+.. code-block:: bash
+
+    tox -e precommit
 
 Using tox
 ---------------------
@@ -148,23 +152,23 @@ makes it easier to run validation on all supported python versions.
 
 .. code-block:: bash
 
-    # install tox
+    # Install tox.
     pip install tox
 
-    # list tox environments that run by default
+    # List the tox environments that run by default.
     tox -e
 
-    # run default environments
+    # Run the default environments.
     tox
 
-    # list all tox environments, including ones that don't run by default
+    # List all tox environments, including ones that don't run by default.
     tox -a
 
-    # run a specific environment
+    # Run a specific environment.
     tox -e py37 # default environment with py37
     tox -e py39-extra # extra tests with py39
 
-    # override the test command
+    # Override the test command.
     # the below command will run `pytest test/test_translate_algebra.py`
     # instead of the default pytest command.
     tox -e py37,py39 -- pytest test/test_translate_algebra.py

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -109,7 +109,7 @@ Check types with `mypy <http://mypy-lang.org/>`_:
     python -m mypy --show-error-context --show-error-codes rdflib
 
 pre-commit and pre-commit ci
----------------------
+----------------------------
 
 We have `pre-commit <https://pre-commit.com/>`_ configured with `pycln
 <https://github.com/hadialqattan/pycln>`_ which cleans out unused imports,
@@ -130,9 +130,7 @@ The basics of using pre-commit is:
     # Run pre-commit on changed files
     pre-commit run
 
-We would prefer that contributors install and use pre-commit so that
-their contributions have cleaned and sorted imports, and formatted code,
-however this is not a hard requirement or blocker for pull requests.
+There is no hard requirement for pull requests to be processed with pre-commit (or the underlying processors), however doing this makes for a less noisy codebase with cleaner history.
 
 We have enabled `https://pre-commit.ci/ <https://pre-commit.ci/>`_ and this can
 be used to automatically fix pull requests by commenting ``pre-commit.ci

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -154,15 +154,20 @@ makes it easier to run validation on all supported python versions.
     # list tox environments that run by default
     tox -e
 
-    # list all tox environments
-    tox -a
-
-    # run default environment for all python versions
+    # run default environments
     tox
+
+    # list all tox environments, including ones that don't run by default
+    tox -a
 
     # run a specific environment
     tox -e py37 # default environment with py37
-    tox -e py39-mypy # mypy environment with py39
+    tox -e py39-extra # extra tests with py39
+
+    # override the test command
+    # the below command will run `pytest test/test_translate_algebra.py`
+    # instead of the default pytest command.
+    tox -e py37,py39 -- pytest test/test_translate_algebra.py
 
 Writing documentation
 ---------------------

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,7 +8,7 @@ mypy
 pytest
 pytest-cov
 pytest-subtests
-sphinx
+sphinx < 5
 sphinxcontrib-apidoc
 types-setuptools
 pre-commit

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,3 +11,4 @@ pytest-subtests
 sphinx
 sphinxcontrib-apidoc
 types-setuptools
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+import codecs
 import os
 import re
-import codecs
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 kwargs = {}
 kwargs["install_requires"] = [
@@ -13,9 +14,7 @@ kwargs["install_requires"] = [
     "importlib-metadata; python_version < '3.8.0'",
 ]
 kwargs["tests_require"] = [
-    "berkeleydb",
     "html5lib",
-    "networkx",
     "pytest",
     "pytest-cov",
     "pytest-subtests",
@@ -23,6 +22,17 @@ kwargs["tests_require"] = [
 kwargs["extras_require"] = {
     "html": ["html5lib"],
     "tests": kwargs["tests_require"],
+    "berkeleydb": ["berkeleydb"],
+    "networkx": ["networkx"],
+    "dev": [
+        "isort",
+        "black",
+        "mypy",
+        "flake8",
+        "flake8-black",
+        "types-setuptools",
+        "pre-commit",
+    ],
     "docs": ["sphinx < 5", "sphinxcontrib-apidoc"],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,56 @@
 [tox]
 envlist =
-    py37,py38,py39,py310
+    pre-commit,py3{7,8,9,10},docs,coverage-report
+
+[gh-actions]
+python =
+    3.7: py37-extra, docs
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 setenv =
-    BERKELEYDB_DIR = /usr
+    py3{7,8,9,10}-extra: BERKELEYDB_DIR = /usr
+    COVERAGE_FILE={envdir}/.coverage
+    MYPY_CACHE_DIR={envdir}/.mypy_cache
+extras =
+    tests
+    dev
+    py3{7,8,9,10}-extra: berkeleydb
+    py3{7,8,9,10}-extra: networkx
 commands =
-    {envpython} -m mypy rdflib --show-error-context --show-error-codes
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    {envpython} -m pytest
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
+    {envpython} -m mypy
+    {posargs:{envpython} -m pytest --cov --cov-report=}
 
-[testenv:cover]
-basepython =
-    python3.7
+
+[testenv:coverage-report]
+basepython = python3.7
+deps = coverage
+skip_install = true
+parallel_show_output = true
+depends = py3{7,8,9,10}{-extra,}
 commands =
-    {envpython} -m pytest \
-		--cov-report term \
-		--cov-report html \
-		--cov
-
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
-
-[testenv:py3{7,8,9,10}-mypy]
-commands =
-    {envpython} -m mypy --show-error-context --show-error-codes
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
+    {envpython} -m coverage combine
+    {envpython} -m coverage report
 
 [testenv:docs]
-basepython =
-    python3.7
-deps =
-extras =
-    docs
+basepython = python3.7
+extras = docs
 passenv = TERM
 setenv =
     PYTHONHASHSEED = 0
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:pre-commit{,-all}]
+basepython = python3.7
+skip_install = true
+deps = pre-commit
+passenv = HOMEPATH  # needed on Windows
+commands =
+    pre-commit: pre-commit run
+    pre-commit-all: pre-commit run --all-files
 
 [pytest]
 # log_cli = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    pre-commit,py3{7,8,9,10},docs,coverage-report
+    py3{7,8,9,10},docs,covreport
 
 [gh-actions]
 python =
@@ -11,25 +11,27 @@ python =
 
 [testenv]
 setenv =
-    py3{7,8,9,10}-extra: BERKELEYDB_DIR = /usr
-    COVERAGE_FILE={envdir}/.coverage
+    extra: BERKELEYDB_DIR = /usr
+    COVERAGE_FILE={toxinidir}/.coverage.{envname}
     MYPY_CACHE_DIR={envdir}/.mypy_cache
 extras =
     tests
     dev
-    py3{7,8,9,10}-extra: berkeleydb
-    py3{7,8,9,10}-extra: networkx
+    extra: berkeleydb
+    extra: networkx
 commands =
     {envpython} -m mypy
     {posargs:{envpython} -m pytest --cov --cov-report=}
 
 
-[testenv:coverage-report]
+[testenv:covreport]
 basepython = python3.7
 deps = coverage
 skip_install = true
 parallel_show_output = true
 depends = py3{7,8,9,10}{-extra,}
+setenv =
+    COVERAGE_FILE=
 commands =
     {envpython} -m coverage combine
     {envpython} -m coverage report
@@ -43,14 +45,14 @@ setenv =
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
-[testenv:pre-commit{,-all}]
+[testenv:precommit{,all}]
 basepython = python3.7
 skip_install = true
 deps = pre-commit
 passenv = HOMEPATH  # needed on Windows
 commands =
-    pre-commit: pre-commit run
-    pre-commit-all: pre-commit run --all-files
+    precommit: pre-commit run
+    precommitall: pre-commit run --all-files
 
 [pytest]
 # log_cli = true


### PR DESCRIPTION
This adds pre-commit config for rdflib that runs:
- [pycln](https://github.com/hadialqattan/pycln)
- [isort](https://github.com/PyCQA/isort) 
- [black](https://github.com/psf/black)

This also includes a quite big revamp of tox config, with the following highlights:

- Simplified the environments.
- Combine coverage for all executed environments
- Add option for doing extra tests (e.g. `tox -e py37-extra`)
- Add environments for pre-commit

Also
- changed github actions config to use tox-gh-actions