### PR TITLE
Fix turtle serialization of PNames that contain brackets

### DIFF
--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -268,6 +268,7 @@ class TurtleSerializer(RecursiveSerializer):
         if isinstance(p, BNode):  # hmm - when is P ever a bnode?
             self._references[p] += 1
 
+    # TODO: Rename to get_pname
     def getQName(self, uri, gen_prefix=True):
         if not isinstance(uri, URIRef):
             return None
@@ -288,6 +289,8 @@ class TurtleSerializer(RecursiveSerializer):
                 return None
 
         prefix, namespace, local = parts
+
+        local = local.replace(r"(", r"\(").replace(r")", r"\)")
 
         # QName cannot end with .
         if local.endswith("."):

--- a/test/nt/rdflibtest-pnamebrackets.nt
+++ b/test/nt/rdflibtest-pnamebrackets.nt
@@ -1,0 +1,1 @@
+<http://example.com/instance/John_Doe> <http://example.com/property/name(s)> "John Doe"@en.

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -138,6 +138,10 @@ XFAILS = {
         reason="missing escaping: PCDATA invalid Char value 12 and 8",
         raises=SAXParseException,
     ),
+    ("xml", "rdflibtest-pnamebrackets.nt"): pytest.mark.xfail(
+        reason="results in invalid xml element name: <ns1:name(s)/>",
+        raises=SAXParseException,
+    ),
 }
 
 # This is for files which can only be represented properly in one format

--- a/test/test_serializer_turtle.py
+++ b/test/test_serializer_turtle.py
@@ -112,4 +112,4 @@ def test_turtle_namespace():
     assert "RO_has_phenotype:" in output
     assert "GENO:0000385" in output
     assert "SERIAL:0167-6423" in output
-    assert "EX:name_with_(parenthesis)" in output
+    assert r"EX:name_with_\(parenthesis\)" in output


### PR DESCRIPTION
Brackets in pnames will now be escaped in output.

This fix is based on a suggestion by Niklas Lindström (@niklasl).

This is somewhat of a stopgap fix, there are some problems being
masked and various cases that could still result in questionable Turtle being
written out, however these can be addressed seperately.


Fixes #1661
