### PR TITLE
Add typing to rdflib.namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Marked the following functions as deprecated:
   rdflib anymore and the utility that it does provide is not implemented
   correctly. It will be removed in RDFLib 7.0.0
 
+### Type Hints
+
+Type hints were added to the following modules:
+
+- `rdflib.namespace`: Nearly everything in this module has type hints now.
+
 PRs merged since last release:
 ------------------------------
 


### PR DESCRIPTION
Everything is as typed as it can be in here, there is maybe some
improvement that can be made to `__new__` in some places but I think
there may be some runtime changes needed there so I don't want to change
that now, the inferred return types are close enough.

Some of the type hints are based on pytest-monkeytype output which was
slightly tuned for simplicity and with some additional typing for methods
that are not being tested.

This changeset contains type changes only and does not change runtime
behaviour.
