### PR TITLE
Add typing to rdflib.term

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1223,7 +1223,7 @@ class Graph(Node):
         parser = plugin.get(format, Parser)()
         try:
             # TODO FIXME: Parser.parse should have **kwargs argument.
-            parser.parse(source, self, **args)  # type: ignore[call-arg]
+            parser.parse(source, self, **args)
         except SyntaxError as se:
             if could_not_guess_format:
                 raise ParserError(
@@ -1624,7 +1624,7 @@ class ConjunctiveGraph(Graph):
             return True
         return False
 
-    def add(self, triple_or_quad: Union[Tuple[Node, Node, Node, Optional[Any]], Tuple[Node, Node, Node]]) -> "ConjunctiveGraph":  # type: ignore[override]
+    def add(self, triple_or_quad: Union[Tuple[Node, Node, Node, Optional[Any]], Tuple[Node, Node, Node]]) -> "ConjunctiveGraph":
         """
         Add a triple or quad to the store.
 

--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -474,7 +474,7 @@ class RDFXMLHandler(handler.ContentHandler):
                     o = URIRef(atts[att])
                 else:
                     if datatype is not None:
-                        language = None  # type: ignore[unreachable]
+                        language = None
                     o = Literal(atts[att], language, datatype)
 
                 if object is None:

--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -90,6 +90,7 @@ class TrigSerializer(TurtleSerializer):
             if self.default_context and store.identifier == self.default_context:
                 self.write(self.indent() + "\n{")
             else:
+                iri: Optional[str]
                 if isinstance(store.identifier, BNode):
                     iri = store.identifier.n3()
                 else:

--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -61,11 +61,19 @@ class XMLResult(Result):
             for result in results:  # type: ignore[union-attr]
                 r = {}
                 for binding in result:
-                    r[Variable(binding.get("name"))] = parseTerm(binding[0])
+                    # type error: error: Argument 1 to "Variable" has incompatible type "Union[str, None, Any]"; expected "str"
+                    # NOTE on type error: Element.get() can return None, and
+                    # this will invariably fail if passed into Variable
+                    # constructor as value
+                    r[Variable(binding.get("name"))] = parseTerm(binding[0])  # type: ignore[arg-type] # FIXME
                 self.bindings.append(r)
 
             self.vars = [
-                Variable(x.get("name"))
+                # type error: Argument 1 to "Variable" has incompatible type "Optional[str]"; expected "str"
+                # NOTE on type error: Element.get() can return None, and this
+                # will invariably fail if passed into Variable constructor as
+                # value
+                Variable(x.get("name"))  # type: ignore[arg-type] # FIXME
                 for x in tree.findall(
                     "./%shead/%svariable" % (RESULTS_NS_ET, RESULTS_NS_ET)
                 )

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -37,7 +37,7 @@ def _node_to_sparql(node) -> str:
     return node.n3()
 
 
-class SPARQLStore(SPARQLConnector, Store):  # type: ignore[misc]
+class SPARQLStore(SPARQLConnector, Store):
     """An RDFLib store around a SPARQL endpoint
 
     This is context-aware and should work as expected
@@ -543,7 +543,7 @@ class SPARQLUpdateStore(SPARQLStore):
         Graph("SPARQLStore"), can set the required parameters
         """
         if type(configuration) == str:
-            self.query_endpoint = configuration  # type: ignore[assignment]
+            self.query_endpoint = configuration
         elif type(configuration) == tuple:
             self.query_endpoint = configuration[0]
             self.update_endpoint = configuration[1]

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -380,7 +380,7 @@ class Store(object):
         # See https://stackoverflow.com/q/13243766 and
         # https://www.python.org/dev/peps/pep-0255/#why-a-new-keyword-for-yield-why-not-a-builtin-function-instead
         if False:
-            yield None  # type: ignore[unreachable]
+            yield None
 
     # Optional Transactional methods
 

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -64,10 +64,23 @@ from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, Callable, Optional, Union, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    Type,
+)
+
 
 if TYPE_CHECKING:
     from .paths import AlternativePath, InvPath, NegatedPath, SequencePath, Path
+    from .namespace import NamespaceManager
 
 logger = logging.getLogger(__name__)
 skolem_genid = "/.well-known/genid/"
@@ -78,7 +91,7 @@ skolems: Dict[str, "BNode"] = {}
 _invalid_uri_chars = '<>" {}|\\^`'
 
 
-def _is_valid_uri(uri):
+def _is_valid_uri(uri: str) -> bool:
     for c in _invalid_uri_chars:
         if c in uri:
             return False
@@ -88,11 +101,11 @@ def _is_valid_uri(uri):
 _lang_tag_regex = compile("^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")
 
 
-def _is_valid_langtag(tag: str):
+def _is_valid_langtag(tag: str) -> bool:
     return bool(_lang_tag_regex.match(tag))
 
 
-def _is_valid_unicode(value):
+def _is_valid_unicode(value: Union[str, bytes]) -> bool:
     """
     Verify that the provided value can be converted into a Python
     unicode object.
@@ -129,20 +142,20 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
     def __new__(cls, value: str) -> "Identifier":
         return str.__new__(cls, value)
 
-    def eq(self, other):
+    def eq(self, other: Any) -> bool:
         """A "semantic"/interpreted equality function,
         by default, same as __eq__"""
         return self.__eq__(other)
 
-    def neq(self, other):
+    def neq(self, other: Any) -> bool:
         """A "semantic"/interpreted not equal function,
         by default, same as __ne__"""
         return self.__ne__(other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """
         Equality for Nodes.
 
@@ -167,7 +180,7 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
         else:
             return False
 
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> bool:
         """
         This implements ordering for Nodes,
 
@@ -187,7 +200,7 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
 
         return NotImplemented
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         if other is None:
             return False  # Nothing is less than None
         elif type(self) == type(other):
@@ -197,19 +210,22 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
 
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self, other: Any) -> bool:
         r = self.__lt__(other)
         if r:
             return True
         return self == other
 
-    def __ge__(self, other):
+    def __ge__(self, other: Any) -> bool:
         r = self.__gt__(other)
         if r:
             return True
         return self == other
 
-    def startswith(self, prefix, start=..., end=...) -> bool:
+    # type error: Argument 1 of "startswith" is incompatible with supertype "str"; supertype defines the argument type as "Union[str, Tuple[str, ...]]"
+    # FIXME: this does not accommodate prefix of type Tuple[str, ...] which is a
+    # valid for str.startswith
+    def startswith(self, prefix: str, start=..., end=...) -> bool:  # type: ignore[override] # FIXME
         return str(self).startswith(str(prefix))
 
     # use parent's hash for efficiency reasons
@@ -226,7 +242,7 @@ class IdentifiedNode(Identifier):
     The name "Identified Node" is not explicitly defined in the RDF specification, but can be drawn from this section: https://www.w3.org/TR/rdf-concepts/#section-URI-Vocabulary
     """
 
-    def __getnewargs__(self):
+    def __getnewargs__(self) -> Tuple[str]:
         return (str(self),)
 
     def toPython(self) -> str:
@@ -245,9 +261,10 @@ class URIRef(IdentifiedNode):
     __neg__: Callable[["URIRef"], "NegatedPath"]
     __truediv__: Callable[["URIRef", Union["URIRef", "Path"]], "SequencePath"]
 
-    def __new__(cls, value: str, base: Optional[str] = None):
+    def __new__(cls, value: str, base: Optional[str] = None) -> "URIRef":
         if base is not None:
             ends_in_hash = value.endswith("#")
+            # type error: Argument "allow_fragments" to "urljoin" has incompatible type "int"; expected "bool"
             value = urljoin(base, value, allow_fragments=1)  # type: ignore[arg-type]
             if ends_in_hash:
                 if not value.endswith("#"):
@@ -262,10 +279,11 @@ class URIRef(IdentifiedNode):
         try:
             rt = str.__new__(cls, value)
         except UnicodeDecodeError:
+            # type error: No overload variant of "__new__" of "str" matches argument types "Type[URIRef]", "str", "str"
             rt = str.__new__(cls, value, "utf-8")  # type: ignore[call-overload]
         return rt
 
-    def n3(self, namespace_manager=None) -> str:
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         """
         This will do a limited check for valid URIs,
         essentially just making sure that the string includes no illegal
@@ -286,17 +304,17 @@ class URIRef(IdentifiedNode):
         else:
             return "<%s>" % self
 
-    def defrag(self):
+    def defrag(self) -> "URIRef":
         if "#" in self:
             url, frag = urldefrag(self)
             return URIRef(url)
         else:
             return self
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type["URIRef"], Tuple[str]]:
         return (URIRef, (str(self),))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.__class__ is URIRef:
             clsName = "rdflib.term.URIRef"
         else:
@@ -304,16 +322,16 @@ class URIRef(IdentifiedNode):
 
         return """%s(%s)""" % (clsName, super(URIRef, self).__repr__())
 
-    def __add__(self, other):
+    def __add__(self, other) -> "URIRef":
         return self.__class__(str(self) + other)
 
-    def __radd__(self, other):
+    def __radd__(self, other) -> "URIRef":
         return self.__class__(other + str(self))
 
-    def __mod__(self, other):
+    def __mod__(self, other) -> "URIRef":
         return self.__class__(str(self) % other)
 
-    def de_skolemize(self):
+    def de_skolemize(self) -> "BNode":
         """Create a Blank Node from a skolem URI, in accordance
         with http://www.w3.org/TR/rdf11-concepts/#section-skolemization.
         This function accepts only rdflib type skolemization, to provide
@@ -340,7 +358,7 @@ class Genid(URIRef):
     __slots__ = ()
 
     @staticmethod
-    def _is_external_skolem(uri):
+    def _is_external_skolem(uri: Any) -> bool:
         if not isinstance(uri, str):
             uri = str(uri)
         parsed_uri = urlparse(uri)
@@ -354,7 +372,7 @@ class RDFLibGenid(Genid):
     __slots__ = ()
 
     @staticmethod
-    def _is_rdflib_skolem(uri):
+    def _is_rdflib_skolem(uri: Any) -> bool:
         if not isinstance(uri, str):
             uri = str(uri)
         parsed_uri = urlparse(uri)
@@ -370,7 +388,7 @@ class RDFLibGenid(Genid):
         return True
 
 
-def _unique_id():
+def _unique_id() -> str:
     # Used to read: """Create a (hopefully) unique prefix"""
     # now retained merely to leave internal API unchanged.
     # From BNode.__new__() below ...
@@ -383,7 +401,7 @@ def _unique_id():
     return "N"  # ensure that id starts with a letter
 
 
-def _serial_number_generator():
+def _serial_number_generator() -> Callable[[], str]:
     """
     Generates UUID4-based but ncname-compliant identifiers.
     """
@@ -425,22 +443,25 @@ class BNode(IdentifiedNode):
             pass  # assert is_ncname(str(value)), "BNode identifiers
             # must be valid NCNames" _:[A-Za-z][A-Za-z0-9]*
             # http://www.w3.org/TR/2004/REC-rdf-testcases-20040210/#nodeID
+        # type error: Incompatible return value type (got "Identifier", expected "BNode")
         return Identifier.__new__(cls, value)  # type: ignore[return-value]
 
-    def n3(self, namespace_manager=None):
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         return "_:%s" % self
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type["BNode"], Tuple[str]]:
         return (BNode, (str(self),))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.__class__ is BNode:
             clsName = "rdflib.term.BNode"
         else:
             clsName = self.__class__.__name__
         return """%s('%s')""" % (clsName, str(self))
 
-    def skolemize(self, authority=None, basepath=None):
+    def skolemize(
+        self, authority: Optional[str] = None, basepath: Optional[str] = None
+    ) -> URIRef:
         """Create a URIRef "skolem" representation of the BNode, in accordance
         with http://www.w3.org/TR/rdf11-concepts/#section-skolemization
 
@@ -539,7 +560,9 @@ class Literal(Identifier):
     """
 
     _value: Any
-
+    _language: Optional[str]
+    # NOTE: _datatype should maybe be of type URIRef, and not optional.
+    _datatype: Optional[str]
     __slots__ = ("_language", "_datatype", "_value")
 
     def __new__(
@@ -548,7 +571,7 @@ class Literal(Identifier):
         lang: Optional[str] = None,
         datatype: Optional[str] = None,
         normalize: Optional[bool] = None,
-    ):
+    ) -> "Literal":
 
         if lang == "":
             lang = None  # no empty lang-tags in RDF
@@ -620,7 +643,7 @@ class Literal(Identifier):
 
         return inst
 
-    def normalize(self):
+    def normalize(self) -> "Literal":
         """
         Returns a new literal with a normalised lexical representation
         of this literal
@@ -640,7 +663,7 @@ class Literal(Identifier):
             return self
 
     @property
-    def value(self):
+    def value(self) -> Any:
         return self._value
 
     @property
@@ -648,24 +671,26 @@ class Literal(Identifier):
         return self._language
 
     @property
-    def datatype(self):
+    def datatype(self) -> Optional[str]:
         return self._datatype
 
-    def __reduce__(self):
+    def __reduce__(
+        self,
+    ) -> Tuple[Type["Literal"], Tuple[str, Union[str, None], Union[str, None]]]:
         return (
             Literal,
             (str(self), self.language, self.datatype),
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> Tuple[None, Dict[str, Union[str, None]]]:
         return (None, dict(language=self.language, datatype=self.datatype))
 
-    def __setstate__(self, arg):
+    def __setstate__(self, arg: Tuple[Any, Dict[str, str]]) -> None:
         _, d = arg
         self._language = d["language"]
         self._datatype = d["datatype"]
 
-    def __add__(self, val):
+    def __add__(self, val: Any) -> "Literal":
         """
         >>> Literal(1) + 1
         rdflib.term.Literal(u'2', datatype=rdflib.term.URIRef(u'http://www.w3.org/2001/XMLSchema#integer'))
@@ -719,7 +744,7 @@ class Literal(Identifier):
 
             return Literal(s, self.language, datatype=new_datatype)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """
         Is the Literal "True"
         This is used for if statements, bool(literal), etc.
@@ -728,7 +753,7 @@ class Literal(Identifier):
             return bool(self.value)
         return len(self) != 0
 
-    def __neg__(self):
+    def __neg__(self) -> "Literal":
         """
         >>> (- Literal(1))
         rdflib.term.Literal(u'-1', datatype=rdflib.term.URIRef(u'http://www.w3.org/2001/XMLSchema#integer'))
@@ -750,7 +775,7 @@ class Literal(Identifier):
         else:
             raise TypeError("Not a number; %s" % repr(self))
 
-    def __pos__(self):
+    def __pos__(self) -> "Literal":
         """
         >>> (+ Literal(1))
         rdflib.term.Literal(u'1', datatype=rdflib.term.URIRef(u'http://www.w3.org/2001/XMLSchema#integer'))
@@ -770,7 +795,7 @@ class Literal(Identifier):
         else:
             raise TypeError("Not a number; %s" % repr(self))
 
-    def __abs__(self):
+    def __abs__(self) -> "Literal":
         """
         >>> abs(Literal(-1))
         rdflib.term.Literal(u'1', datatype=rdflib.term.URIRef(u'http://www.w3.org/2001/XMLSchema#integer'))
@@ -789,7 +814,7 @@ class Literal(Identifier):
         else:
             raise TypeError("Not a number; %s" % repr(self))
 
-    def __invert__(self):
+    def __invert__(self) -> "Literal":
         """
         >>> ~(Literal(-1))
         rdflib.term.Literal(u'0', datatype=rdflib.term.URIRef(u'http://www.w3.org/2001/XMLSchema#integer'))
@@ -806,11 +831,12 @@ class Literal(Identifier):
         TypeError: Not a number; rdflib.term.Literal(u'1')
         """
         if isinstance(self.value, (int, long_type, float)):
-            return Literal(self.value.__invert__())
+            # type error: Unsupported operand type for ~ ("float")
+            return Literal(self.value.__invert__())  # type: ignore[operator] # FIXME
         else:
             raise TypeError("Not a number; %s" % repr(self))
 
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> bool:
         """
 
         This implements ordering for Literals,
@@ -905,7 +931,7 @@ class Literal(Identifier):
         else:
             return NotImplemented  # we can only compare to nodes
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         if other is None:
             return False  # Nothing is less than None
         if isinstance(other, Literal):
@@ -918,7 +944,7 @@ class Literal(Identifier):
 
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self, other: Any) -> bool:
         """
         >>> from rdflib.namespace import XSD
         >>> Literal('2007-01-01T10:00:00', datatype=XSD.dateTime
@@ -933,7 +959,7 @@ class Literal(Identifier):
         except TypeError:
             return NotImplemented
 
-    def __ge__(self, other):
+    def __ge__(self, other: Any) -> bool:
         r = self.__gt__(other)
         if r:
             return True
@@ -942,7 +968,7 @@ class Literal(Identifier):
         except TypeError:
             return NotImplemented
 
-    def _comparable_to(self, other):
+    def _comparable_to(self, other: Any) -> bool:
         """
         Helper method to decide which things are meaningful to
         rich-compare with this literal
@@ -971,7 +997,11 @@ class Literal(Identifier):
 
         return True
 
-    def __hash__(self):
+    # type error: Signature of "__hash__" incompatible with supertype "Identifier"
+    #  Superclass: def __hash__(self: str) -> int
+    #  Subclass: def __hash__(self) -> int
+    #  NOTE for type ignore: This can possibly be fixed by changing how __hash__ is implemented in Identifier
+    def __hash__(self) -> int:  # type: ignore[override]
         """
         >>> from rdflib.namespace import XSD
         >>> a = {Literal('1', datatype=XSD.integer):'one'}
@@ -1009,7 +1039,7 @@ class Literal(Identifier):
             res ^= hash(self._datatype)
         return res
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """
         Literals are only equal to other literals.
 
@@ -1060,7 +1090,7 @@ class Literal(Identifier):
 
         return False
 
-    def eq(self, other):
+    def eq(self, other: Any) -> bool:
         """
         Compare the value of this literal with something else
 
@@ -1166,16 +1196,17 @@ class Literal(Identifier):
                 _XSD_YEARMONTHDURATION,
             ):
                 return self.value == other
-        elif isinstance(other, bool):
+        # NOTE for type ignore: bool is a subclass of int so this won't ever run.
+        elif isinstance(other, bool):  # type: ignore[unreachable]
             if self.datatype == _XSD_BOOLEAN:
                 return self.value == other
 
         return NotImplemented
 
-    def neq(self, other):
+    def neq(self, other: Any) -> bool:
         return not self.eq(other)
 
-    def n3(self, namespace_manager=None):
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         r'''
         Returns a representation in the N3 format.
 
@@ -1233,7 +1264,11 @@ class Literal(Identifier):
         else:
             return self._literal_n3()
 
-    def _literal_n3(self, use_plain=False, qname_callback=None) -> str:
+    def _literal_n3(
+        self,
+        use_plain: bool = False,
+        qname_callback: Optional[Callable[[str], str]] = None,
+    ) -> str:
         """
         Using plain literal (shorthand) output::
             >>> from rdflib.namespace import XSD
@@ -1338,7 +1373,7 @@ class Literal(Identifier):
         else:
             return "%s" % encoded
 
-    def _quote_encode(self):
+    def _quote_encode(self) -> str:
         # This simpler encoding doesn't work; a newline gets encoded as "\\n",
         # which is ok in sourcecode, but we want "\n".
         # encoded = self.encode('unicode-escape').replace(
@@ -1363,7 +1398,7 @@ class Literal(Identifier):
                 '"', '\\"'
             ).replace("\r", "\\r")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = [super(Literal, self).__repr__()]
         if self.language is not None:
             args.append("lang=%s" % repr(self.language))
@@ -1385,7 +1420,7 @@ class Literal(Identifier):
         return self
 
 
-def _parseXML(xmlstring):
+def _parseXML(xmlstring: str) -> xml.dom.minidom.Document:
     retval = xml.dom.minidom.parseString(
         "<rdflibtoplevelelement>%s</rdflibtoplevelelement>" % xmlstring
     )
@@ -1393,7 +1428,7 @@ def _parseXML(xmlstring):
     return retval
 
 
-def _parseHTML(htmltext):
+def _parseHTML(htmltext: str) -> xml.dom.minidom.DocumentFragment:
     try:
         import html5lib
 
@@ -1408,7 +1443,9 @@ def _parseHTML(htmltext):
         )
 
 
-def _writeXML(xmlnode):
+def _writeXML(
+    xmlnode: Union[xml.dom.minidom.Document, xml.dom.minidom.DocumentFragment]
+) -> bytes:
     if isinstance(xmlnode, xml.dom.minidom.DocumentFragment):
         d = xml.dom.minidom.Document()
         d.childNodes += xmlnode.childNodes
@@ -1426,14 +1463,14 @@ def _writeXML(xmlnode):
     return s
 
 
-def _unhexlify(value):
+def _unhexlify(value: Union[str, bytes, Literal]) -> bytes:
     # In Python 3.2, unhexlify does not support str (only bytes)
     if isinstance(value, str):
         value = value.encode()
     return unhexlify(value)
 
 
-def _parseBoolean(value):
+def _parseBoolean(value: str) -> bool:
     true_accepted_values = ["1", "true"]
     false_accepted_values = ["0", "false"]
     new_value = value.lower()
@@ -1478,7 +1515,7 @@ _XSD_GYEAR = URIRef(_XSD_PFX + "gYear")
 _XSD_GYEARMONTH = URIRef(_XSD_PFX + "gYearMonth")
 # TODO: gMonthDay, gDay, gMonth
 
-_NUMERIC_LITERAL_TYPES = (
+_NUMERIC_LITERAL_TYPES: Tuple[URIRef, ...] = (
     _XSD_INTEGER,
     _XSD_DECIMAL,
     _XSD_DOUBLE,
@@ -1498,7 +1535,7 @@ _NUMERIC_LITERAL_TYPES = (
 )
 
 # these have "native" syntax in N3/SPARQL
-_PLAIN_LITERAL_TYPES = (
+_PLAIN_LITERAL_TYPES: Tuple[URIRef, ...] = (
     _XSD_INTEGER,
     _XSD_BOOLEAN,
     _XSD_DOUBLE,
@@ -1507,7 +1544,7 @@ _PLAIN_LITERAL_TYPES = (
 )
 
 # these have special INF and NaN XSD representations
-_NUMERIC_INF_NAN_LITERAL_TYPES = (
+_NUMERIC_INF_NAN_LITERAL_TYPES: Tuple[URIRef, ...] = (
     URIRef(_XSD_PFX + "float"),
     _XSD_DOUBLE,
     _XSD_DECIMAL,
@@ -1516,7 +1553,7 @@ _NUMERIC_INF_NAN_LITERAL_TYPES = (
 # the following types need special treatment for reasonable sorting because
 # certain instances can't be compared to each other. We treat this by
 # partitioning and then sorting within those partitions.
-_TOTAL_ORDER_CASTERS = {
+_TOTAL_ORDER_CASTERS: Dict[Type[Any], Callable[[Any], Any]] = {
     datetime: lambda value: (
         # naive vs. aware
         value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None,
@@ -1531,7 +1568,7 @@ _TOTAL_ORDER_CASTERS = {
 }
 
 
-_STRING_LITERAL_TYPES = (
+_STRING_LITERAL_TYPES: Tuple[URIRef, ...] = (
     _XSD_STRING,
     _RDF_XMLLITERAL,
     _RDF_HTMLLITERAL,
@@ -1540,7 +1577,12 @@ _STRING_LITERAL_TYPES = (
 )
 
 
-def _py2literal(obj, pType, castFunc, dType):
+def _py2literal(
+    obj: Any,
+    pType: Any,
+    castFunc: Optional[Callable[[Any], Any]],
+    dType: Optional[str],
+) -> Tuple[Any, Optional[str]]:
     if castFunc:
         return castFunc(obj), dType
     elif dType:
@@ -1549,11 +1591,15 @@ def _py2literal(obj, pType, castFunc, dType):
         return obj, None
 
 
-def _castPythonToLiteral(obj, datatype):
+def _castPythonToLiteral(
+    obj: Any, datatype: Optional[str]
+) -> Tuple[Any, Optional[str]]:
     """
     Casts a tuple of a python type and a special datatype URI to a tuple of the lexical value and a
     datatype URI (or None)
     """
+    castFunc: Optional[Callable[[Any], Union[str, bytes]]]
+    dType: Optional[str]
     for (pType, dType), castFunc in _SpecificPythonToXSDRules:
         if isinstance(obj, pType) and dType == datatype:
             return _py2literal(obj, pType, castFunc, dType)
@@ -1575,7 +1621,9 @@ def _castPythonToLiteral(obj, datatype):
 # python longs have no limit
 # both map to the abstract integer type,
 # rather than some concrete bit-limited datatype
-_GenericPythonToXSDRules = [
+_GenericPythonToXSDRules: List[
+    Tuple[Type[Any], Tuple[Optional[Callable[[Any], Union[str, bytes]]], Optional[str]]]
+] = [
     (str, (None, None)),
     (float, (None, _XSD_DOUBLE)),
     (bool, (lambda i: str(i).lower(), _XSD_BOOLEAN)),
@@ -1596,7 +1644,9 @@ _GenericPythonToXSDRules = [
     (Fraction, (None, _OWL_RATIONAL)),
 ]
 
-_SpecificPythonToXSDRules = [
+_SpecificPythonToXSDRules: List[
+    Tuple[Tuple[Type[Any], str], Optional[Callable[[Any], Union[str, bytes]]]]
+] = [
     ((date, _XSD_GYEAR), lambda val: val.strftime("%Y").zfill(4)),
     ((date, _XSD_GYEARMONTH), lambda val: val.strftime("%Y-%m").zfill(7)),
     ((str, _XSD_HEXBINARY), hexlify),
@@ -1605,7 +1655,7 @@ _SpecificPythonToXSDRules = [
     ((bytes, _XSD_B64BINARY), b64encode),
 ]
 
-XSDToPython = {
+XSDToPython: Dict[Optional[str], Optional[Callable[[str], Any]]] = {
     None: None,  # plain literals map directly to value space
     URIRef(_XSD_PFX + "time"): parse_time,
     URIRef(_XSD_PFX + "date"): parse_date,
@@ -1643,20 +1693,31 @@ XSDToPython = {
     _RDF_HTMLLITERAL: _parseHTML,
 }
 
-_toPythonMapping = {}
+_toPythonMapping: Dict[Optional[str], Optional[Callable[[str], Any]]] = {}
 
 _toPythonMapping.update(XSDToPython)
 
 
-def _castLexicalToPython(lexical, datatype):
+def _castLexicalToPython(lexical: Union[str, bytes], datatype: Optional[str]) -> Any:
     """
     Map a lexical form to the value-space for the given datatype
     :returns: a python object for the value or ``None``
     """
     convFunc = _toPythonMapping.get(datatype, False)
     if convFunc:
+        if TYPE_CHECKING:
+            # NOTE: This is here because convFunc is seen as
+            # Union[Callable[[str], Any], bool, None]
+            # even though it will never have value of True.
+            assert not isinstance(convFunc, bool)
+        convFunc
         try:
-            return convFunc(lexical)
+            # type error: Argument 1 has incompatible type "Union[str, bytes]"; expected "str"
+            # NOTE for type ignore: various functions in _toPythonMapping will
+            # only work for str, so there is some inconsistency here, the right
+            # approach may be to change lexical to be of str type but this will
+            # require runtime changes.
+            return convFunc(lexical)  # type: ignore[arg-type]
         except:
             # not a valid lexical representation for this dt
             return None
@@ -1665,30 +1726,44 @@ def _castLexicalToPython(lexical, datatype):
         try:
             return str(lexical)
         except UnicodeDecodeError:
-            return str(lexical, "utf-8")
+            # type error: Argument 1 to "str" has incompatible type "Union[str, bytes]"; expected "bytes"
+            # NOTE for type ignore: code assumes that lexical is of type bytes
+            # at this point.
+            return str(lexical, "utf-8")  # type: ignore[arg-type]
     else:
         # no convFunc - unknown data-type
         return None
 
 
-def _normalise_XSD_STRING(lexical_or_value):
+_AnyT = TypeVar("_AnyT", bound=Any)
+
+
+def _normalise_XSD_STRING(lexical_or_value: _AnyT) -> _AnyT:
     """
     Replaces \t, \n, \r (#x9 (tab), #xA (linefeed), and #xD (carriage return)) with space without any whitespace collapsing
     """
     if isinstance(lexical_or_value, str):
-        return lexical_or_value.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+        # type error: Incompatible return value type (got "str", expected "_AnyT")  [return-value]
+        # NOTE for type ignore: this is an issue with mypy: https://github.com/python/mypy/issues/10003
+        return lexical_or_value.replace("\t", " ").replace("\n", " ").replace("\r", " ")  # type: ignore[return-value]
     return lexical_or_value
 
 
-def _strip_and_collapse_whitespace(lexical_or_value):
+def _strip_and_collapse_whitespace(lexical_or_value: _AnyT) -> _AnyT:
     if isinstance(lexical_or_value, str):
         # Use regex to substitute contiguous whitespace into a single whitespace. Strip trailing whitespace.
-        return re.sub(" +", " ", lexical_or_value.strip())
+        # type error: Incompatible return value type (got "str", expected "_AnyT")  [return-value]
+        # NOTE for type ignore: this is an issue with mypy: https://github.com/python/mypy/issues/10003
+        return re.sub(" +", " ", lexical_or_value.strip())  # type: ignore[return-value]
     return lexical_or_value
 
 
 def bind(
-    datatype, pythontype, constructor=None, lexicalizer=None, datatype_specific=False
+    datatype: str,
+    pythontype: Type[Any],
+    constructor: Optional[Callable[[str], Any]] = None,
+    lexicalizer: Optional[Callable[[Any], Union[str, bytes]]] = None,
+    datatype_specific: bool = False,
 ) -> None:
     """
     register a new datatype<->pythontype binding
@@ -1727,14 +1802,14 @@ class Variable(Identifier):
 
     __slots__ = ()
 
-    def __new__(cls, value):
+    def __new__(cls, value: str) -> "Variable":
         if len(value) == 0:
             raise Exception("Attempted to create variable with empty string as name!")
         if value[0] == "?":
             value = value[1:]
         return str.__new__(cls, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.__class__ is Variable:
             clsName = "rdflib.term.Variable"
         else:
@@ -1745,10 +1820,10 @@ class Variable(Identifier):
     def toPython(self) -> str:
         return "?%s" % self
 
-    def n3(self, namespace_manager=None):
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         return "?%s" % self
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type["Variable"], Tuple[str]]:
         return (Variable, (str(self),))
 
 
@@ -1760,8 +1835,37 @@ _ORDERING: Dict[Type[Node], int] = defaultdict(int)
 _ORDERING.update({BNode: 10, Variable: 20, URIRef: 30, Literal: 40})
 
 
-def _isEqualXMLNode(node, other):
-    from xml.dom.minidom import Node
+def _isEqualXMLNode(
+    node: Union[
+        None,
+        xml.dom.minidom.Attr,
+        xml.dom.minidom.Comment,
+        xml.dom.minidom.Document,
+        xml.dom.minidom.DocumentFragment,
+        xml.dom.minidom.DocumentType,
+        xml.dom.minidom.Element,
+        xml.dom.minidom.Entity,
+        xml.dom.minidom.Notation,
+        xml.dom.minidom.ProcessingInstruction,
+        xml.dom.minidom.Text,
+    ],
+    other: Union[
+        None,
+        xml.dom.minidom.Attr,
+        xml.dom.minidom.Comment,
+        xml.dom.minidom.Document,
+        xml.dom.minidom.DocumentFragment,
+        xml.dom.minidom.DocumentType,
+        xml.dom.minidom.Element,
+        xml.dom.minidom.Entity,
+        xml.dom.minidom.Notation,
+        xml.dom.minidom.ProcessingInstruction,
+        xml.dom.minidom.Text,
+    ],
+) -> bool:
+    # importing xml.dom.minidom.Node as XMLNode to avoid confusion with
+    # rdflib.term.Node
+    from xml.dom.minidom import Node as XMLNode
 
     def recurse():
         # Recursion through the children
@@ -1783,10 +1887,13 @@ def _isEqualXMLNode(node, other):
     if node.nodeType != other.nodeType:
         return False
 
-    if node.nodeType in [Node.DOCUMENT_NODE, Node.DOCUMENT_FRAGMENT_NODE]:
+    if node.nodeType in [XMLNode.DOCUMENT_NODE, XMLNode.DOCUMENT_FRAGMENT_NODE]:
         return recurse()
 
-    elif node.nodeType == Node.ELEMENT_NODE:
+    elif node.nodeType == XMLNode.ELEMENT_NODE:
+        if TYPE_CHECKING:
+            assert isinstance(node, xml.dom.minidom.Element)
+            assert isinstance(other, xml.dom.minidom.Element)
         # Get the basics right
         if not (
             node.tagName == other.tagName and node.namespaceURI == other.namespaceURI
@@ -1799,12 +1906,14 @@ def _isEqualXMLNode(node, other):
         # to worry about that, which is a bonus...
         n_keys = [
             k
-            for k in node.attributes.keysNS()
+            # type error: Item "Element" of "Union[Document, Element]" has no attribute "attributes"
+            for k in node.attributes.keysNS()  # type: ignore[union-attr]
             if k[0] != "http://www.w3.org/2000/xmlns/"
         ]
         o_keys = [
             k
-            for k in other.attributes.keysNS()
+            # type error: Item "Element" of "Union[Document, Element]" has no attribute "attributes"
+            for k in other.attributes.keysNS()  # type: ignore[union-attr]
             if k[0] != "http://www.w3.org/2000/xmlns/"
         ]
         if len(n_keys) != len(o_keys):
@@ -1821,20 +1930,46 @@ def _isEqualXMLNode(node, other):
         return recurse()
 
     elif node.nodeType in [
-        Node.TEXT_NODE,
-        Node.COMMENT_NODE,
-        Node.CDATA_SECTION_NODE,
-        Node.NOTATION_NODE,
+        XMLNode.TEXT_NODE,
+        XMLNode.COMMENT_NODE,
+        XMLNode.CDATA_SECTION_NODE,
+        XMLNode.NOTATION_NODE,
     ]:
-        return node.data == other.data
+        if TYPE_CHECKING:
+            assert isinstance(
+                node,
+                (
+                    xml.dom.minidom.Text,
+                    xml.dom.minidom.Comment,
+                    xml.dom.minidom.CDATASection,
+                    xml.dom.minidom.Notation,
+                ),
+            )
+            assert isinstance(
+                other,
+                (
+                    xml.dom.minidom.Text,
+                    xml.dom.minidom.Comment,
+                    xml.dom.minidom.CDATASection,
+                    xml.dom.minidom.Notation,
+                ),
+            )
+        # type error: Item "Notation" of "Union[Comment, Document, Notation, Text]" has no attribute "data"
+        return node.data == other.data  # type: ignore[union-attr] # FIXME
 
-    elif node.nodeType == Node.PROCESSING_INSTRUCTION_NODE:
+    elif node.nodeType == XMLNode.PROCESSING_INSTRUCTION_NODE:
+        if TYPE_CHECKING:
+            assert isinstance(node, xml.dom.minidom.ProcessingInstruction)
+            assert isinstance(other, xml.dom.minidom.ProcessingInstruction)
         return node.data == other.data and node.target == other.target
 
-    elif node.nodeType == Node.ENTITY_NODE:
+    elif node.nodeType == XMLNode.ENTITY_NODE:
         return node.nodeValue == other.nodeValue
 
-    elif node.nodeType == Node.DOCUMENT_TYPE_NODE:
+    elif node.nodeType == XMLNode.DOCUMENT_TYPE_NODE:
+        if TYPE_CHECKING:
+            assert isinstance(node, xml.dom.minidom.Document)
+            assert isinstance(other, xml.dom.minidom.Document)
         return node.publicId == other.publicId and node.systemId == other.system.Id
 
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,12 @@ warn_unused_configs = True
 ignore_missing_imports = True
 disallow_subclassing_any = False
 warn_unreachable = True
+warn_unused_ignores = True
+
+[mypy-rdflib.plugin]
+# There is one type ignore in rdflib.plugin which is not needed on python 3.10
+# but is needed on earlier versions, so this does not work for that module.
+warn_unused_ignores = False
 
 [tool:pytest]
 addopts =


### PR DESCRIPTION
This adds as much typing as possible to `rdflib.term`.

Other changes:
- Added back `warn_unused_ignores`. I actually thought this was enabled
  but I forgot I disabled it because of some issue on python 3.10.
- Disabled `warn_unused_ignores` only for `rdflib.plugin`. There is an
  ignore in this module which is not needed on python 3.10, this is the
  most targetted way to avoid having that fail the type checking that I
  can think of for now.
- Removed unused type ignores.

This changeset includes no runtime changes.

