### PR TITLE
Fix turtle serialization of `rdf:type` in subject, object

### DIFF
--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -257,7 +257,8 @@ class TurtleSerializer(RecursiveSerializer):
     def preprocessTriple(self, triple):
         super(TurtleSerializer, self).preprocessTriple(triple)
         for i, node in enumerate(triple):
-            if node in self.keywords:
+            if i == VERB and node in self.keywords:
+                # predicate is a keyword
                 continue
             # Don't use generated prefixes for subjects and objects
             self.getQName(node, gen_prefix=(i == VERB))

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -138,22 +138,6 @@ XFAILS = {
         reason="missing escaping: PCDATA invalid Char value 12 and 8",
         raises=SAXParseException,
     ),
-    ("n3", "rdf_prefix.jsonld"): pytest.mark.xfail(
-        reason="missing 'rdf:' prefix",
-        raises=BadSyntax,
-    ),
-    ("ttl", "rdf_prefix.jsonld"): pytest.mark.xfail(
-        reason="missing 'rdf:' prefix",
-        raises=BadSyntax,
-    ),
-    ("trig", "rdf_prefix.jsonld"): pytest.mark.xfail(
-        reason="missing 'rdf:' prefix",
-        raises=BadSyntax,
-    ),
-    ("turtle", "rdf_prefix.jsonld"): pytest.mark.xfail(
-        reason="missing 'rdf:' prefix",
-        raises=BadSyntax,
-    ),
 }
 
 # This is for files which can only be represented properly in one format


### PR DESCRIPTION
Previously if `rdf:type` occurred in subject or object of a triple then
turtle would have not added a prefix for rdf as it considered `rdf:type`
to be a keyword regardless of where in the triple it occurred.

This changeset ensures that rdf:type is only considered a keyword if it
occurs as the predicate of a triple.

Fixes #1649