### PR TITLE
Format whole `*.py` codes

### DIFF
--- a/admin/get_merged_prs.py
+++ b/admin/get_merged_prs.py
@@ -1,9 +1,9 @@
 """Get all merged PRs since last release, save them to a JSON file"""
 
-import httpx
 import json
 from datetime import datetime
 
+import httpx
 
 r = httpx.get(
     "https://api.github.com/repos/rdflib/rdflib/pulls",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import re
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/berkeleydb_example.py
+++ b/examples/berkeleydb_example.py
@@ -16,9 +16,10 @@ Example 2: larger data
 * does not delete the DB at the end so you can see it on disk
 """
 import os
-from rdflib import ConjunctiveGraph, Namespace, Literal
-from rdflib.store import NO_STORE, VALID_STORE
 from tempfile import mktemp
+
+from rdflib import ConjunctiveGraph, Literal, Namespace
+from rdflib.store import NO_STORE, VALID_STORE
 
 
 def example_1():
@@ -98,10 +99,10 @@ def example_2():
         9719
         ...
     """
-    from urllib.request import urlopen, Request
-    from urllib.error import HTTPError
-    import json
     import base64
+    import json
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
 
     g = ConjunctiveGraph("BerkeleyDB")
     g.open("gsg_vocabs", create=True)

--- a/examples/conjunctive_graphs.py
+++ b/examples/conjunctive_graphs.py
@@ -8,8 +8,8 @@ This example shows how to create Named Graphs and work with the
 conjunction (union) of all the graphs.
 """
 
-from rdflib import Namespace, Literal, URIRef
-from rdflib.graph import Graph, ConjunctiveGraph
+from rdflib import Literal, Namespace, URIRef
+from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.plugins.stores.memory import Memory
 
 if __name__ == "__main__":

--- a/examples/custom_datatype.py
+++ b/examples/custom_datatype.py
@@ -9,8 +9,7 @@ mappings between literal datatypes and Python objects
 """
 
 
-from rdflib import Graph, Literal, Namespace, XSD
-from rdflib import term
+from rdflib import XSD, Graph, Literal, Namespace, term
 
 if __name__ == "__main__":
 

--- a/examples/custom_eval.py
+++ b/examples/custom_eval.py
@@ -17,9 +17,8 @@ i.e. in your setup.py::
 """
 
 import rdflib
-
-from rdflib.plugins.sparql.evaluate import evalBGP
 from rdflib.namespace import FOAF, RDF, RDFS
+from rdflib.plugins.sparql.evaluate import evalBGP
 
 inferredSubClass = RDFS.subClassOf * "*"  # any number of rdfs.subClassOf
 

--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -7,7 +7,7 @@ This example file shows how to decalre a Dataset, add content to it, serialise i
 and remove things from it.
 """
 
-from rdflib import Dataset, URIRef, Literal, Namespace
+from rdflib import Dataset, Literal, Namespace, URIRef
 
 #
 #   Create & Add

--- a/examples/film.py
+++ b/examples/film.py
@@ -22,8 +22,8 @@ Usage:
 """
 import datetime
 import os
-import sys
 import re
+import sys
 import time
 
 try:
@@ -31,8 +31,8 @@ try:
 except ImportError:
     imdb = None
 
-from rdflib import BNode, ConjunctiveGraph, URIRef, Literal, Namespace
-from rdflib.namespace import FOAF, DC, RDF
+from rdflib import BNode, ConjunctiveGraph, Literal, Namespace, URIRef
+from rdflib.namespace import DC, FOAF, RDF
 
 storefn = os.path.expanduser("~/movies.n3")
 # storefn = '/home/simon/codes/film.dev/movies.n3'

--- a/examples/foafpaths.py
+++ b/examples/foafpaths.py
@@ -26,7 +26,7 @@ See the docs for :mod:`rdflib.paths` for the details.
 This example shows how to get the name of friends (i.e values two steps away x knows y, y name z) with a single query.
 """
 
-from rdflib import URIRef, Graph
+from rdflib import Graph, URIRef
 from rdflib.namespace import FOAF
 
 if __name__ == "__main__":

--- a/examples/prepared_query.py
+++ b/examples/prepared_query.py
@@ -9,9 +9,8 @@ When executing, variables can be bound with the
 """
 
 import rdflib
-from rdflib.plugins.sparql import prepareQuery
 from rdflib.namespace import FOAF
-
+from rdflib.plugins.sparql import prepareQuery
 
 if __name__ == "__main__":
 

--- a/examples/resource_example.py
+++ b/examples/resource_example.py
@@ -7,7 +7,7 @@ where this resource is the subject.
 This example shows g.resource() in action.
 """
 
-from rdflib import Graph, RDF, RDFS, Literal
+from rdflib import RDF, RDFS, Graph, Literal
 from rdflib.namespace import FOAF
 
 if __name__ == "__main__":

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,5 +1,5 @@
-from rdflib import Graph, Literal, BNode, RDF
-from rdflib.namespace import FOAF, DC
+from rdflib import RDF, BNode, Graph, Literal
+from rdflib.namespace import DC, FOAF
 
 if __name__ == "__main__":
 

--- a/examples/slice.py
+++ b/examples/slice.py
@@ -9,7 +9,7 @@ can be realised.
 See :meth:`rdflib.graph.Graph.__getitem__` for details
 """
 
-from rdflib import Graph, RDF
+from rdflib import RDF, Graph
 from rdflib.namespace import FOAF
 
 if __name__ == "__main__":

--- a/examples/sparqlstore_example.py
+++ b/examples/sparqlstore_example.py
@@ -2,7 +2,7 @@
 Simple examples showing how to use the SPARQLStore
 """
 
-from rdflib import Graph, URIRef, Namespace
+from rdflib import Graph, Namespace, URIRef
 from rdflib.plugins.stores.sparqlstore import SPARQLStore
 
 if __name__ == "__main__":

--- a/examples/swap_primer.py
+++ b/examples/swap_primer.py
@@ -5,8 +5,8 @@ example stuff in the Primer on N3:
 http://www.w3.org/2000/10/swap/Primer
 """
 
-from rdflib import ConjunctiveGraph, Namespace, Literal
-from rdflib.namespace import OWL, DC
+from rdflib import ConjunctiveGraph, Literal, Namespace
+from rdflib.namespace import DC, OWL
 
 if __name__ == "__main__":
 

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -86,8 +86,8 @@ __all__ = [
     "util",
 ]
 
-import sys
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -156,47 +156,16 @@ In particular, this determines how the rich comparison operators for
 Literal work, eq, __neq__, __lt__, etc.
 """
 
-from rdflib.term import URIRef, BNode, IdentifiedNode, Literal, Variable
-
-from rdflib.graph import Dataset, Graph, ConjunctiveGraph
-
-from rdflib import plugin
-from rdflib import query
-
-from rdflib.namespace import (
-    BRICK,
-    CSVW,
-    DC,
-    DCAT,
-    DCMITYPE,
-    DCTERMS,
-    DOAP,
-    FOAF,
-    ODRL2,
-    ORG,
-    OWL,
-    PROF,
-    PROV,
-    QB,
-    RDF,
-    RDFS,
-    SDO,
-    SH,
-    SKOS,
-    SOSA,
-    SSN,
-    TIME,
-    VANN,
-    VOID,
-    XMLNS,
-    XSD,
-    Namespace,
-)
+from rdflib import plugin, query
+from rdflib.graph import ConjunctiveGraph, Dataset, Graph
+from rdflib.namespace import (BRICK, CSVW, DC, DCAT, DCMITYPE, DCTERMS, DOAP, FOAF,
+                              ODRL2, ORG, OWL, PROF, PROV, QB, RDF, RDFS, SDO, SH, SKOS,
+                              SOSA, SSN, TIME, VANN, VOID, XMLNS, XSD, Namespace)
+from rdflib.term import BNode, IdentifiedNode, Literal, URIRef, Variable
 
 # tedious sop to flake8
 assert plugin
 assert query
 
 from rdflib import util
-
 from rdflib.container import *

--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -1,7 +1,5 @@
 from rdflib.namespace import RDF
-from rdflib.term import BNode
-from rdflib.term import Literal
-
+from rdflib.term import BNode, Literal
 
 __all__ = ["Collection"]
 

--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -73,10 +73,7 @@ Only in second::
     _:cb558f30e21ddfc05ca53108348338ade8
         <http://example.org/ns#label> "B" .
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
+from __future__ import absolute_import, division, print_function
 
 # TODO:
 # - Doesn't handle quads.
@@ -92,23 +89,14 @@ __all__ = [
     "similar",
 ]
 
-from rdflib.graph import Graph, ConjunctiveGraph, ReadOnlyGraphAggregate
-from rdflib.term import BNode, Node, URIRef
-from hashlib import sha256
-
-from datetime import datetime
 from collections import defaultdict
-from typing import (
-    Set,
-    Dict,
-    TYPE_CHECKING,
-    Union,
-    List,
-    Tuple,
-    Callable,
-    Optional,
-    Iterator,
-)
+from datetime import datetime
+from hashlib import sha256
+from typing import (TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Set, Tuple,
+                    Union)
+
+from rdflib.graph import ConjunctiveGraph, Graph, ReadOnlyGraphAggregate
+from rdflib.term import BNode, Node, URIRef
 
 if TYPE_CHECKING:
     from _hashlib import HASH

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -3,11 +3,10 @@ Utility functions and objects to ease Python 2/3 compatibility,
 and different versions of support libraries.
 """
 
-import re
 import codecs
+import re
 import warnings
 from typing import TYPE_CHECKING, Match
-
 
 if TYPE_CHECKING:
     import xml.etree.ElementTree as etree

--- a/rdflib/container.py
+++ b/rdflib/container.py
@@ -1,6 +1,7 @@
+from random import randint
+
 from rdflib.namespace import RDF
 from rdflib.term import BNode, URIRef
-from random import randint
 
 __all__ = ["Container", "Bag", "Seq", "Alt", "NoElementException"]
 

--- a/rdflib/extras/cmdlineutils.py
+++ b/rdflib/extras/cmdlineutils.py
@@ -1,9 +1,9 @@
+import codecs
+import getopt
 import sys
 import time
-import getopt
-import rdflib
-import codecs
 
+import rdflib
 from rdflib.util import guess_format
 
 

--- a/rdflib/extras/describer.py
+++ b/rdflib/extras/describer.py
@@ -106,12 +106,10 @@ Full example in the ``to_rdf`` method below::
 """
 
 from contextlib import contextmanager
+
 from rdflib.graph import Graph
 from rdflib.namespace import RDF
-from rdflib.term import BNode
-from rdflib.term import Identifier
-from rdflib.term import Literal
-from rdflib.term import URIRef
+from rdflib.term import BNode, Identifier, Literal, URIRef
 
 
 class Describer(object):

--- a/rdflib/extras/infixowl.py
+++ b/rdflib/extras/infixowl.py
@@ -109,16 +109,14 @@ Python
 """
 
 import itertools
+import logging
 
-from rdflib import BNode, Literal, Namespace, RDF, RDFS, URIRef, Variable
-from rdflib.graph import Graph
+from rdflib import RDF, RDFS, BNode, Literal, Namespace, URIRef, Variable
 from rdflib.collection import Collection
-from rdflib.namespace import OWL, XSD
-from rdflib.namespace import NamespaceManager
+from rdflib.graph import Graph
+from rdflib.namespace import OWL, XSD, NamespaceManager
 from rdflib.term import Identifier
 from rdflib.util import first
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1,42 +1,28 @@
-from typing import (
-    IO,
-    Any,
-    BinaryIO,
-    Iterable,
-    Optional,
-    TextIO,
-    Union,
-    Type,
-    cast,
-    overload,
-    Generator,
-    Tuple,
-)
 import logging
-from warnings import warn
-import random
-from rdflib.namespace import Namespace, RDF
-from rdflib import plugin, exceptions, query, namespace
-import rdflib.term
-from rdflib.term import BNode, Node, URIRef, Literal, Genid
-from rdflib.paths import Path
-from rdflib.store import Store
-from rdflib.serializer import Serializer
-from rdflib.parser import InputSource, Parser, create_input_source
-from rdflib.namespace import NamespaceManager
-from rdflib.resource import Resource
-from rdflib.collection import Collection
-import rdflib.util  # avoid circular dependency
-from rdflib.exceptions import ParserError
-
 import os
+import pathlib
+import random
 import shutil
 import tempfile
-import pathlib
-
 from io import BytesIO
+from typing import (IO, Any, BinaryIO, Generator, Iterable, Optional, TextIO, Tuple,
+                    Type, Union, cast, overload)
 from urllib.parse import urlparse
 from urllib.request import url2pathname
+from warnings import warn
+
+import rdflib.term
+import rdflib.util  # avoid circular dependency
+from rdflib import exceptions, namespace, plugin, query
+from rdflib.collection import Collection
+from rdflib.exceptions import ParserError
+from rdflib.namespace import RDF, Namespace, NamespaceManager
+from rdflib.parser import InputSource, Parser, create_input_source
+from rdflib.paths import Path
+from rdflib.resource import Resource
+from rdflib.serializer import Serializer
+from rdflib.store import Store
+from rdflib.term import BNode, Genid, Literal, Node, URIRef
 
 assert Literal  # avoid warning
 assert Namespace  # avoid warning

--- a/rdflib/namespace/_BRICK.py
+++ b/rdflib/namespace/_BRICK.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class BRICK(DefinedNamespace):

--- a/rdflib/namespace/_CSVW.py
+++ b/rdflib/namespace/_CSVW.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class CSVW(DefinedNamespace):

--- a/rdflib/namespace/_DC.py
+++ b/rdflib/namespace/_DC.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DC(DefinedNamespace):

--- a/rdflib/namespace/_DCAM.py
+++ b/rdflib/namespace/_DCAM.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DCAM(DefinedNamespace):

--- a/rdflib/namespace/_DCAT.py
+++ b/rdflib/namespace/_DCAT.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DCAT(DefinedNamespace):

--- a/rdflib/namespace/_DCMITYPE.py
+++ b/rdflib/namespace/_DCMITYPE.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DCMITYPE(DefinedNamespace):

--- a/rdflib/namespace/_DCTERMS.py
+++ b/rdflib/namespace/_DCTERMS.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DCTERMS(DefinedNamespace):

--- a/rdflib/namespace/_DOAP.py
+++ b/rdflib/namespace/_DOAP.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class DOAP(DefinedNamespace):

--- a/rdflib/namespace/_FOAF.py
+++ b/rdflib/namespace/_FOAF.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class FOAF(DefinedNamespace):

--- a/rdflib/namespace/_GEO.py
+++ b/rdflib/namespace/_GEO.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class GEO(DefinedNamespace):
@@ -24,50 +24,50 @@ class GEO(DefinedNamespace):
     """
 
     # http://www.w3.org/2000/01/rdf-schema#Datatype
-    gmlLiteral: URIRef              # A GML serialization of a geometry object.
-    wktLiteral: URIRef              # A Well-known Text serialization of a geometry object.
+    gmlLiteral: URIRef  # A GML serialization of a geometry object.
+    wktLiteral: URIRef  # A Well-known Text serialization of a geometry object.
 
     # http://www.w3.org/2002/07/owl#Class
-    Feature: URIRef                 # This class represents the top-level feature type. This class is        equivalent to GFI_Feature defined in ISO 19156:2011, and it is        superclass of all feature types.
-    Geometry: URIRef                # The class represents the top-level geometry type. This class is        equivalent to the UML class GM_Object defined in ISO 19107, and        it is superclass of all geometry types.
-    SpatialObject: URIRef           # The class spatial-object represents everything that can have        a spatial representation. It is superclass of feature and geometry.
+    Feature: URIRef  # This class represents the top-level feature type. This class is        equivalent to GFI_Feature defined in ISO 19156:2011, and it is        superclass of all feature types.
+    Geometry: URIRef  # The class represents the top-level geometry type. This class is        equivalent to the UML class GM_Object defined in ISO 19107, and        it is superclass of all geometry types.
+    SpatialObject: URIRef  # The class spatial-object represents everything that can have        a spatial representation. It is superclass of feature and geometry.
 
     # http://www.w3.org/2002/07/owl#DatatypeProperty
-    asGML: URIRef                   # The GML serialization of a geometry
-    asWKT: URIRef                   # The WKT serialization of a geometry
-    coordinateDimension: URIRef     # The number of measurements or axes needed to describe the position of this       geometry in a coordinate system.
-    dimension: URIRef               # The topological dimension of this geometric object, which        must be less than or equal to the coordinate dimension.        In non-homogeneous collections, this will return the largest        topological dimension of the contained objects.
-    hasSerialization: URIRef        # Connects a geometry object with its text-based serialization.
-    isEmpty: URIRef                 # (true) if this geometric object is the empty Geometry. If        true, then this geometric object represents the empty point        set for the coordinate space.
-    isSimple: URIRef                # (true) if this geometric object has no anomalous geometric        points, such as self intersection or self tangency.
-    spatialDimension: URIRef        # The number of measurements or axes needed to describe the spatial position of        this geometry in a coordinate system.
+    asGML: URIRef  # The GML serialization of a geometry
+    asWKT: URIRef  # The WKT serialization of a geometry
+    coordinateDimension: URIRef  # The number of measurements or axes needed to describe the position of this       geometry in a coordinate system.
+    dimension: URIRef  # The topological dimension of this geometric object, which        must be less than or equal to the coordinate dimension.        In non-homogeneous collections, this will return the largest        topological dimension of the contained objects.
+    hasSerialization: URIRef  # Connects a geometry object with its text-based serialization.
+    isEmpty: URIRef  # (true) if this geometric object is the empty Geometry. If        true, then this geometric object represents the empty point        set for the coordinate space.
+    isSimple: URIRef  # (true) if this geometric object has no anomalous geometric        points, such as self intersection or self tangency.
+    spatialDimension: URIRef  # The number of measurements or axes needed to describe the spatial position of        this geometry in a coordinate system.
 
     # http://www.w3.org/2002/07/owl#ObjectProperty
-    defaultGeometry: URIRef         # The default geometry to be used in spatial calculations.       It is Usually the most detailed geometry.
-    ehContains: URIRef              # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: T*TFF*FF*
-    ehCoveredBy: URIRef             # Exists if the subject SpatialObject is spatially covered        by the object SpatialObject. DE-9IM: TFF*TFT**
-    ehCovers: URIRef                # Exists if the subject SpatialObject spatially covers the        object SpatialObject. DE-9IM: T*TFT*FF*
-    ehDisjoint: URIRef              # Exists if the subject SpatialObject is spatially disjoint       from the object SpatialObject. DE-9IM: FF*FF****
-    ehEquals: URIRef                # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
-    ehInside: URIRef                # Exists if the subject SpatialObject is spatially inside        the object SpatialObject. DE-9IM: TFF*FFT**
-    ehMeet: URIRef                  # Exists if the subject SpatialObject spatially meets the        object SpatialObject.        DE-9IM: FT******* ^ F**T***** ^ F***T****
-    ehOverlap: URIRef               # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: T*T***T**
-    hasGeometry: URIRef             # A spatial representation for a given feature.
-    rcc8dc: URIRef                  # Exists if the subject SpatialObject is spatially disjoint       from the object SpatialObject. DE-9IM: FFTFFTTTT
-    rcc8ec: URIRef                  # Exists if the subject SpatialObject spatially meets the        object SpatialObject. DE-9IM: FFTFTTTTT
-    rcc8eq: URIRef                  # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
-    rcc8ntpp: URIRef                # Exists if the subject SpatialObject is spatially inside        the object SpatialObject. DE-9IM: TFFTFFTTT
-    rcc8ntppi: URIRef               # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: TTTFFTFFT
-    rcc8po: URIRef                  # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: TTTTTTTTT
-    rcc8tpp: URIRef                 # Exists if the subject SpatialObject is spatially covered        by the object SpatialObject. DE-9IM: TFFTTFTTT
-    rcc8tppi: URIRef                # Exists if the subject SpatialObject spatially covers the        object SpatialObject. DE-9IM: TTTFTTFFT
-    sfContains: URIRef              # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: T*****FF*
-    sfCrosses: URIRef               # Exists if the subject SpatialObject spatially crosses the        object SpatialObject. DE-9IM: T*T******
-    sfDisjoint: URIRef              # Exists if the subject SpatialObject is spatially disjoint        from the object SpatialObject. DE-9IM: FF*FF****
-    sfEquals: URIRef                # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
-    sfIntersects: URIRef            # Exists if the subject SpatialObject is not spatially disjoint        from the object SpatialObject.       DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    sfOverlaps: URIRef              # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: T*T***T**
-    sfTouches: URIRef               # Exists if the subject SpatialObject spatially touches the        object SpatialObject.       DE-9IM: FT******* ^ F**T***** ^ F***T****
-    sfWithin: URIRef                # Exists if the subject SpatialObject is spatially within the        object SpatialObject. DE-9IM: T*F**F***
+    defaultGeometry: URIRef  # The default geometry to be used in spatial calculations.       It is Usually the most detailed geometry.
+    ehContains: URIRef  # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: T*TFF*FF*
+    ehCoveredBy: URIRef  # Exists if the subject SpatialObject is spatially covered        by the object SpatialObject. DE-9IM: TFF*TFT**
+    ehCovers: URIRef  # Exists if the subject SpatialObject spatially covers the        object SpatialObject. DE-9IM: T*TFT*FF*
+    ehDisjoint: URIRef  # Exists if the subject SpatialObject is spatially disjoint       from the object SpatialObject. DE-9IM: FF*FF****
+    ehEquals: URIRef  # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
+    ehInside: URIRef  # Exists if the subject SpatialObject is spatially inside        the object SpatialObject. DE-9IM: TFF*FFT**
+    ehMeet: URIRef  # Exists if the subject SpatialObject spatially meets the        object SpatialObject.        DE-9IM: FT******* ^ F**T***** ^ F***T****
+    ehOverlap: URIRef  # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: T*T***T**
+    hasGeometry: URIRef  # A spatial representation for a given feature.
+    rcc8dc: URIRef  # Exists if the subject SpatialObject is spatially disjoint       from the object SpatialObject. DE-9IM: FFTFFTTTT
+    rcc8ec: URIRef  # Exists if the subject SpatialObject spatially meets the        object SpatialObject. DE-9IM: FFTFTTTTT
+    rcc8eq: URIRef  # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
+    rcc8ntpp: URIRef  # Exists if the subject SpatialObject is spatially inside        the object SpatialObject. DE-9IM: TFFTFFTTT
+    rcc8ntppi: URIRef  # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: TTTFFTFFT
+    rcc8po: URIRef  # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: TTTTTTTTT
+    rcc8tpp: URIRef  # Exists if the subject SpatialObject is spatially covered        by the object SpatialObject. DE-9IM: TFFTTFTTT
+    rcc8tppi: URIRef  # Exists if the subject SpatialObject spatially covers the        object SpatialObject. DE-9IM: TTTFTTFFT
+    sfContains: URIRef  # Exists if the subject SpatialObject spatially contains the        object SpatialObject. DE-9IM: T*****FF*
+    sfCrosses: URIRef  # Exists if the subject SpatialObject spatially crosses the        object SpatialObject. DE-9IM: T*T******
+    sfDisjoint: URIRef  # Exists if the subject SpatialObject is spatially disjoint        from the object SpatialObject. DE-9IM: FF*FF****
+    sfEquals: URIRef  # Exists if the subject SpatialObject spatially equals the        object SpatialObject. DE-9IM: TFFFTFFFT
+    sfIntersects: URIRef  # Exists if the subject SpatialObject is not spatially disjoint        from the object SpatialObject.       DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
+    sfOverlaps: URIRef  # Exists if the subject SpatialObject spatially overlaps the        object SpatialObject. DE-9IM: T*T***T**
+    sfTouches: URIRef  # Exists if the subject SpatialObject spatially touches the        object SpatialObject.       DE-9IM: FT******* ^ F**T***** ^ F***T****
+    sfWithin: URIRef  # Exists if the subject SpatialObject is spatially within the        object SpatialObject. DE-9IM: T*F**F***
 
     _NS = Namespace("http://www.opengis.net/ont/geosparql#")

--- a/rdflib/namespace/_ODRL2.py
+++ b/rdflib/namespace/_ODRL2.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class ODRL2(DefinedNamespace):

--- a/rdflib/namespace/_ORG.py
+++ b/rdflib/namespace/_ORG.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class ORG(DefinedNamespace):

--- a/rdflib/namespace/_OWL.py
+++ b/rdflib/namespace/_OWL.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class OWL(DefinedNamespace):

--- a/rdflib/namespace/_PROF.py
+++ b/rdflib/namespace/_PROF.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class PROF(DefinedNamespace):

--- a/rdflib/namespace/_PROV.py
+++ b/rdflib/namespace/_PROV.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class PROV(DefinedNamespace):

--- a/rdflib/namespace/_QB.py
+++ b/rdflib/namespace/_QB.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class QB(DefinedNamespace):

--- a/rdflib/namespace/_RDF.py
+++ b/rdflib/namespace/_RDF.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class RDF(DefinedNamespace):

--- a/rdflib/namespace/_RDFS.py
+++ b/rdflib/namespace/_RDFS.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class RDFS(DefinedNamespace):

--- a/rdflib/namespace/_SDO.py
+++ b/rdflib/namespace/_SDO.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class SDO(DefinedNamespace):

--- a/rdflib/namespace/_SH.py
+++ b/rdflib/namespace/_SH.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class SH(DefinedNamespace):

--- a/rdflib/namespace/_SKOS.py
+++ b/rdflib/namespace/_SKOS.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class SKOS(DefinedNamespace):

--- a/rdflib/namespace/_SOSA.py
+++ b/rdflib/namespace/_SOSA.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class SOSA(DefinedNamespace):

--- a/rdflib/namespace/_SSN.py
+++ b/rdflib/namespace/_SSN.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class SSN(DefinedNamespace):

--- a/rdflib/namespace/_TIME.py
+++ b/rdflib/namespace/_TIME.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class TIME(DefinedNamespace):

--- a/rdflib/namespace/_VANN.py
+++ b/rdflib/namespace/_VANN.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class VANN(DefinedNamespace):

--- a/rdflib/namespace/_VOID.py
+++ b/rdflib/namespace/_VOID.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class VOID(DefinedNamespace):

--- a/rdflib/namespace/_XSD.py
+++ b/rdflib/namespace/_XSD.py
@@ -1,5 +1,5 @@
-from rdflib.term import URIRef
 from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
 
 
 class XSD(DefinedNamespace):

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -1,11 +1,9 @@
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Iterable
-from unicodedata import category
-
 from pathlib import Path
-from urllib.parse import urldefrag
-from urllib.parse import urljoin
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from unicodedata import category
+from urllib.parse import urldefrag, urljoin
 
 from rdflib.term import URIRef, Variable, _is_valid_uri
 
@@ -754,10 +752,10 @@ def get_longest_namespace(trie: Dict[str, Any], value: str) -> Optional[str]:
 from rdflib.namespace._BRICK import BRICK
 from rdflib.namespace._CSVW import CSVW
 from rdflib.namespace._DC import DC
+from rdflib.namespace._DCAM import DCAM
 from rdflib.namespace._DCAT import DCAT
 from rdflib.namespace._DCMITYPE import DCMITYPE
 from rdflib.namespace._DCTERMS import DCTERMS
-from rdflib.namespace._DCAM import DCAM
 from rdflib.namespace._DOAP import DOAP
 from rdflib.namespace._FOAF import FOAF
 from rdflib.namespace._GEO import GEO

--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -14,29 +14,15 @@ import codecs
 import os
 import pathlib
 import sys
-
-from io import BytesIO, RawIOBase, TextIOBase, TextIOWrapper, StringIO, BufferedIOBase
-from typing import (
-    IO,
-    Any,
-    BinaryIO,
-    Optional,
-    TextIO,
-    Tuple,
-    Union,
-    TYPE_CHECKING,
-)
-
-from urllib.request import Request
-from urllib.request import url2pathname
-from urllib.request import urlopen
+from io import BufferedIOBase, BytesIO, RawIOBase, StringIO, TextIOBase, TextIOWrapper
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Optional, TextIO, Tuple, Union
 from urllib.error import HTTPError
-
+from urllib.request import Request, url2pathname, urlopen
 from xml.sax import xmlreader
 
 from rdflib import __version__
-from rdflib.term import URIRef
 from rdflib.namespace import Namespace
+from rdflib.term import URIRef
 
 if TYPE_CHECKING:
     from rdflib import Graph

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -182,9 +182,9 @@ No vars specified:
 
 
 from functools import total_ordering
-from rdflib.term import URIRef, Node
-from typing import Union, Callable
+from typing import Callable, Union
 
+from rdflib.term import Node, URIRef
 
 # property paths
 

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -25,30 +25,16 @@ information.
 
 """
 
-from rdflib.store import Store
-from rdflib.parser import Parser
-from rdflib.serializer import Serializer
-from rdflib.query import (
-    ResultParser,
-    ResultSerializer,
-    Processor,
-    Result,
-    UpdateProcessor,
-)
-from rdflib.exceptions import Error
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generic,
-    Iterator,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    overload,
-)
+from typing import (TYPE_CHECKING, Any, Dict, Generic, Iterator, Optional, Tuple, Type,
+                    TypeVar, overload)
+
+from rdflib.exceptions import Error
+from rdflib.parser import Parser
+from rdflib.query import (Processor, Result, ResultParser, ResultSerializer,
+                          UpdateProcessor)
+from rdflib.serializer import Serializer
+from rdflib.store import Store
 
 if TYPE_CHECKING:
     from pkg_resources import EntryPoint

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -4,12 +4,11 @@ This is a rdflib plugin for parsing Hextuple files, which are Newline-Delimited 
 handle contexts, i.e. multiple graphs.
 """
 import json
-
-from typing import List, Union
-from rdflib.parser import Parser
-from rdflib import ConjunctiveGraph, URIRef, Literal, BNode
 import warnings
+from typing import List, Union
 
+from rdflib import BNode, ConjunctiveGraph, Literal, URIRef
+from rdflib.parser import Parser
 
 __all__ = ["HextuplesParser"]
 
@@ -39,8 +38,8 @@ class HextuplesParser(Parser):
         # language and graph may be None
         if tup[0] is None or tup[1] is None or tup[2] is None or tup[3] is None:
             raise ValueError(
-                "subject, predicate, value, datatype cannot be None. Given: "
-                f"{tup}")
+                "subject, predicate, value, datatype cannot be None. Given: " f"{tup}"
+            )
 
         # 1 - subject
         s: Union[URIRef, BNode]

--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -33,39 +33,20 @@ Example usage::
 # NOTE: This code reads the entire JSON object into memory before parsing, but
 # we should consider streaming the input to deal with arbitrarily large graphs.
 
-from typing import Optional
 import warnings
-from rdflib.graph import ConjunctiveGraph
-from rdflib.parser import URLInputSource
+from typing import Optional
+
 import rdflib.parser
+from rdflib.graph import ConjunctiveGraph
 from rdflib.namespace import RDF, XSD
-from rdflib.term import URIRef, BNode, Literal
+from rdflib.parser import URLInputSource
+from rdflib.term import BNode, Literal, URIRef
 
-from ..shared.jsonld.context import Context, Term, UNDEF
-from ..shared.jsonld.util import (
-    json,
-    source_to_json,
-    VOCAB_DELIMS,
-    context_from_urlinputsource,
-)
-from ..shared.jsonld.keys import (
-    CONTEXT,
-    GRAPH,
-    ID,
-    INCLUDED,
-    INDEX,
-    JSON,
-    LANG,
-    LIST,
-    NEST,
-    NONE,
-    REV,
-    SET,
-    TYPE,
-    VALUE,
-    VOCAB,
-)
-
+from ..shared.jsonld.context import UNDEF, Context, Term
+from ..shared.jsonld.keys import (CONTEXT, GRAPH, ID, INCLUDED, INDEX, JSON, LANG, LIST,
+                                  NEST, NONE, REV, SET, TYPE, VALUE, VOCAB)
+from ..shared.jsonld.util import (VOCAB_DELIMS, context_from_urlinputsource, json,
+                                  source_to_json)
 
 __all__ = ["JsonLDParser", "to_rdf"]
 

--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -27,32 +27,21 @@ Modified to work with rdflib by Gunnar Aastrand Grimnes
 Copyright 2010, Gunnar A. Grimnes
 
 """
-import sys
+import codecs
 import os
 import re
-import codecs
-from typing import IO, TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar, Union
-
+import sys
 # importing typing for `typing.List` because `List`` is used for something else
 import typing
-
 from decimal import Decimal
-
+from typing import IO, TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar, Union
 from uuid import uuid4
 
-from rdflib.exceptions import ParserError
-from rdflib.term import (
-    Identifier,
-    Node,
-    URIRef,
-    BNode,
-    Literal,
-    Variable,
-    _XSD_PFX,
-    _unique_id,
-)
-from rdflib.graph import QuotedGraph, ConjunctiveGraph, Graph
 from rdflib.compat import long_type
+from rdflib.exceptions import ParserError
+from rdflib.graph import ConjunctiveGraph, Graph, QuotedGraph
+from rdflib.term import (_XSD_PFX, BNode, Identifier, Literal, Node, URIRef, Variable,
+                         _unique_id)
 
 __all__ = [
     "BadSyntax",

--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -26,12 +26,9 @@ graphs that can be used and queried. The store that backs the graph
 from codecs import getreader
 
 from rdflib import ConjunctiveGraph
-
 # Build up from the NTriples parser:
-from rdflib.plugins.parsers.ntriples import W3CNTriplesParser
-from rdflib.plugins.parsers.ntriples import ParseError
-from rdflib.plugins.parsers.ntriples import r_tail
-from rdflib.plugins.parsers.ntriples import r_wspace
+from rdflib.plugins.parsers.ntriples import (ParseError, W3CNTriplesParser, r_tail,
+                                             r_wspace)
 
 __all__ = ["NQuadsParser"]
 

--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -6,18 +6,17 @@ License: GPL 2, W3C, BSD, or MIT
 Author: Sean B. Palmer, inamidst.com
 """
 
-import re
 import codecs
+import re
+from io import BytesIO, StringIO, TextIOBase
 from typing import IO, TYPE_CHECKING, Optional, Pattern, TextIO, Union
 
-from rdflib.term import Node, URIRef as URI
-from rdflib.term import BNode as bNode
-from rdflib.term import Literal
-from rdflib.compat import decodeUnicodeEscape, _string_escape_map
+from rdflib.compat import _string_escape_map, decodeUnicodeEscape
 from rdflib.exceptions import ParserError as ParseError
 from rdflib.parser import InputSource, Parser
-
-from io import StringIO, TextIOBase, BytesIO
+from rdflib.term import BNode as bNode
+from rdflib.term import Literal, Node
+from rdflib.term import URIRef as URI
 
 if TYPE_CHECKING:
     from rdflib.graph import Graph

--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -2,20 +2,16 @@
 An RDF/XML parser for RDFLib
 """
 
-from xml.sax import make_parser, handler, xmlreader
-from xml.sax.handler import ErrorHandler
-from xml.sax.saxutils import quoteattr, escape
-
-
 from urllib.parse import urldefrag, urljoin
-from rdflib.namespace import is_ncname
-from rdflib.namespace import RDF
-from rdflib.plugins.parsers.RDFVOC import RDFVOC
-from rdflib.term import URIRef
-from rdflib.term import BNode
-from rdflib.term import Literal
-from rdflib.exceptions import ParserError, Error
+from xml.sax import handler, make_parser, xmlreader
+from xml.sax.handler import ErrorHandler
+from xml.sax.saxutils import escape, quoteattr
+
+from rdflib.exceptions import Error, ParserError
+from rdflib.namespace import RDF, is_ncname
 from rdflib.parser import Parser
+from rdflib.plugins.parsers.RDFVOC import RDFVOC
+from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["create_parser", "BagID", "ElementHandler", "RDFXMLHandler", "RDFXMLParser"]
 

--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -1,6 +1,7 @@
 from rdflib import ConjunctiveGraph
 from rdflib.parser import Parser
-from .notation3 import SinkParser, RDFSink
+
+from .notation3 import RDFSink, SinkParser
 
 
 def becauseSubGraph(*args, **kwargs):

--- a/rdflib/plugins/parsers/trix.py
+++ b/rdflib/plugins/parsers/trix.py
@@ -1,18 +1,15 @@
 """
 A TriX parser for RDFLib
 """
-from rdflib.namespace import Namespace
-from rdflib.term import URIRef
-from rdflib.term import BNode
-from rdflib.term import Literal
-from rdflib.graph import Graph
-from rdflib.exceptions import ParserError
-from rdflib.parser import Parser
-
-
-from xml.sax.saxutils import handler
 from xml.sax import make_parser
 from xml.sax.handler import ErrorHandler
+from xml.sax.saxutils import handler
+
+from rdflib.exceptions import ParserError
+from rdflib.graph import Graph
+from rdflib.namespace import Namespace
+from rdflib.parser import Parser
+from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["create_parser", "TriXHandler", "TriXParser"]
 

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -2,13 +2,14 @@
 HextuplesSerializer RDF graph serializer for RDFLib.
 See <https://github.com/ontola/hextuples> for details about the format.
 """
-from typing import IO, Optional, Type, Union
 import json
-from rdflib.graph import Graph, ConjunctiveGraph
-from rdflib.term import Literal, URIRef, Node, BNode
-from rdflib.serializer import Serializer
-from rdflib.namespace import RDF, XSD
 import warnings
+from typing import IO, Optional, Type, Union
+
+from rdflib.graph import ConjunctiveGraph, Graph
+from rdflib.namespace import RDF, XSD
+from rdflib.serializer import Serializer
+from rdflib.term import BNode, Literal, Node, URIRef
 
 __all__ = ["HextuplesSerializer"]
 
@@ -105,14 +106,19 @@ class HextuplesSerializer(Serializer):
             else:
                 language = ""
 
-            return json.dumps([
-                self._iri_or_bn(triple[0]),
-                triple[1],
-                value,
-                datatype,
-                language,
-                self._context(context)
-            ]) + "\n"
+            return (
+                json.dumps(
+                    [
+                        self._iri_or_bn(triple[0]),
+                        triple[1],
+                        value,
+                        datatype,
+                        language,
+                        self._context(context),
+                    ]
+                )
+                + "\n"
+            )
         else:  # do not return anything for non-IRIs or BNs, e.g. QuotedGraph, Subjects
             return None
 

--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -36,16 +36,16 @@ Example usage::
 # graphs.
 
 import warnings
-
-from rdflib.serializer import Serializer
-from rdflib.graph import Graph
-from rdflib.term import URIRef, Literal, BNode
-from rdflib.namespace import RDF, XSD
 from typing import IO, Optional
 
-from ..shared.jsonld.context import Context, UNDEF
+from rdflib.graph import Graph
+from rdflib.namespace import RDF, XSD
+from rdflib.serializer import Serializer
+from rdflib.term import BNode, Literal, URIRef
+
+from ..shared.jsonld.context import UNDEF, Context
+from ..shared.jsonld.keys import CONTEXT, GRAPH, ID, LANG, LIST, SET, VOCAB
 from ..shared.jsonld.util import json
-from ..shared.jsonld.keys import CONTEXT, GRAPH, ID, VOCAB, LIST, SET, LANG
 
 __all__ = ["JsonLDSerializer", "from_rdf"]
 

--- a/rdflib/plugins/serializers/longturtle.py
+++ b/rdflib/plugins/serializers/longturtle.py
@@ -16,10 +16,11 @@ to turtle - the original turtle serializer. It:
 - Nicholas Car, 2021
 """
 
-from rdflib.term import BNode, Literal, URIRef
 from rdflib.exceptions import Error
-from .turtle import RecursiveSerializer
 from rdflib.namespace import RDF
+from rdflib.term import BNode, Literal, URIRef
+
+from .turtle import RecursiveSerializer
 
 __all__ = ["LongTurtleSerializer"]
 

--- a/rdflib/plugins/serializers/n3.py
+++ b/rdflib/plugins/serializers/n3.py
@@ -2,8 +2,8 @@
 Notation 3 (N3) RDF graph serializer for RDFLib.
 """
 from rdflib.graph import Graph
-from rdflib.namespace import Namespace, OWL
-from rdflib.plugins.serializers.turtle import TurtleSerializer, SUBJECT, OBJECT
+from rdflib.namespace import OWL, Namespace
+from rdflib.plugins.serializers.turtle import OBJECT, SUBJECT, TurtleSerializer
 
 __all__ = ["N3Serializer"]
 

--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -1,11 +1,10 @@
-from typing import IO, Optional
 import warnings
+from typing import IO, Optional
 
 from rdflib.graph import ConjunctiveGraph, Graph
-from rdflib.term import Literal
-from rdflib.serializer import Serializer
-
 from rdflib.plugins.serializers.nt import _quoteLiteral
+from rdflib.serializer import Serializer
+from rdflib.term import Literal
 
 __all__ = ["NQuadsSerializer"]
 

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -3,14 +3,13 @@ N-Triples RDF graph serializer for RDFLib.
 See <http://www.w3.org/TR/rdf-testcases/#ntriples> for details about the
 format.
 """
+import codecs
+import warnings
 from typing import IO, Optional
 
 from rdflib.graph import Graph
-from rdflib.term import Literal
 from rdflib.serializer import Serializer
-
-import warnings
-import codecs
+from rdflib.term import Literal
 
 __all__ = ["NTSerializer"]
 

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -1,17 +1,15 @@
-from typing import IO, Dict, Optional, Set
-from rdflib.plugins.serializers.xmlwriter import XMLWriter
-
-from rdflib.namespace import Namespace, RDF, RDFS  # , split_uri
-from rdflib.plugins.parsers.RDFVOC import RDFVOC
-
-from rdflib.graph import Graph
-from rdflib.term import Identifier, URIRef, Literal, BNode
-from rdflib.util import first, more_than
-from rdflib.collection import Collection
-from rdflib.serializer import Serializer
-
-from xml.sax.saxutils import quoteattr, escape
 import xml.dom.minidom
+from typing import IO, Dict, Optional, Set
+from xml.sax.saxutils import escape, quoteattr
+
+from rdflib.collection import Collection
+from rdflib.graph import Graph
+from rdflib.namespace import RDF, RDFS, Namespace  # , split_uri
+from rdflib.plugins.parsers.RDFVOC import RDFVOC
+from rdflib.plugins.serializers.xmlwriter import XMLWriter
+from rdflib.serializer import Serializer
+from rdflib.term import BNode, Identifier, Literal, URIRef
+from rdflib.util import first, more_than
 
 from .xmlwriter import ESCAPE_ENTITIES
 

--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -10,7 +10,6 @@ from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.plugins.serializers.turtle import TurtleSerializer
 from rdflib.term import BNode, Node
 
-
 __all__ = ["TrigSerializer"]
 
 

--- a/rdflib/plugins/serializers/trix.py
+++ b/rdflib/plugins/serializers/trix.py
@@ -1,12 +1,10 @@
 from typing import IO, Optional
-from rdflib.serializer import Serializer
-from rdflib.plugins.serializers.xmlwriter import XMLWriter
 
-from rdflib.term import URIRef, Literal, BNode
+from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.namespace import Namespace
-
-from rdflib.graph import Graph, ConjunctiveGraph
-
+from rdflib.plugins.serializers.xmlwriter import XMLWriter
+from rdflib.serializer import Serializer
+from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["TriXSerializer"]
 

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -6,10 +6,10 @@ See <http://www.w3.org/TeamSubmission/turtle/> for syntax specification.
 from collections import defaultdict
 from functools import cmp_to_key
 
-from rdflib.term import BNode, Literal, URIRef
 from rdflib.exceptions import Error
-from rdflib.serializer import Serializer
 from rdflib.namespace import RDF, RDFS
+from rdflib.serializer import Serializer
+from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["RecursiveSerializer", "TurtleSerializer"]
 

--- a/rdflib/plugins/serializers/xmlwriter.py
+++ b/rdflib/plugins/serializers/xmlwriter.py
@@ -1,5 +1,5 @@
 import codecs
-from xml.sax.saxutils import quoteattr, escape
+from xml.sax.saxutils import escape, quoteattr
 
 __all__ = ["XMLWriter"]
 

--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -12,37 +12,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 from rdflib.namespace import RDF
 
-from .keys import (
-    BASE,
-    CONTAINER,
-    CONTEXT,
-    GRAPH,
-    ID,
-    IMPORT,
-    INCLUDED,
-    INDEX,
-    JSON,
-    LANG,
-    LIST,
-    NEST,
-    NONE,
-    PREFIX,
-    PROPAGATE,
-    PROTECTED,
-    REV,
-    SET,
-    TYPE,
-    VALUE,
-    VERSION,
-    VOCAB,
-)
-from .errors import (
-    INVALID_REMOTE_CONTEXT,
-    RECURSIVE_CONTEXT_INCLUSION,
-    INVALID_CONTEXT_ENTRY,
-)
-from .util import source_to_json, urljoin, urlsplit, split_iri, norm_url
-
+from .errors import (INVALID_CONTEXT_ENTRY, INVALID_REMOTE_CONTEXT,
+                     RECURSIVE_CONTEXT_INCLUSION)
+from .keys import (BASE, CONTAINER, CONTEXT, GRAPH, ID, IMPORT, INCLUDED, INDEX, JSON,
+                   LANG, LIST, NEST, NONE, PREFIX, PROPAGATE, PROTECTED, REV, SET, TYPE,
+                   VALUE, VERSION, VOCAB)
+from .util import norm_url, source_to_json, split_iri, urljoin, urlsplit
 
 NODE_KEYS = {GRAPH, ID, INCLUDED, JSON, LIST, NEST, NONE, REV, SET, TYPE, VALUE, LANG}
 

--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -12,14 +12,11 @@ else:
     except ImportError:
         import simplejson as json
 
-from posixpath import sep
-from posixpath import normpath
-
+from io import TextIOBase, TextIOWrapper
+from posixpath import normpath, sep
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
-from rdflib.parser import create_input_source, PythonInputSource, StringInputSource
-
-from io import TextIOBase, TextIOWrapper
+from rdflib.parser import PythonInputSource, StringInputSource, create_input_source
 
 
 def source_to_json(source):

--- a/rdflib/plugins/sparql/__init__.py
+++ b/rdflib/plugins/sparql/__init__.py
@@ -31,10 +31,8 @@ NotImplementedError if they cannot handle a certain part
 PLUGIN_ENTRY_POINT = "rdf.plugins.sparqleval"
 
 import sys
-from . import parser
-from . import operators
-from . import parserutils
 
+from . import operators, parser, parserutils
 from .processor import prepareQuery, prepareUpdate, processUpdate
 
 assert parser

--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -1,11 +1,10 @@
-from rdflib import Literal, XSD
-from rdflib.plugins.sparql.evalutils import _eval, NotBoundError, _val
-from rdflib.plugins.sparql.operators import numeric
-from rdflib.plugins.sparql.datatypes import type_promotion
-
-from rdflib.plugins.sparql.sparql import SPARQLTypeError
-
 from decimal import Decimal
+
+from rdflib import XSD, Literal
+from rdflib.plugins.sparql.datatypes import type_promotion
+from rdflib.plugins.sparql.evalutils import NotBoundError, _eval, _val
+from rdflib.plugins.sparql.operators import numeric
+from rdflib.plugins.sparql.sparql import SPARQLTypeError
 
 """
 Aggregation functions

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -5,26 +5,19 @@ http://www.w3.org/TR/sparql11-query/#sparqlQuery
 
 """
 
+import collections
 import functools
 import operator
-import collections
-
 from functools import reduce
-
-from rdflib import Literal, Variable, URIRef, BNode
-
-from rdflib.plugins.sparql.sparql import Prologue, Query, Update
-from rdflib.plugins.sparql.parserutils import CompValue, Expr
-from rdflib.plugins.sparql.operators import (
-    and_,
-    TrueFilter,
-    simplify as simplifyFilters,
-)
-from rdflib.paths import InvPath, AlternativePath, SequencePath, MulPath, NegatedPath
 
 from pyparsing import ParseResults
 
-
+from rdflib import BNode, Literal, URIRef, Variable
+from rdflib.paths import AlternativePath, InvPath, MulPath, NegatedPath, SequencePath
+from rdflib.plugins.sparql.operators import TrueFilter, and_
+from rdflib.plugins.sparql.operators import simplify as simplifyFilters
+from rdflib.plugins.sparql.parserutils import CompValue, Expr
+from rdflib.plugins.sparql.sparql import Prologue, Query, Update
 # ---------------------------
 # Some convenience methods
 from rdflib.term import Identifier
@@ -967,7 +960,7 @@ def translateAlgebra(query_algebra: Query):
                         )
                     aggr_vars[agg_func.res].append(agg_func.vars)
 
-                    agg_func_name = agg_func.name.split('_')[1]
+                    agg_func_name = agg_func.name.split("_")[1]
                     distinct = ""
                     if agg_func.distinct:
                         distinct = agg_func.distinct + " "
@@ -1470,9 +1463,10 @@ def pprintAlgebra(q):
 
 
 if __name__ == "__main__":
-    import sys
-    from rdflib.plugins.sparql import parser
     import os.path
+    import sys
+
+    from rdflib.plugins.sparql import parser
 
     if os.path.exists(sys.argv[1]):
         q = open(sys.argv[1]).read()

--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -16,36 +16,22 @@ also return a dict of list of dicts
 
 import collections
 import itertools
+import json as j
 import re
 from typing import Any, Deque, Dict, List, Union
-from urllib.request import urlopen, Request
 from urllib.parse import urlencode
-import json as j
+from urllib.request import Request, urlopen
+
 from pyparsing import ParseException
 
-from rdflib import Variable, Graph, BNode, URIRef, Literal
-from rdflib.plugins.sparql import CUSTOM_EVALS
-from rdflib.plugins.sparql.parserutils import CompValue, value
-from rdflib.plugins.sparql.sparql import (
-    QueryContext,
-    AlreadyBound,
-    FrozenBindings,
-    Bindings,
-    SPARQLError,
-)
-from rdflib.plugins.sparql.evalutils import (
-    _filter,
-    _eval,
-    _join,
-    _diff,
-    _minus,
-    _fillTemplate,
-    _ebv,
-    _val,
-)
-
+from rdflib import BNode, Graph, Literal, URIRef, Variable
+from rdflib.plugins.sparql import CUSTOM_EVALS, parser
 from rdflib.plugins.sparql.aggregates import Aggregator
-from rdflib.plugins.sparql import parser
+from rdflib.plugins.sparql.evalutils import (_diff, _ebv, _eval, _fillTemplate, _filter,
+                                             _join, _minus, _val)
+from rdflib.plugins.sparql.parserutils import CompValue, value
+from rdflib.plugins.sparql.sparql import (AlreadyBound, Bindings, FrozenBindings,
+                                          QueryContext, SPARQLError)
 from rdflib.term import Identifier
 
 

--- a/rdflib/plugins/sparql/evalutils.py
+++ b/rdflib/plugins/sparql/evalutils.py
@@ -1,11 +1,10 @@
 import collections
 from typing import Dict, Iterable
 
-from rdflib.term import Variable, Literal, BNode, URIRef
-
 from rdflib.plugins.sparql.operators import EBV
-from rdflib.plugins.sparql.parserutils import Expr, CompValue
-from rdflib.plugins.sparql.sparql import FrozenDict, SPARQLError, NotBoundError
+from rdflib.plugins.sparql.parserutils import CompValue, Expr
+from rdflib.plugins.sparql.sparql import FrozenDict, NotBoundError, SPARQLError
+from rdflib.term import BNode, Literal, URIRef, Variable
 
 
 def _diff(a: Iterable[FrozenDict], b: Iterable[FrozenDict], expr):

--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -6,34 +6,28 @@ using setEvalFn
 
 """
 
-import sys
-import re
-import math
-import random
-import uuid
-import hashlib
 import datetime as py_datetime  # naming conflict with function within this module
-import warnings
-
-from functools import reduce
-
-from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
-
+import hashlib
+import math
 import operator as pyop  # python operators
-
-import isodate
-
-from rdflib.plugins.sparql.parserutils import CompValue, Expr
-from rdflib.plugins.sparql.datatypes import XSD_DTs, type_promotion
-from rdflib.plugins.sparql.datatypes import XSD_DateTime_DTs, XSD_Duration_DTs
-from rdflib import URIRef, BNode, Variable, Literal, XSD, RDF
-from rdflib.term import Node
-
+import random
+import re
+import sys
+import uuid
+import warnings
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from functools import reduce
 from urllib.parse import quote
 
+import isodate
 from pyparsing import ParseResults
 
+from rdflib import RDF, XSD, BNode, Literal, URIRef, Variable
+from rdflib.plugins.sparql.datatypes import (XSD_DateTime_DTs, XSD_DTs,
+                                             XSD_Duration_DTs, type_promotion)
+from rdflib.plugins.sparql.parserutils import CompValue, Expr
 from rdflib.plugins.sparql.sparql import SPARQLError, SPARQLTypeError
+from rdflib.term import Node
 
 
 def Builtin_IRI(expr, ctx):

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -4,34 +4,24 @@ SPARQL 1.1 Parser
 based on pyparsing
 """
 
-import sys
 import re
+import sys
 
-from pyparsing import (
-    Literal,
-    Regex,
-    Optional,
-    OneOrMore,
-    ZeroOrMore,
-    Forward,
-    ParseException,
-    Suppress,
-    Combine,
-    restOfLine,
-    Group,
-    ParseResults,
-    delimitedList,
-)
 from pyparsing import CaselessKeyword as Keyword  # watch out :)
+from pyparsing import (Combine, Forward, Group, Literal, OneOrMore, Optional,
+                       ParseException, ParseResults, Regex, Suppress, ZeroOrMore,
+                       delimitedList, restOfLine)
+
+import rdflib
+from rdflib.compat import decodeUnicodeEscape
+
+from . import operators as op
+from .parserutils import Comp, Param, ParamList
 
 # from pyparsing import Keyword as CaseSensitiveKeyword
 
-from .parserutils import Comp, Param, ParamList
 
-from . import operators as op
-from rdflib.compat import decodeUnicodeEscape
 
-import rdflib
 
 DEBUG = False
 

--- a/rdflib/plugins/sparql/parserutils.py
+++ b/rdflib/plugins/sparql/parserutils.py
@@ -1,8 +1,7 @@
+from collections import OrderedDict
 from types import MethodType
 
-from collections import OrderedDict
-
-from pyparsing import TokenConverter, ParseResults, originalTextFor
+from pyparsing import ParseResults, TokenConverter, originalTextFor
 
 from rdflib import BNode, Variable
 
@@ -271,8 +270,9 @@ def prettify_parsetree(t, indent="", depth=0):
 
 
 if __name__ == "__main__":
-    from pyparsing import Word, nums
     import sys
+
+    from pyparsing import Word, nums
 
     Number = Word(nums)
     Number.setParseAction(lambda x: int(x[0]))
@@ -284,4 +284,4 @@ if __name__ == "__main__":
     print(r[0].eval({}))
 
 # hurrah for circular imports
-from rdflib.plugins.sparql.sparql import SPARQLError, NotBoundError
+from rdflib.plugins.sparql.sparql import NotBoundError, SPARQLError

--- a/rdflib/plugins/sparql/processor.py
+++ b/rdflib/plugins/sparql/processor.py
@@ -6,15 +6,12 @@ These should be automatically registered with RDFLib
 """
 
 
-from rdflib.query import Processor, Result, UpdateProcessor
-
-from rdflib.plugins.sparql.sparql import Query
-
-from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
 from rdflib.plugins.sparql.algebra import translateQuery, translateUpdate
-
 from rdflib.plugins.sparql.evaluate import evalQuery
+from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
+from rdflib.plugins.sparql.sparql import Query
 from rdflib.plugins.sparql.update import evalUpdate
+from rdflib.query import Processor, Result, UpdateProcessor
 
 
 def prepareQuery(queryString, initNs={}, base=None) -> Query:

--- a/rdflib/plugins/sparql/results/csvresults.py
+++ b/rdflib/plugins/sparql/results/csvresults.py
@@ -11,9 +11,8 @@ import codecs
 import csv
 from typing import IO
 
-from rdflib import Variable, BNode, URIRef, Literal
-
-from rdflib.query import Result, ResultSerializer, ResultParser
+from rdflib import BNode, Literal, URIRef, Variable
+from rdflib.query import Result, ResultParser, ResultSerializer
 
 
 class CSVResultParser(ResultParser):

--- a/rdflib/plugins/sparql/results/graph.py
+++ b/rdflib/plugins/sparql/results/graph.py
@@ -1,5 +1,4 @@
 from rdflib import Graph
-
 from rdflib.query import Result, ResultParser
 
 

--- a/rdflib/plugins/sparql/results/jsonresults.py
+++ b/rdflib/plugins/sparql/results/jsonresults.py
@@ -1,9 +1,8 @@
 import json
 from typing import IO, Any, Dict, Optional, TextIO, Union
 
-from rdflib.query import Result, ResultException, ResultSerializer, ResultParser
-from rdflib import Literal, URIRef, BNode, Variable
-
+from rdflib import BNode, Literal, URIRef, Variable
+from rdflib.query import Result, ResultException, ResultParser, ResultSerializer
 
 """A Serializer for SPARQL results in JSON:
 

--- a/rdflib/plugins/sparql/results/rdfresults.py
+++ b/rdflib/plugins/sparql/results/rdfresults.py
@@ -1,5 +1,4 @@
-from rdflib import Graph, Namespace, RDF, Variable
-
+from rdflib import RDF, Graph, Namespace, Variable
 from rdflib.query import Result, ResultParser
 
 RS = Namespace("http://www.w3.org/2001/sw/DataAccess/tests/result-set#")

--- a/rdflib/plugins/sparql/results/tsvresults.py
+++ b/rdflib/plugins/sparql/results/tsvresults.py
@@ -6,32 +6,15 @@ It is implemented with pyparsing, reusing the elements from the SPARQL Parser
 
 import codecs
 
-from pyparsing import (
-    Optional,
-    ZeroOrMore,
-    Literal,
-    ParserElement,
-    ParseException,
-    Suppress,
-    FollowedBy,
-    LineEnd,
-)
-
-from rdflib.query import Result, ResultParser
-
-from rdflib.plugins.sparql.parser import (
-    Var,
-    STRING_LITERAL1,
-    STRING_LITERAL2,
-    IRIREF,
-    BLANK_NODE_LABEL,
-    NumericLiteral,
-    BooleanLiteral,
-    LANGTAG,
-)
-from rdflib.plugins.sparql.parserutils import Comp, Param, CompValue
+from pyparsing import (FollowedBy, LineEnd, Literal, Optional, ParseException,
+                       ParserElement, Suppress, ZeroOrMore)
 
 from rdflib import Literal as RDFLiteral
+from rdflib.plugins.sparql.parser import (BLANK_NODE_LABEL, IRIREF, LANGTAG,
+                                          STRING_LITERAL1, STRING_LITERAL2,
+                                          BooleanLiteral, NumericLiteral, Var)
+from rdflib.plugins.sparql.parserutils import Comp, CompValue, Param
+from rdflib.query import Result, ResultParser
 
 ParserElement.setDefaultWhitespaceChars(" \n")
 

--- a/rdflib/plugins/sparql/results/txtresults.py
+++ b/rdflib/plugins/sparql/results/txtresults.py
@@ -1,7 +1,8 @@
 from typing import IO, List, Optional
-from rdflib import URIRef, BNode, Literal
-from rdflib.query import ResultSerializer
+
+from rdflib import BNode, Literal, URIRef
 from rdflib.namespace import NamespaceManager
+from rdflib.query import ResultSerializer
 from rdflib.term import Variable
 
 

--- a/rdflib/plugins/sparql/results/xmlresults.py
+++ b/rdflib/plugins/sparql/results/xmlresults.py
@@ -1,15 +1,12 @@
 import logging
 from typing import IO, Optional
-
-from xml.sax.saxutils import XMLGenerator
 from xml.dom import XML_NAMESPACE
+from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesNSImpl
 
+from rdflib import BNode, Literal, URIRef, Variable
 from rdflib.compat import etree
-
-from rdflib import Literal, URIRef, BNode, Variable
-from rdflib.query import Result, ResultParser, ResultSerializer, ResultException
-
+from rdflib.query import Result, ResultException, ResultParser, ResultSerializer
 
 SPARQL_XML_NAMESPACE = "http://www.w3.org/2005/sparql-results#"
 RESULTS_NS_ET = "{%s}" % SPARQL_XML_NAMESPACE

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -1,17 +1,15 @@
 import collections
-import itertools
 import datetime
+import itertools
 
 import isodate
 
+import rdflib.plugins.sparql
+from rdflib import BNode, ConjunctiveGraph, Graph, Literal, URIRef, Variable
 from rdflib.compat import Mapping, MutableMapping
 from rdflib.namespace import NamespaceManager
-from rdflib import Variable, BNode, Graph, ConjunctiveGraph, URIRef, Literal
-from rdflib.term import Node
-
 from rdflib.plugins.sparql.parserutils import CompValue
-
-import rdflib.plugins.sparql
+from rdflib.term import Node
 
 
 class SPARQLError(Exception):

--- a/rdflib/plugins/sparql/update.py
+++ b/rdflib/plugins/sparql/update.py
@@ -5,9 +5,9 @@ Code for carrying out Update Operations
 """
 
 from rdflib import Graph, Variable
-from rdflib.plugins.sparql.sparql import QueryContext
-from rdflib.plugins.sparql.evalutils import _fillTemplate, _join
 from rdflib.plugins.sparql.evaluate import evalBGP, evalPart
+from rdflib.plugins.sparql.evalutils import _fillTemplate, _join
+from rdflib.plugins.sparql.sparql import QueryContext
 
 
 def _graphOrDefault(ctx, g):

--- a/rdflib/plugins/stores/auditable.py
+++ b/rdflib/plugins/stores/auditable.py
@@ -15,9 +15,10 @@ system fails): A and I out of ACID.
 
 """
 
-from rdflib.store import Store
-from rdflib import Graph, ConjunctiveGraph
 import threading
+
+from rdflib import ConjunctiveGraph, Graph
+from rdflib.store import Store
 
 destructiveOpLocks = {
     "add": None,

--- a/rdflib/plugins/stores/berkeleydb.py
+++ b/rdflib/plugins/stores/berkeleydb.py
@@ -1,10 +1,11 @@
 import logging
-from threading import Thread
-from os.path import exists, abspath
 from os import mkdir
-from rdflib.store import Store, VALID_STORE, NO_STORE
-from rdflib.term import URIRef
+from os.path import abspath, exists
+from threading import Thread
 from urllib.request import pathname2url
+
+from rdflib.store import NO_STORE, VALID_STORE, Store
+from rdflib.term import URIRef
 
 
 def bb(u):

--- a/rdflib/plugins/stores/regexmatching.py
+++ b/rdflib/plugins/stores/regexmatching.py
@@ -8,11 +8,10 @@ provides the support by replacing the REGEXTerms by wildcards (None) and
 matching against the results from the store it's wrapping.
 """
 
-from rdflib.store import Store
-from rdflib.graph import Graph
-
-
 import re
+
+from rdflib.graph import Graph
+from rdflib.store import Store
 
 # Store is capable of doing its own REGEX matching
 NATIVE_REGEX = 0

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -1,14 +1,13 @@
-import logging
-from typing import Optional, TYPE_CHECKING, Tuple
-from urllib.request import urlopen, Request
-from urllib.parse import urlencode
-from urllib.error import HTTPError, URLError
 import base64
-
+import logging
 from io import BytesIO
+from typing import TYPE_CHECKING, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
-from rdflib.query import Result
 from rdflib import BNode
+from rdflib.query import Result
 
 log = logging.getLogger(__name__)
 

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -5,18 +5,17 @@ This is an RDFLib store around Ivan Herman et al.'s SPARQL service wrapper.
 This was first done in layer-cake, and then ported to RDFLib
 
 """
-import re
 import collections
+import re
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from rdflib import BNode, Variable
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.plugins.stores.regexmatching import NATIVE_REGEX
+from rdflib.store import Store
+from rdflib.term import Node
 
 from .sparqlconnector import SPARQLConnector
-
-from rdflib.plugins.stores.regexmatching import NATIVE_REGEX
-
-from rdflib.store import Store
-from rdflib import Variable, BNode
-from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
-from rdflib.term import Node
-from typing import Any, Callable, Dict, Optional, Union, Tuple
 
 # Defines some SPARQL keywords
 LIMIT = "LIMIT"

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -1,13 +1,11 @@
-import os
 import itertools
+import os
 import shutil
 import tempfile
-import warnings
 import types
-from typing import IO, TYPE_CHECKING, List, Optional, Union, cast
-
+import warnings
 from io import BytesIO
-
+from typing import IO, TYPE_CHECKING, List, Optional, Union, cast
 from urllib.parse import urlparse
 
 __all__ = ["Processor", "Result", "ResultParser", "ResultSerializer", "ResultException"]

--- a/rdflib/resource.py
+++ b/rdflib/resource.py
@@ -286,9 +286,9 @@ objects::
 
 """
 
-from rdflib.term import Node, BNode, URIRef
 from rdflib.namespace import RDF
 from rdflib.paths import Path
+from rdflib.term import BNode, Node, URIRef
 
 __all__ = ["Resource"]
 

--- a/rdflib/serializer.py
+++ b/rdflib/serializer.py
@@ -11,6 +11,7 @@ See also rdflib.plugin
 """
 
 from typing import IO, TYPE_CHECKING, Optional
+
 from rdflib.term import URIRef
 
 if TYPE_CHECKING:

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -1,11 +1,12 @@
-from io import BytesIO
 import pickle
+from io import BytesIO
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple
+
 from rdflib.events import Dispatcher, Event
-from typing import Tuple, TYPE_CHECKING, Iterable, Optional
 
 if TYPE_CHECKING:
-    from rdflib.term import Node
     from rdflib.graph import Graph
+    from rdflib.term import Node
 
 """
 ============
@@ -153,11 +154,8 @@ class Store(object):
 
     def __get_node_pickler(self):
         if self.__node_pickler is None:
-            from rdflib.term import URIRef
-            from rdflib.term import BNode
-            from rdflib.term import Literal
             from rdflib.graph import Graph, QuotedGraph
-            from rdflib.term import Variable
+            from rdflib.term import BNode, Literal, URIRef, Variable
 
             self.__node_pickler = np = NodePickler()
             np.register(self, "S")

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -21,7 +21,6 @@ underlying Graph:
 
 """
 import re
-
 from fractions import Fraction
 
 __all__ = [
@@ -36,38 +35,26 @@ __all__ = [
 ]
 
 import logging
-import warnings
 import math
-
+import warnings
 import xml.dom.minidom
-
-from datetime import date, time, datetime, timedelta
-from re import sub, compile
-from collections import defaultdict
-
-from isodate import (
-    parse_time,
-    parse_date,
-    parse_datetime,
-    Duration,
-    parse_duration,
-    duration_isoformat,
-)
 from base64 import b64decode, b64encode
 from binascii import hexlify, unhexlify
+from collections import defaultdict
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from re import compile, sub
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type, Union
+from urllib.parse import urldefrag, urljoin, urlparse
+
+from isodate import (Duration, duration_isoformat, parse_date, parse_datetime,
+                     parse_duration, parse_time)
 
 import rdflib
 from rdflib.compat import long_type
 
-from urllib.parse import urldefrag
-from urllib.parse import urljoin
-from urllib.parse import urlparse
-
-from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, Callable, Optional, Union, Type
-
 if TYPE_CHECKING:
-    from .paths import AlternativePath, InvPath, NegatedPath, SequencePath, Path
+    from .paths import AlternativePath, InvPath, NegatedPath, Path, SequencePath
 
 logger = logging.getLogger(__name__)
 skolem_genid = "/.well-known/genid/"

--- a/rdflib/tools/csv2rdf.py
+++ b/rdflib/tools/csv2rdf.py
@@ -7,17 +7,16 @@ try: ``csv2rdf --help``
 
 """
 
-import sys
-import re
-import csv
-import getopt
-import fileinput
 import codecs
-import time
-import datetime
-import warnings
-
 import configparser
+import csv
+import datetime
+import fileinput
+import getopt
+import re
+import sys
+import time
+import warnings
 from urllib.parse import quote
 
 import rdflib

--- a/rdflib/tools/defined_namespace_creator.py
+++ b/rdflib/tools/defined_namespace_creator.py
@@ -10,10 +10,10 @@ namespace:
 
 Nicholas J. Car, Dec, 2021
 """
-import sys
-from pathlib import Path
 import argparse
 import datetime
+import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.absolute().parent.parent))
 

--- a/rdflib/tools/graphisomorphism.py
+++ b/rdflib/tools/graphisomorphism.py
@@ -3,9 +3,9 @@ A commandline tool for testing if RDF graphs are isomorpic, i.e. equal
 if BNode labels are ignored.
 """
 
-from rdflib import Graph
-from rdflib import BNode
 from itertools import combinations
+
+from rdflib import BNode, Graph
 
 
 class IsomorphicTestableGraph(Graph):

--- a/rdflib/tools/rdf2dot.py
+++ b/rdflib/tools/rdf2dot.py
@@ -9,13 +9,12 @@ You can draw the graph of an RDF file directly:
 
 """
 
+import collections
+import html
+import sys
+
 import rdflib
 import rdflib.extras.cmdlineutils
-
-import sys
-import html
-import collections
-
 from rdflib import XSD
 
 LABEL_PROPERTIES = [

--- a/rdflib/tools/rdfpipe.py
+++ b/rdflib/tools/rdfpipe.py
@@ -5,19 +5,17 @@ A commandline tool for parsing RDF in different formats and serializing the
 resulting graph to a chosen format.
 """
 
+import logging
 import sys
 from optparse import OptionParser
-import logging
 
 import rdflib
 from rdflib import plugin
-from rdflib.store import Store
 from rdflib.graph import ConjunctiveGraph
 from rdflib.parser import Parser
 from rdflib.serializer import Serializer
-
+from rdflib.store import Store
 from rdflib.util import guess_format
-
 
 DEFAULT_INPUT_FORMAT = "xml"
 DEFAULT_OUTPUT_FORMAT = "n3"

--- a/rdflib/tools/rdfs2dot.py
+++ b/rdflib/tools/rdfs2dot.py
@@ -9,15 +9,12 @@ You can draw the graph of an RDFS file directly:
    rdf2dot my_rdfs_file.rdf | dot -Tpng | display
 """
 
-import rdflib.extras.cmdlineutils
-
-import sys
-import itertools
 import collections
+import itertools
+import sys
 
-
-from rdflib import XSD, RDF, RDFS
-
+import rdflib.extras.cmdlineutils
+from rdflib import RDF, RDFS, XSD
 
 XSDTERMS = [
     XSD[x]

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -30,28 +30,17 @@ Statement and component type checkers
 """
 
 from calendar import timegm
-from time import altzone
+from os.path import splitext
+# from time import daylight
+from time import altzone, gmtime, localtime, time, timezone
 from typing import Optional
 
-# from time import daylight
-from time import gmtime
-from time import localtime
-from time import time
-from time import timezone
-
-from os.path import splitext
-
-from rdflib.exceptions import ContextTypeError
-from rdflib.exceptions import ObjectTypeError
-from rdflib.exceptions import PredicateTypeError
-from rdflib.exceptions import SubjectTypeError
 import rdflib.graph  # avoid circular dependency
-from rdflib.namespace import Namespace
-from rdflib.namespace import NamespaceManager
-from rdflib.term import BNode
-from rdflib.term import Literal
-from rdflib.term import URIRef
 from rdflib.compat import sign
+from rdflib.exceptions import (ContextTypeError, ObjectTypeError, PredicateTypeError,
+                               SubjectTypeError)
+from rdflib.namespace import Namespace, NamespaceManager
+from rdflib.term import BNode, Literal, URIRef
 
 __all__ = [
     "list2set",

--- a/rdflib/void.py
+++ b/rdflib/void.py
@@ -1,7 +1,7 @@
 import collections
 
-from rdflib import URIRef, Graph, Literal
-from rdflib.namespace import VOID, RDF
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF, VOID
 
 
 def generateVoID(g, dataset=None, res=None, distinctForPartitions=True):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,12 +4,13 @@ doctest-ignore-unicode==0.1.2
 flake8
 flake8-black
 html5lib
+isort
 mypy
+myst-parser
 pytest
 pytest-cov
 pytest-subtests
 sphinx
 sphinxcontrib-apidoc
-myst-parser
-types-setuptools
 sphinxcontrib-kroki
+types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+import codecs
 import os
 import re
-import codecs
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 kwargs = {}
 kwargs["install_requires"] = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
-from .earl import EarlReporter
 import pytest
+
+from .earl import EarlReporter
 
 pytest_plugins = [EarlReporter.__module__]
 

--- a/test/earl.py
+++ b/test/earl.py
@@ -9,7 +9,6 @@ from test.manifest import RDFT
 from typing import TYPE_CHECKING, Generator, Optional, Tuple, cast
 
 import pytest
-
 from pytest import Item
 
 from rdflib import RDF, BNode, Graph, Literal, Namespace, URIRef

--- a/test/helper.py
+++ b/test/helper.py
@@ -4,7 +4,6 @@ import urllib.error
 import rdflib
 import rdflib.query
 
-
 MAX_RETRY = 10
 BACKOFF_FACTOR = 1.5
 

--- a/test/jsonld/__init__.py
+++ b/test/jsonld/__init__.py
@@ -1,6 +1,4 @@
-from rdflib import plugin
-from rdflib import serializer
-from rdflib import parser
+from rdflib import parser, plugin, serializer
 
 assert plugin
 assert serializer

--- a/test/jsonld/runner.py
+++ b/test/jsonld/runner.py
@@ -1,13 +1,13 @@
 # -*- coding: UTF-8 -*-
 import json
+
 from rdflib import ConjunctiveGraph
 from rdflib.compare import isomorphic
 from rdflib.plugins.parsers.jsonld import to_rdf
+# monkey-patch N-Quads parser via it's underlying W3CNTriplesParser to keep source bnode id:s ..
+from rdflib.plugins.parsers.ntriples import W3CNTriplesParser, bNode, r_nodeid
 from rdflib.plugins.serializers.jsonld import from_rdf
 from rdflib.plugins.shared.jsonld.keys import CONTEXT, GRAPH
-
-# monkey-patch N-Quads parser via it's underlying W3CNTriplesParser to keep source bnode id:s ..
-from rdflib.plugins.parsers.ntriples import W3CNTriplesParser, r_nodeid, bNode
 
 
 def _preserving_nodeid(self, bnode_context=None):

--- a/test/jsonld/test_api.py
+++ b/test/jsonld/test_api.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-from rdflib.plugin import register, Parser, Serializer
+from rdflib.plugin import Parser, Serializer, register
 
 register("json-ld", Parser, "rdflib.plugins.parsers.jsonld", "JsonLDParser")
 register("json-ld", Serializer, "rdflib.plugins.serializers.jsonld", "JsonLDSerializer")

--- a/test/jsonld/test_compaction.py
+++ b/test/jsonld/test_compaction.py
@@ -1,12 +1,13 @@
 # -*- coding: UTF-8 -*-
 
-import re
-import json
 import itertools
+import json
+import re
 
 import pytest
+
 from rdflib import Graph
-from rdflib.plugin import register, Serializer
+from rdflib.plugin import Serializer, register
 
 register("json-ld", Serializer, "rdflib.plugins.serializers.jsonld", "JsonLDSerializer")
 

--- a/test/jsonld/test_context.py
+++ b/test/jsonld/test_context.py
@@ -4,9 +4,9 @@ JSON-LD Context Spec
 
 from functools import wraps
 from typing import Any, Dict
+
+from rdflib.plugins.shared.jsonld import context, errors
 from rdflib.plugins.shared.jsonld.context import Context, Term
-from rdflib.plugins.shared.jsonld import context
-from rdflib.plugins.shared.jsonld import errors
 
 
 # exception utility (see also nose.tools.raises)

--- a/test/jsonld/test_localsuite.py
+++ b/test/jsonld/test_localsuite.py
@@ -1,12 +1,13 @@
-import os
-from os import environ, chdir, getcwd, path as p
 import json
+import os
+from os import chdir, environ, getcwd
+from os import path as p
 
 import pytest
 
 from rdflib.term import URIRef
-from . import runner
 
+from . import runner
 
 TC_BASE = "http://rdflib.net/rdflib-jsonld/local-testsuite/"
 
@@ -37,9 +38,7 @@ def get_test_suite_cases():
                 func = runner.do_test_parser
         else:  # fromRdf
             func = runner.do_test_serializer
-        rdf_test_uri = URIRef("{0}{1}-manifest.jsonld#t{2}".format(
-            TC_BASE, cat, num
-        ))
+        rdf_test_uri = URIRef("{0}{1}-manifest.jsonld#t{2}".format(TC_BASE, cat, num))
         yield rdf_test_uri, func, TC_BASE, cat, num, inputpath, expectedpath, context, options
 
 
@@ -55,5 +54,15 @@ def testsuide_dir():
     "rdf_test_uri, func, suite_base, cat, num, inputpath, expectedpath, context, options",
     get_test_suite_cases(),
 )
-def test_suite(rdf_test_uri: URIRef, func, suite_base, cat, num, inputpath, expectedpath, context, options):
+def test_suite(
+    rdf_test_uri: URIRef,
+    func,
+    suite_base,
+    cat,
+    num,
+    inputpath,
+    expectedpath,
+    context,
+    options,
+):
     func(suite_base, cat, num, inputpath, expectedpath, context, options)

--- a/test/jsonld/test_named_graphs.py
+++ b/test/jsonld/test_named_graphs.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 from rdflib import *
-from rdflib.plugin import register, Parser
+from rdflib.plugin import Parser, register
 
 register("json-ld", Parser, "rdflib.plugins.parsers.jsonld", "JsonLDParser")
 register("application/ld+json", Parser, "rdflib.plugins.parsers.jsonld", "JsonLDParser")

--- a/test/jsonld/test_onedotone.py
+++ b/test/jsonld/test_onedotone.py
@@ -1,14 +1,14 @@
-from os import environ, chdir, getcwd, path as p
 import json
 import os
+from os import chdir, environ, getcwd
+from os import path as p
 from typing import Tuple
-
 
 import pytest
 
 from rdflib.term import URIRef
-from . import runner
 
+from . import runner
 
 TC_BASE = "https://w3c.github.io/json-ld-api/tests/toRdf/"
 
@@ -141,7 +141,7 @@ known_bugs: Tuple[str, ...] = (
 
 if os.name == "nt":
     # nquad parser does not correctly handle unnormalized unicode on windows.
-    known_bugs += ("toRdf/js11-in", )
+    known_bugs += ("toRdf/js11-in",)
 
 TC_BASE = "https://w3c.github.io/json-ld-api/tests/"
 allow_lists_of_lists = True
@@ -197,9 +197,7 @@ def get_test_suite_cases():
     if SKIP_KNOWN_BUGS:
         skiptests += known_bugs
 
-    for cat, num, inputpath, expectedpath, context, options in read_manifest(
-        skiptests
-    ):
+    for cat, num, inputpath, expectedpath, context, options in read_manifest(skiptests):
         if options:
             if (
                 SKIP_1_0_TESTS
@@ -215,9 +213,7 @@ def get_test_suite_cases():
                 func = runner.do_test_parser
         else:  # fromRdf
             func = runner.do_test_serializer
-        rdf_test_uri = URIRef("{0}{1}-manifest#t{2}".format(
-            TC_BASE, cat, num
-        ))
+        rdf_test_uri = URIRef("{0}{1}-manifest#t{2}".format(TC_BASE, cat, num))
         yield rdf_test_uri, func, TC_BASE, cat, num, inputpath, expectedpath, context, options
 
 
@@ -233,5 +229,15 @@ def global_state():
     "rdf_test_uri, func, suite_base, cat, num, inputpath, expectedpath, context, options",
     get_test_suite_cases(),
 )
-def test_suite(rdf_test_uri: URIRef, func, suite_base, cat, num, inputpath, expectedpath, context, options):
+def test_suite(
+    rdf_test_uri: URIRef,
+    func,
+    suite_base,
+    cat,
+    num,
+    inputpath,
+    expectedpath,
+    context,
+    options,
+):
     func(suite_base, cat, num, inputpath, expectedpath, context, options)

--- a/test/jsonld/test_pythonparse.py
+++ b/test/jsonld/test_pythonparse.py
@@ -1,6 +1,7 @@
+import json
+
 from rdflib import Graph
 from rdflib.compare import isomorphic
-import json
 
 
 def test_wrap():

--- a/test/jsonld/test_testsuite.py
+++ b/test/jsonld/test_testsuite.py
@@ -1,13 +1,15 @@
-from os import environ, chdir, getcwd, path as p
 import json
+from os import chdir, environ, getcwd
+from os import path as p
 from typing import Tuple
 
 import pytest
+
 import rdflib
 import rdflib.plugins.parsers.jsonld as parser
 from rdflib.term import URIRef
-from . import runner
 
+from . import runner
 
 unsupported_tests: Tuple[str, ...] = ("frame", "normalize")
 unsupported_tests += (
@@ -82,9 +84,7 @@ def get_test_suite_cases(skip_known_bugs=True):
     skiptests = unsupported_tests
     if skip_known_bugs:
         skiptests += known_bugs
-    for cat, num, inputpath, expectedpath, context, options in read_manifest(
-        skiptests
-    ):
+    for cat, num, inputpath, expectedpath, context, options in read_manifest(skiptests):
         if inputpath.endswith(".jsonld"):  # toRdf
             if expectedpath.endswith(".jsonld"):  # compact/expand/flatten
                 func = runner.do_test_json
@@ -93,9 +93,7 @@ def get_test_suite_cases(skip_known_bugs=True):
         else:  # fromRdf
             func = runner.do_test_serializer
         # func.description = "%s-%s-%s" % (group, case)
-        rdf_test_uri = URIRef("{0}{1}-manifest.jsonld#t{2}".format(
-            TC_BASE, cat, num
-        ))
+        rdf_test_uri = URIRef("{0}{1}-manifest.jsonld#t{2}".format(TC_BASE, cat, num))
         yield rdf_test_uri, func, TC_BASE, cat, num, inputpath, expectedpath, context, options
 
 
@@ -117,5 +115,15 @@ def global_state():
     "rdf_test_uri, func, suite_base, cat, num, inputpath, expectedpath, context, options",
     get_test_suite_cases(),
 )
-def test_suite(rdf_test_uri: URIRef, func, suite_base, cat, num, inputpath, expectedpath, context, options):
+def test_suite(
+    rdf_test_uri: URIRef,
+    func,
+    suite_base,
+    cat,
+    num,
+    inputpath,
+    expectedpath,
+    context,
+    options,
+):
     func(suite_base, cat, num, inputpath, expectedpath, context, options)

--- a/test/store_performance.py
+++ b/test/store_performance.py
@@ -1,15 +1,14 @@
-import unittest
-import os
 import gc
 import itertools
-from time import time
-from random import random
-
-from tempfile import mkdtemp
+import os
 import shutil
+import unittest
+from random import random
+from tempfile import mkdtemp
+from time import time
 
-from rdflib.term import URIRef
 from rdflib.graph import Graph
+from rdflib.term import URIRef
 
 
 def random_uri():

--- a/test/test_aggregate_graphs.py
+++ b/test/test_aggregate_graphs.py
@@ -1,10 +1,10 @@
-from rdflib.namespace import RDF, RDFS
-from rdflib import logger, plugin
 from io import StringIO
-from rdflib.term import URIRef
-from rdflib.store import Store
-from rdflib.graph import Graph, ConjunctiveGraph, ReadOnlyGraphAggregate
 
+from rdflib import logger, plugin
+from rdflib.graph import ConjunctiveGraph, Graph, ReadOnlyGraphAggregate
+from rdflib.namespace import RDF, RDFS
+from rdflib.store import Store
+from rdflib.term import URIRef
 
 testGraph1N3 = """
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/test/test_b64_binary.py
+++ b/test/test_b64_binary.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import base64
-from rdflib import Literal, XSD
+import unittest
+
+from rdflib import XSD, Literal
 
 
 class B64BinaryTestCase(unittest.TestCase):

--- a/test/test_batch_add.py
+++ b/test/test_batch_add.py
@@ -1,5 +1,6 @@
 import unittest
-from rdflib.graph import Graph, BatchAddGraph
+
+from rdflib.graph import BatchAddGraph, Graph
 from rdflib.term import URIRef
 
 

--- a/test/test_bnode_ncname.py
+++ b/test/test_bnode_ncname.py
@@ -3,7 +3,6 @@ import re
 from hashlib import md5
 from uuid import uuid4
 
-
 # Adapted from http://icodesnip.com/snippet/python/simple-universally-unique-id-uuid-or-guid
 
 

--- a/test/test_canonicalization.py
+++ b/test/test_canonicalization.py
@@ -1,18 +1,17 @@
+import unittest
 from collections import Counter
+from io import StringIO
 from typing import Set, Tuple
 from unittest.case import expectedFailure
 
 import pytest
-from rdflib.term import Node
-from rdflib import Graph, RDF, BNode, URIRef, Namespace, ConjunctiveGraph, Literal
-from rdflib.namespace import FOAF
-from rdflib.compare import to_isomorphic, to_canonical_graph
 
 import rdflib
+from rdflib import RDF, BNode, ConjunctiveGraph, Graph, Literal, Namespace, URIRef
+from rdflib.compare import to_canonical_graph, to_isomorphic
+from rdflib.namespace import FOAF
 from rdflib.plugins.stores.memory import Memory
-
-from io import StringIO
-import unittest
+from rdflib.term import Node
 
 from .testutils import GraphHelper
 

--- a/test/test_comparison.py
+++ b/test/test_comparison.py
@@ -1,15 +1,9 @@
 import unittest
 
-from rdflib.namespace import RDF
-
-from rdflib.term import URIRef
-from rdflib.term import BNode
-from rdflib.term import Literal
-
 from rdflib.graph import Graph
-
+from rdflib.namespace import RDF
 from rdflib.plugins.parsers.rdfxml import CORE_SYNTAX_TERMS
-
+from rdflib.term import BNode, Literal, URIRef
 
 """
 Ah... it's coming back to me...

--- a/test/test_conjunctive_graph.py
+++ b/test/test_conjunctive_graph.py
@@ -2,13 +2,13 @@
 Tests for ConjunctiveGraph that do not depend on the underlying store
 """
 
+from os import path
+
 import pytest
 
 from rdflib import ConjunctiveGraph, Graph
-from rdflib.term import Identifier, URIRef, BNode
 from rdflib.parser import StringInputSource
-from os import path
-
+from rdflib.term import BNode, Identifier, URIRef
 
 DATA = """
 <http://example.org/record/1> a <http://xmlns.com/foaf/0.1/Document> .

--- a/test/test_conjunctivegraph_generators.py
+++ b/test/test_conjunctivegraph_generators.py
@@ -1,6 +1,6 @@
 import os
-from rdflib import ConjunctiveGraph, URIRef
 
+from rdflib import ConjunctiveGraph, URIRef
 
 timblcardn3 = open(
     os.path.join(os.path.dirname(__file__), "consistent_test_data", "timbl-card.n3")

--- a/test/test_conjunctivegraph_operator_combinations.py
+++ b/test/test_conjunctivegraph_operator_combinations.py
@@ -1,10 +1,6 @@
 import os
-from rdflib import (
-    Graph,
-    ConjunctiveGraph,
-    URIRef,
-)
 
+from rdflib import ConjunctiveGraph, Graph, URIRef
 
 michel = URIRef("urn:example:michel")
 tarek = URIRef("urn:example:tarek")

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -1,8 +1,8 @@
-from rdflib.term import BNode
-from rdflib.term import Literal
+import unittest
+
 from rdflib import Graph
 from rdflib.container import Alt, Bag, Seq
-import unittest
+from rdflib.term import BNode, Literal
 
 
 class TestContainer(unittest.TestCase):

--- a/test/test_conventions.py
+++ b/test/test_conventions.py
@@ -1,6 +1,6 @@
-import unittest
-import pkgutil
 import os.path
+import pkgutil
+import unittest
 
 import rdflib
 

--- a/test/test_csv2rdf.py
+++ b/test/test_csv2rdf.py
@@ -1,9 +1,9 @@
 import subprocess
-import unittest
 import sys
-from os import remove, close
-from tempfile import mkstemp
+import unittest
+from os import close, remove
 from pathlib import Path
+from tempfile import mkstemp
 
 
 class CSV2RDFTest(unittest.TestCase):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,12 +1,12 @@
-import sys
 import os
-from typing import Optional
-import unittest
-
-from tempfile import mkdtemp, mkstemp
 import shutil
+import sys
+import unittest
+from tempfile import mkdtemp, mkstemp
+from typing import Optional
 
 import pytest
+
 from rdflib import Dataset, URIRef, plugin
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 

--- a/test/test_dataset_generators.py
+++ b/test/test_dataset_generators.py
@@ -1,4 +1,5 @@
 import os
+
 from rdflib import Dataset, URIRef
 
 timblcardn3 = open(

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -1,14 +1,12 @@
 import sys
 import unittest
-
 from datetime import datetime
 
-from isodate import datetime_isoformat, UTC
+from isodate import UTC, datetime_isoformat
 from isodate.isostrf import DATE_EXT_COMPLETE, TZ_EXT
 
-from rdflib.term import URIRef
-from rdflib.term import Literal
 from rdflib.namespace import XSD
+from rdflib.term import Literal, URIRef
 
 
 class TestRelativeBase(unittest.TestCase):

--- a/test/test_dawg.py
+++ b/test/test_dawg.py
@@ -1,45 +1,40 @@
 from __future__ import print_function
 
 import os
-from pathlib import PurePath
 import sys
 from io import TextIOWrapper
-
+from pathlib import PurePath
 # Needed to pass
 # http://www.w3.org/2009/sparql/docs/tests/data-sparql11/
 #           syntax-update-2/manifest#syntax-update-other-01
 from test import TEST_DIR
-from test.manifest import UP, MF, RDFTest, ResultType, read_manifest
-import pytest
-
+from test.manifest import MF, UP, RDFTest, ResultType, read_manifest
 from test.testutils import file_uri_to_path
+
+import pytest
 
 sys.setrecursionlimit(6000)  # default is 1000
 
 
-from collections import Counter
-
-
 import datetime
-import isodate
 import typing
-from typing import Dict, Callable, List, Optional, Tuple, cast
+from collections import Counter
+from io import BytesIO
+from typing import Callable, Dict, List, Optional, Tuple, cast
+from urllib.parse import urljoin
 
+import isodate
 
-from rdflib import Dataset, Graph, URIRef, BNode
-from rdflib.term import Identifier, Node
-from rdflib.query import Result
+from rdflib import BNode, Dataset, Graph, URIRef
 from rdflib.compare import isomorphic
-
+from rdflib.compat import bopen, decodeStringEscape
 from rdflib.plugins import sparql as rdflib_sparql_module
 from rdflib.plugins.sparql.algebra import pprintAlgebra, translateQuery, translateUpdate
 from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
 from rdflib.plugins.sparql.results.rdfresults import RDFResultParser
 from rdflib.plugins.sparql.update import evalUpdate
-
-from rdflib.compat import decodeStringEscape, bopen
-from urllib.parse import urljoin
-from io import BytesIO
+from rdflib.query import Result
+from rdflib.term import Identifier, Node
 
 
 def eq(a, b, msg):

--- a/test/test_definednamespace_creator.py
+++ b/test/test_definednamespace_creator.py
@@ -1,5 +1,5 @@
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -8,7 +8,12 @@ def test_definednamespace_creator_qb():
     Tests basic use of DefinedNamespace creator script using QB
     """
 
-    definednamespace_script = Path(__file__).parent.parent / "rdflib" / "tools" / "defined_namespace_creator.py"
+    definednamespace_script = (
+        Path(__file__).parent.parent
+        / "rdflib"
+        / "tools"
+        / "defined_namespace_creator.py"
+    )
     qb_data_file = Path(__file__).parent / "defined_namespaces" / "qb.ttl"
     print("\n")
     print(f"Using {definednamespace_script}...")
@@ -33,7 +38,10 @@ def test_definednamespace_creator_qb():
         for line in f.readlines():
             if '_NS = Namespace("http://purl.org/linked-data/cube#")' in line:
                 has_ns = True
-            if 'Attachable: URIRef  # Abstract superclass for everything that can have attributes and dimensions' in line:
+            if (
+                "Attachable: URIRef  # Abstract superclass for everything that can have attributes and dimensions"
+                in line
+            ):
                 has_test_class = True
     assert has_ns, "_QB.py does not contain _NS"
     assert has_test_class, "_QB.py does not class Attachable"
@@ -48,7 +56,12 @@ def test_definednamespace_creator_fake():
     RDF file of unknonwn type
     """
 
-    definednamespace_script = Path(__file__).parent.parent / "rdflib" / "tools" / "defined_namespace_creator.py"
+    definednamespace_script = (
+        Path(__file__).parent.parent
+        / "rdflib"
+        / "tools"
+        / "defined_namespace_creator.py"
+    )
     qb_data_file = Path(__file__).parent / "defined_namespaces" / "fake.xxx"
     print("\n")
     print(f"Using {definednamespace_script}...")
@@ -74,7 +87,12 @@ def test_definednamespace_creator_bad_ns():
     supplied namespace doesn't end in # or /
     """
 
-    definednamespace_script = Path(__file__).parent.parent / "rdflib" / "tools" / "defined_namespace_creator.py"
+    definednamespace_script = (
+        Path(__file__).parent.parent
+        / "rdflib"
+        / "tools"
+        / "defined_namespace_creator.py"
+    )
     qb_data_file = Path(__file__).parent / "defined_namespaces" / "fake.xxx"
     print("\n")
     print(f"Using {definednamespace_script}...")

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -1,11 +1,13 @@
-from typing import Set, Tuple
 import unittest
+from typing import Set, Tuple
 from unittest.case import expectedFailure
+
 import rdflib
-from rdflib.compare import graph_diff
-from rdflib.namespace import RDF, FOAF
 from rdflib import Graph
-from rdflib.term import Node, BNode, Literal
+from rdflib.compare import graph_diff
+from rdflib.namespace import FOAF, RDF
+from rdflib.term import BNode, Literal, Node
+
 from .testutils import GraphHelper
 
 """Test for graph_diff - much more extensive testing

--- a/test/test_empty_xml_base.py
+++ b/test/test_empty_xml_base.py
@@ -5,13 +5,12 @@ xml:base='' should resolve to the given publicID per XML Base specification
 and RDF/XML dependence on it
 """
 
-from rdflib.graph import ConjunctiveGraph
-from rdflib.term import URIRef
-from rdflib.namespace import RDF, FOAF
+import unittest
 from io import StringIO
 
-import unittest
-
+from rdflib.graph import ConjunctiveGraph
+from rdflib.namespace import FOAF, RDF
+from rdflib.term import URIRef
 
 test_data = """
 <rdf:RDF

--- a/test/test_evaluate_bind.py
+++ b/test/test_evaluate_bind.py
@@ -4,7 +4,7 @@ Verify evaluation of BIND expressions of different types. See
 """
 import pytest
 
-from rdflib import Graph, URIRef, Literal, Variable
+from rdflib import Graph, Literal, URIRef, Variable
 
 
 def get_bind_tests():
@@ -36,6 +36,7 @@ def get_bind_tests():
         "type",
         URIRef("http://example.org/ns#Thing"),
     )
+
 
 @pytest.mark.parametrize("checker, expr, var, obj", get_bind_tests())
 def test_bind(checker, expr, var, obj) -> None:

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,4 +1,5 @@
 import unittest
+
 from rdflib import events
 
 

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -1,11 +1,10 @@
 from functools import partial
 
 import rdflib.plugins.sparql.parser as p
-from rdflib.plugins.sparql.sparql import QueryContext, SPARQLError, Prologue
-from rdflib.plugins.sparql.algebra import traverse, translatePName
+from rdflib import Literal, Variable
+from rdflib.plugins.sparql.algebra import translatePName, traverse
 from rdflib.plugins.sparql.operators import simplify
-
-from rdflib import Variable, Literal
+from rdflib.plugins.sparql.sparql import Prologue, QueryContext, SPARQLError
 
 from .testutils import eq_ as eq
 

--- a/test/test_extras_external_graph_libs.py
+++ b/test/test_extras_external_graph_libs.py
@@ -1,14 +1,16 @@
-from rdflib import Graph, URIRef, Literal
 import pytest
+
+from rdflib import Graph, Literal, URIRef
+
 
 def test_rdflib_to_networkx():
     try:
         import networkx
     except ImportError:
         pytest.skip("couldn't find networkx")
-    from rdflib.extras.external_graph_libs import rdflib_to_networkx_multidigraph
-    from rdflib.extras.external_graph_libs import rdflib_to_networkx_digraph
-    from rdflib.extras.external_graph_libs import rdflib_to_networkx_graph
+    from rdflib.extras.external_graph_libs import (rdflib_to_networkx_digraph,
+                                                   rdflib_to_networkx_graph,
+                                                   rdflib_to_networkx_multidigraph)
 
     g = Graph()
     a, b, l = URIRef("a"), URIRef("b"), Literal("l")

--- a/test/test_finalnewline.py
+++ b/test/test_finalnewline.py
@@ -1,5 +1,5 @@
-from rdflib import ConjunctiveGraph, URIRef
 import rdflib.plugin
+from rdflib import ConjunctiveGraph, URIRef
 
 
 def testFinalNewline():

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,21 +1,18 @@
-import sys
 import os
-import unittest
-
-from tempfile import mkdtemp, mkstemp
 import shutil
-from urllib.error import URLError, HTTPError
+import sys
+import unittest
+from pathlib import Path
+from tempfile import mkdtemp, mkstemp
+from test.testutils import GraphHelper
+from urllib.error import HTTPError, URLError
 
 import pytest
 
-from rdflib import URIRef, Graph, plugin
+from rdflib import Graph, URIRef, plugin
 from rdflib.exceptions import ParserError
-from rdflib.plugin import PluginException
 from rdflib.namespace import Namespace
-
-from pathlib import Path
-
-from test.testutils import GraphHelper
+from rdflib.plugin import PluginException
 
 
 class GraphTestCase(unittest.TestCase):

--- a/test/test_graph_cbd.py
+++ b/test/test_graph_cbd.py
@@ -1,6 +1,6 @@
 import pytest
-from rdflib import Graph, Namespace
 
+from rdflib import Graph, Namespace
 
 """Tests the Graph class' cbd() function"""
 

--- a/test/test_graph_context.py
+++ b/test/test_graph_context.py
@@ -1,12 +1,13 @@
-import sys
 import os
-import unittest
-
-from tempfile import mkdtemp, mkstemp
 import shutil
+import sys
+import unittest
+from tempfile import mkdtemp, mkstemp
 
 import pytest
-from rdflib import Graph, ConjunctiveGraph, URIRef, BNode, plugin
+
+from rdflib import BNode, ConjunctiveGraph, Graph, URIRef, plugin
+
 
 class ContextTestCase(unittest.TestCase):
     store = "default"

--- a/test/test_graph_formula.py
+++ b/test/test_graph_formula.py
@@ -1,11 +1,11 @@
-import sys
 import os
+import sys
 from tempfile import mkdtemp, mkstemp
 
 import pytest
-from rdflib import RDF, RDFS, URIRef, BNode, Variable, plugin
-from rdflib.graph import QuotedGraph, ConjunctiveGraph
 
+from rdflib import RDF, RDFS, BNode, URIRef, Variable, plugin
+from rdflib.graph import ConjunctiveGraph, QuotedGraph
 
 implies = URIRef("http://www.w3.org/2000/10/swap/log#implies")
 testN3 = """
@@ -139,6 +139,7 @@ def get_formula_stores_tests():
         if not s.getClass().formula_aware:
             continue
         yield checkFormulaStore, s.name
+
 
 @pytest.mark.parametrize("checker, name", get_formula_stores_tests())
 def test_formula_stores(checker, name) -> None:

--- a/test/test_graph_generators.py
+++ b/test/test_graph_generators.py
@@ -1,4 +1,5 @@
 import os
+
 from rdflib import Graph, URIRef
 
 michel = URIRef("urn:example:michel")

--- a/test/test_graph_http.py
+++ b/test/test_graph_http.py
@@ -1,10 +1,10 @@
-from rdflib import Graph, Namespace
-
+import unittest
 from http.server import BaseHTTPRequestHandler
 from urllib.error import HTTPError
-from .testutils import SimpleHTTPMock, MockHTTPResponse, ctx_http_server, GraphHelper
-import unittest
 
+from rdflib import Graph, Namespace
+
+from .testutils import GraphHelper, MockHTTPResponse, SimpleHTTPMock, ctx_http_server
 
 """
 Test that correct content negotiation headers are passed

--- a/test/test_graph_items.py
+++ b/test/test_graph_items.py
@@ -1,4 +1,4 @@
-from rdflib import Graph, RDF
+from rdflib import RDF, Graph
 
 
 def test_recursive_list_detection():

--- a/test/test_hex_binary.py
+++ b/test/test_hex_binary.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import binascii
-from rdflib import Literal, XSD
+import unittest
+
+from rdflib import XSD, Literal
 
 
 class HexBinaryTestCase(unittest.TestCase):

--- a/test/test_infixowl.py
+++ b/test/test_infixowl.py
@@ -1,18 +1,9 @@
-from rdflib import BNode, Graph, Literal, Namespace, RDFS, OWL, XSD
+from rdflib import OWL, RDFS, XSD, BNode, Graph, Literal, Namespace
+from rdflib.extras.infixowl import (BooleanClass, Class, Collection, DeepClassClear,
+                                    EnumeratedClass, Individual, Property, Restriction,
+                                    max, some)
 from rdflib.namespace import NamespaceManager
 from rdflib.util import first
-from rdflib.extras.infixowl import (
-    BooleanClass,
-    Class,
-    Collection,
-    DeepClassClear,
-    Individual,
-    some,
-    EnumeratedClass,
-    Property,
-    Restriction,
-    max,
-)
 
 
 def test_infix_owl_example1():
@@ -51,8 +42,7 @@ def test_infix_owl_example1():
     namespace_manager.bind("owl", OWL, override=False)
     owlGraph.namespace_manager = namespace_manager
     assert (
-        str(list(Class(OWL.Class, graph=owlGraph).subClassOf))
-        == "[Class: rdfs:Class ]"
+        str(list(Class(OWL.Class, graph=owlGraph).subClassOf)) == "[Class: rdfs:Class ]"
     )
 
     # Operators are also available. For instance we can add ex:Opera to the extension

--- a/test/test_initbindings.py
+++ b/test/test_initbindings.py
@@ -1,7 +1,5 @@
+from rdflib import ConjunctiveGraph, Literal, Namespace, URIRef, Variable
 from rdflib.plugins.sparql import prepareQuery
-
-
-from rdflib import ConjunctiveGraph, URIRef, Literal, Namespace, Variable
 
 g = ConjunctiveGraph()
 

--- a/test/test_issue084.py
+++ b/test/test_issue084.py
@@ -1,7 +1,7 @@
 from codecs import getreader
 from io import BytesIO, StringIO
 
-from rdflib import URIRef, Literal
+from rdflib import Literal, URIRef
 from rdflib.graph import Graph
 
 rdf = """@prefix skos:

--- a/test/test_issue1003.py
+++ b/test/test_issue1003.py
@@ -1,5 +1,5 @@
-from rdflib import Graph, Dataset, Literal, Namespace, RDF, URIRef
-from rdflib.namespace import SKOS, DCTERMS
+from rdflib import RDF, Dataset, Graph, Literal, Namespace, URIRef
+from rdflib.namespace import DCTERMS, SKOS
 
 
 def test_scenarios() -> None:

--- a/test/test_issue1043.py
+++ b/test/test_issue1043.py
@@ -1,9 +1,9 @@
 import decimal
-import unittest
 import io
 import sys
+import unittest
 
-from rdflib import Graph, Namespace, XSD, RDFS, Literal
+from rdflib import RDFS, XSD, Graph, Literal, Namespace
 
 
 class TestIssue1043(unittest.TestCase):

--- a/test/test_issue1141.py
+++ b/test/test_issue1141.py
@@ -1,8 +1,8 @@
 import unittest
 
 from rdflib import Graph
-from rdflib.plugins.stores.memory import Memory, SimpleMemory
 from rdflib.plugins.stores.auditable import AuditableStore
+from rdflib.plugins.stores.memory import Memory, SimpleMemory
 
 
 class TestIssue1141(unittest.TestCase):

--- a/test/test_issue1160.py
+++ b/test/test_issue1160.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 import rdflib
-
 from rdflib import ConjunctiveGraph
 from rdflib.parser import URLInputSource
 

--- a/test/test_issue1404.py
+++ b/test/test_issue1404.py
@@ -1,6 +1,6 @@
-from rdflib import Graph, URIRef, FOAF
-from rdflib.term import RDFLibGenid
+from rdflib import FOAF, Graph, URIRef
 from rdflib.compare import isomorphic
+from rdflib.term import RDFLibGenid
 
 
 def test_skolem_de_skolem_roundtrip():
@@ -9,18 +9,21 @@ def test_skolem_de_skolem_roundtrip():
     Issue: https://github.com/RDFLib/rdflib/issues/1404
     """
 
-    ttl = '''
+    ttl = """
     @prefix wd: <http://www.wikidata.org/entity/> .
     @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
     wd:Q1203 foaf:knows [ a foaf:Person;
         foaf:name "Ringo" ].
-    '''
+    """
 
     graph = Graph()
-    graph.parse(data=ttl, format='turtle')
+    graph.parse(data=ttl, format="turtle")
 
-    query = {"subject": URIRef("http://www.wikidata.org/entity/Q1203"), "predicate": FOAF.knows}
+    query = {
+        "subject": URIRef("http://www.wikidata.org/entity/Q1203"),
+        "predicate": FOAF.knows,
+    }
 
     # Save the original bnode id.
     bnode_id = graph.value(**query)

--- a/test/test_issue1484.py
+++ b/test/test_issue1484.py
@@ -1,7 +1,8 @@
-import unittest
 import io
 import json
-from rdflib import Graph, RDF, RDFS, Namespace
+import unittest
+
+from rdflib import RDF, RDFS, Graph, Namespace
 
 
 class TestIssue1484_json(unittest.TestCase):
@@ -57,8 +58,8 @@ class TestIssue1484_str(unittest.TestCase):
         g.bind("rdfs", RDFS)
         g.parse(data=jsonstr, publicID=b, format="json-ld")
 
-        assert((n.s, RDF.type, n.t) in g)
-        assert((n.s, n.p, n.o) in g)
+        assert (n.s, RDF.type, n.t) in g
+        assert (n.s, n.p, n.o) in g
 
 
 if __name__ == "__main__":

--- a/test/test_issue160.py
+++ b/test/test_issue160.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
-from rdflib import ConjunctiveGraph
-from rdflib import Namespace, Literal
+
+from rdflib import ConjunctiveGraph, Literal, Namespace
 from rdflib.collection import Collection
 
 target1xml = """\

--- a/test/test_issue161.py
+++ b/test/test_issue161.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from rdflib.graph import ConjunctiveGraph
 
 

--- a/test/test_issue184.py
+++ b/test/test_issue184.py
@@ -1,6 +1,5 @@
-from rdflib.term import Literal
-from rdflib.term import URIRef
 from rdflib.graph import ConjunctiveGraph
+from rdflib.term import Literal, URIRef
 
 
 def test_escaping_of_triple_doublequotes():

--- a/test/test_issue190.py
+++ b/test/test_issue190.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import textwrap
 import unittest
+
+import pytest
 
 from rdflib.graph import ConjunctiveGraph
 from rdflib.parser import StringInputSource
-import textwrap
-import pytest
 
 prefix = textwrap.dedent(
     """\

--- a/test/test_issue200.py
+++ b/test/test_issue200.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 import os
-import rdflib
 import unittest
+
 import pytest
 
+import rdflib
 
 if os.name == "nt":
     pytestmark = pytest.mark.skip(

--- a/test/test_issue209.py
+++ b/test/test_issue209.py
@@ -1,6 +1,7 @@
-import rdflib
-import unittest
 import threading
+import unittest
+
+import rdflib
 
 
 def makeNode():

--- a/test/test_issue223.py
+++ b/test/test_issue223.py
@@ -1,6 +1,6 @@
+from rdflib.collection import Collection
 from rdflib.graph import Graph
 from rdflib.term import URIRef
-from rdflib.collection import Collection
 
 ttl = """
 @prefix : <http://example.org/>.

--- a/test/test_issue247.py
+++ b/test/test_issue247.py
@@ -1,5 +1,6 @@
-import rdflib
 import unittest
+
+import rdflib
 
 failxml = """\
 <rdf:RDF

--- a/test/test_issue248.py
+++ b/test/test_issue248.py
@@ -1,5 +1,6 @@
-import rdflib
 import unittest
+
+import rdflib
 
 
 class TestSerialization(unittest.TestCase):

--- a/test/test_issue274.py
+++ b/test/test_issue274.py
@@ -1,12 +1,12 @@
-from .testutils import eq_
 from unittest import TestCase
+
 import pytest
 
-from rdflib import BNode, Graph, Literal, Namespace, RDFS, XSD
-from rdflib.plugins.sparql.operators import (
-    register_custom_function,
-    unregister_custom_function,
-)
+from rdflib import RDFS, XSD, BNode, Graph, Literal, Namespace
+from rdflib.plugins.sparql.operators import (register_custom_function,
+                                             unregister_custom_function)
+
+from .testutils import eq_
 
 EX = Namespace("http://example.org/")
 G = Graph()

--- a/test/test_issue363.py
+++ b/test/test_issue363.py
@@ -1,4 +1,5 @@
 import pytest
+
 import rdflib
 
 data = """<?xml version="1.0" encoding="utf-8"?>

--- a/test/test_issue446.py
+++ b/test/test_issue446.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # test for https://github.com/RDFLib/rdflib/issues/446
 
-from rdflib import Graph, URIRef, Literal
+from rdflib import Graph, Literal, URIRef
 
 
 def test_sparql_unicode():

--- a/test/test_issue545.py
+++ b/test/test_issue545.py
@@ -1,5 +1,5 @@
+from rdflib.namespace import DC, OWL, RDFS, SKOS
 from rdflib.plugins import sparql
-from rdflib.namespace import RDFS, OWL, DC, SKOS
 
 
 def test_issue():

--- a/test/test_issue563.py
+++ b/test/test_issue563.py
@@ -1,4 +1,4 @@
-from rdflib import BNode, Literal, Graph, Namespace
+from rdflib import BNode, Graph, Literal, Namespace
 from rdflib.compare import isomorphic
 
 EX = Namespace("http://example.org/")

--- a/test/test_issue579.py
+++ b/test/test_issue579.py
@@ -1,6 +1,6 @@
 # test for https://github.com/RDFLib/rdflib/issues/579
 
-from rdflib import Graph, URIRef, Literal, Namespace
+from rdflib import Graph, Literal, Namespace, URIRef
 from rdflib.namespace import FOAF, RDF
 
 

--- a/test/test_issue655.py
+++ b/test/test_issue655.py
@@ -1,6 +1,7 @@
-from decimal import Decimal
 import unittest
-from rdflib import Graph, Namespace, URIRef, Literal, XSD
+from decimal import Decimal
+
+from rdflib import XSD, Graph, Literal, Namespace, URIRef
 from rdflib.compare import to_isomorphic
 
 

--- a/test/test_issue715.py
+++ b/test/test_issue715.py
@@ -5,7 +5,7 @@ zeroOrMore ('*') property paths and specifying neither the
 subject or the object.
 """
 
-from rdflib import URIRef, Graph
+from rdflib import Graph, URIRef
 
 
 def test_issue_715():

--- a/test/test_issue733.py
+++ b/test/test_issue733.py
@@ -5,10 +5,10 @@ zeroOrMore ('*') property paths and specifying neither the
 subject or the object.
 """
 
-from rdflib import URIRef, Graph
 import unittest
 
-from rdflib.namespace import RDF, RDFS, NamespaceManager, Namespace
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF, RDFS, Namespace, NamespaceManager
 
 
 class TestIssue733(unittest.TestCase):

--- a/test/test_issue801.py
+++ b/test/test_issue801.py
@@ -1,8 +1,9 @@
 """
 Issue 801 - Problem with prefixes created for URIs containing %20
 """
-from rdflib import Namespace, Graph, BNode, Literal
 import unittest
+
+from rdflib import BNode, Graph, Literal, Namespace
 
 
 class TestIssue801(unittest.TestCase):

--- a/test/test_issue893.py
+++ b/test/test_issue893.py
@@ -1,4 +1,5 @@
 import pickle
+
 from rdflib.graph import Dataset
 from rdflib.namespace import Namespace
 

--- a/test/test_issue910.py
+++ b/test/test_issue910.py
@@ -1,5 +1,6 @@
-from rdflib import Graph
 import unittest
+
+from rdflib import Graph
 
 
 class TestIssue910(unittest.TestCase):

--- a/test/test_issue920.py
+++ b/test/test_issue920.py
@@ -9,8 +9,9 @@ N3, by contrast, succeeds:
 
 g.parse(data='<a:> <b:> <c:> .', format='n3')
 """
-from rdflib import Graph
 import unittest
+
+from rdflib import Graph
 
 
 class TestIssue920(unittest.TestCase):

--- a/test/test_issue953.py
+++ b/test/test_issue953.py
@@ -1,7 +1,7 @@
+import unittest
 from fractions import Fraction
 
-from rdflib import Graph, ConjunctiveGraph, Literal, URIRef
-import unittest
+from rdflib import ConjunctiveGraph, Graph, Literal, URIRef
 
 
 class TestIssue953(unittest.TestCase):

--- a/test/test_issue977.py
+++ b/test/test_issue977.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rdflib import Graph, XSD, RDF, RDFS, URIRef, Literal
+from rdflib import RDF, RDFS, XSD, Graph, Literal, URIRef
 
 
 class TestIssue977(unittest.TestCase):

--- a/test/test_issue_git_200.py
+++ b/test/test_issue_git_200.py
@@ -1,5 +1,6 @@
-import rdflib
 import pytest
+
+import rdflib
 
 
 def test_broken_add():

--- a/test/test_literal.py
+++ b/test/test_literal.py
@@ -7,16 +7,16 @@
 # mypy: no_implicit_optional, warn_redundant_casts, warn_unused_ignores
 # mypy: warn_return_any, no_implicit_reexport, strict_equality
 
+import datetime
+import unittest
 from decimal import Decimal
 from typing import Any, Optional, Sequence, Tuple, Type
-import unittest
-import datetime
-
-import rdflib  # needed for eval(repr(...)) below
-from rdflib.term import Literal, URIRef, _XSD_DOUBLE, bind, _XSD_BOOLEAN
-from rdflib import XSD
 
 import pytest
+
+import rdflib  # needed for eval(repr(...)) below
+from rdflib import XSD
+from rdflib.term import _XSD_BOOLEAN, _XSD_DOUBLE, Literal, URIRef, bind
 
 
 class TestLiteral(unittest.TestCase):

--- a/test/test_memory_store.py
+++ b/test/test_memory_store.py
@@ -1,4 +1,5 @@
 import unittest
+
 import rdflib
 
 rdflib.plugin.register(

--- a/test/test_mulpath_n3.py
+++ b/test/test_mulpath_n3.py
@@ -1,6 +1,5 @@
-from rdflib.paths import ZeroOrMore
-
 from rdflib import RDFS, URIRef
+from rdflib.paths import ZeroOrMore
 
 
 def test_mulpath_n3():

--- a/test/test_n3.py
+++ b/test/test_n3.py
@@ -1,15 +1,14 @@
+import itertools
 import os
+import unittest
+from test import TEST_DIR
+from urllib.error import URLError
 
 import pytest
 
-from rdflib.graph import Graph, ConjunctiveGraph
-import unittest
-from rdflib.term import Literal, URIRef
+from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.plugins.parsers.notation3 import BadSyntax, exponent_syntax
-import itertools
-from urllib.error import URLError
-
-from test import TEST_DIR
+from rdflib.term import Literal, URIRef
 
 test_data = """
 #  Definitions of terms describing the n3 model

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -1,21 +1,11 @@
 import unittest
 from unittest.case import expectedFailure
-
 from warnings import warn
 
 from rdflib import DCTERMS
 from rdflib.graph import Graph
-from rdflib.namespace import (
-    FOAF,
-    OWL,
-    RDF,
-    RDFS,
-    SH,
-    DefinedNamespaceMeta,
-    Namespace,
-    ClosedNamespace,
-    URIPattern,
-)
+from rdflib.namespace import (FOAF, OWL, RDF, RDFS, SH, ClosedNamespace,
+                              DefinedNamespaceMeta, Namespace, URIPattern)
 from rdflib.term import URIRef
 
 

--- a/test/test_nodepickler.py
+++ b/test/test_nodepickler.py
@@ -1,9 +1,8 @@
-import unittest
 import pickle
-
-from rdflib.term import Literal
+import unittest
 
 from rdflib.store import NodePickler
+from rdflib.term import Literal
 
 # same as nt/more_literals.nt
 cases = [

--- a/test/test_nquads.py
+++ b/test/test_nquads.py
@@ -1,7 +1,8 @@
 import os
 import unittest
-from rdflib import ConjunctiveGraph, URIRef, Namespace
 from test import TEST_DIR
+
+from rdflib import ConjunctiveGraph, Namespace, URIRef
 
 TEST_BASE = "test/nquads.rdflib"
 

--- a/test/test_nquads_w3c.py
+++ b/test/test_nquads_w3c.py
@@ -1,11 +1,13 @@
 """This runs the nquads tests for the W3C RDF Working Group's N-Quads
 test suite."""
 
+from test.manifest import RDFT, RDFTest, read_manifest
 from typing import Callable, Dict
+
+import pytest
+
 from rdflib import ConjunctiveGraph
 from rdflib.term import Node, URIRef
-from test.manifest import RDFT, RDFTest, read_manifest
-import pytest
 
 verbose = False
 

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -1,13 +1,13 @@
-import unittest
 import logging
 import os
 import re
+import unittest
+from pathlib import Path
+from test import TEST_DIR
+from urllib.request import urlopen
+
 from rdflib import Graph, Literal, URIRef
 from rdflib.plugins.parsers import ntriples
-from urllib.request import urlopen
-from pathlib import Path
-
-from test import TEST_DIR
 
 log = logging.getLogger(__name__)
 

--- a/test/test_nt_w3c.py
+++ b/test/test_nt_w3c.py
@@ -1,14 +1,14 @@
 """This runs the nt tests for the W3C RDF Working Group's N-Quads
 test suite."""
 import os
+from test import TEST_DIR
+from test.manifest import RDFT, RDFTest, read_manifest
 from typing import Callable, Dict
+
+import pytest
 
 from rdflib import Graph
 from rdflib.term import Node, URIRef
-from test import TEST_DIR
-from test.manifest import RDFT, RDFTest, read_manifest
-
-import pytest
 
 verbose = False
 

--- a/test/test_parse_file_guess_format.py
+++ b/test/test_parse_file_guess_format.py
@@ -7,15 +7,14 @@
 # mypy: no_implicit_optional, warn_redundant_casts, warn_unused_ignores
 # mypy: warn_return_any, no_implicit_reexport, strict_equality
 
-import unittest
 import logging
+import unittest
 from pathlib import Path
 from shutil import copyfile
 from tempfile import TemporaryDirectory
 
-from rdflib.exceptions import ParserError
-
 from rdflib import Graph
+from rdflib.exceptions import ParserError
 from rdflib.util import guess_format
 
 
@@ -25,7 +24,9 @@ class FileParserGuessFormatTest(unittest.TestCase):
         self.assertEqual(guess_format("local-file.jsonld"), "json-ld")
         self.assertEqual(guess_format("local-file.json-ld"), "json-ld")
         self.assertEqual(guess_format("/some/place/on/disk/example.json"), "json-ld")
-        self.assertEqual(guess_format("../../relative/place/on/disk/example.json"), "json-ld")
+        self.assertEqual(
+            guess_format("../../relative/place/on/disk/example.json"), "json-ld"
+        )
         self.assertEqual(guess_format("example.rdf"), "xml")
         self.assertEqual(guess_format("example.nt"), "nt")
         self.assertEqual(guess_format("example.nq"), "nquads")

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,9 +1,8 @@
 import unittest
 
-from rdflib.namespace import RDF, RDFS
-from rdflib.term import URIRef
-from rdflib.term import Literal
 from rdflib.graph import Graph
+from rdflib.namespace import RDF, RDFS
+from rdflib.term import Literal, URIRef
 
 
 class ParserTestCase(unittest.TestCase):

--- a/test/test_parser_hext.py
+++ b/test/test_parser_hext.py
@@ -1,7 +1,8 @@
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).parent.parent.absolute()))
-from rdflib import Dataset, ConjunctiveGraph, Literal
+from rdflib import ConjunctiveGraph, Dataset, Literal
 from rdflib.namespace import XSD
 
 
@@ -40,7 +41,9 @@ def test_small_string_cg():
 
 
 def test_small_file_singlegraph():
-    d = Dataset().parse(Path(__file__).parent / "test_parser_hext_singlegraph.ndjson", format="hext")
+    d = Dataset().parse(
+        Path(__file__).parent / "test_parser_hext_singlegraph.ndjson", format="hext"
+    )
     assert len(d) == 10
 
 
@@ -50,7 +53,7 @@ def test_small_file_multigraph():
     d.parse(
         Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
         format="hext",
-        publicID=d.default_context.identifier
+        publicID=d.default_context.identifier,
     )
 
     """There are 22 lines in the file test_parser_hext_multigraph.ndjson. When loaded
@@ -70,7 +73,7 @@ def test_small_file_multigraph_cg():
     d.parse(
         Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
         format="hext",
-        publicID=d.default_context.identifier
+        publicID=d.default_context.identifier,
     )
 
     """There are 22 lines in the file test_parser_hext_multigraph.ndjson. When loaded
@@ -121,7 +124,7 @@ def test_roundtrip():
                 cg2.parse(
                     data=cg.serialize(format="hext"),
                     format="hext",
-                    publicID=cg2.default_context.identifier
+                    publicID=cg2.default_context.identifier,
                 )
                 if cg2.context_aware:
                     for context in cg2.contexts():
@@ -129,7 +132,9 @@ def test_roundtrip():
                             if type(triple[2]) == Literal:
                                 if triple[2].datatype == XSD.string:
                                     context.remove((triple[0], triple[1], triple[2]))
-                                    context.add((triple[0], triple[1], Literal(str(triple[2]))))
+                                    context.add(
+                                        (triple[0], triple[1], Literal(str(triple[2])))
+                                    )
                 else:
                     for triple in cg2.triples((None, None, None)):
                         if type(triple[2]) == Literal:

--- a/test/test_parser_reads_from_pathlike_object.py
+++ b/test/test_parser_reads_from_pathlike_object.py
@@ -1,6 +1,7 @@
 import tempfile
-import rdflib
 from pathlib import Path
+
+import rdflib
 
 
 def test_reading_from_path_object():

--- a/test/test_parser_structure.py
+++ b/test/test_parser_structure.py
@@ -1,5 +1,6 @@
-import rdflib.plugins.sparql.parser
 import pprint
+
+import rdflib.plugins.sparql.parser
 
 
 def test_parser_structure() -> None:

--- a/test/test_prettyxml.py
+++ b/test/test_prettyxml.py
@@ -1,10 +1,10 @@
 # -*- coding: UTF-8 -*-
-from rdflib.term import URIRef, BNode, Literal
-from rdflib.namespace import RDF, RDFS
 from io import BytesIO
-from rdflib.plugins.serializers.rdfxml import PrettyXMLSerializer
 
 from rdflib.graph import ConjunctiveGraph
+from rdflib.namespace import RDF, RDFS
+from rdflib.plugins.serializers.rdfxml import PrettyXMLSerializer
+from rdflib.term import BNode, Literal, URIRef
 
 
 class SerializerTestBase(object):

--- a/test/test_rdf_lists.py
+++ b/test/test_rdf_lists.py
@@ -4,7 +4,6 @@ import unittest
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 
-
 DATA = """<http://example.com#C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class>.
 <http://example.com#B> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:fIYNVPxd4.
 <http://example.com#B> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.com#A>.

--- a/test/test_rdfxml.py
+++ b/test/test_rdfxml.py
@@ -1,22 +1,17 @@
-import sys
-from encodings.utf_8 import StreamWriter
-from typing import ClassVar
-
-import unittest
-
+import logging
 import os
 import os.path
+import sys
+import unittest
+from encodings.utf_8 import StreamWriter
 from io import StringIO
-
+from typing import ClassVar
 from urllib.request import url2pathname, urlopen
 
-from rdflib import RDF, RDFS, URIRef, BNode, Literal, Namespace, Graph
+from rdflib import RDF, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.exceptions import ParserError
 from rdflib.plugins.parsers.RDFVOC import RDFVOC
 from rdflib.util import first
-
-
-import logging
 
 _logger = logging.getLogger("parser_rdfcore")
 
@@ -85,7 +80,7 @@ RDFCOREBASE = "http://www.w3.org/2000/10/rdf-tests/rdfcore/"
 
 
 def relative(url):
-    return url[len(RDFCOREBASE):]
+    return url[len(RDFCOREBASE) :]
 
 
 def resolve(rel):
@@ -245,8 +240,8 @@ if __name__ == "__main__":
         cached_file("http://www.w3.org/2000/10/rdf-tests/rdfcore/Manifest.rdf"),
         format="xml",
     )
-    import sys
     import getopt
+    import sys
 
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "h:", ["help"])

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -1,7 +1,8 @@
-from json.decoder import JSONDecodeError
 import logging
 import os.path
+from json.decoder import JSONDecodeError
 from pathlib import Path
+from test.testutils import GraphHelper
 from typing import Callable, Collection, Iterable, List, Optional, Set, Tuple, Union
 from xml.sax import SAXParseException
 
@@ -10,10 +11,9 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 
 import rdflib
 import rdflib.compare
+from rdflib.namespace import XSD
 from rdflib.plugins.parsers.notation3 import BadSyntax
 from rdflib.util import guess_format
-from rdflib.namespace import XSD
-from test.testutils import GraphHelper
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -1,13 +1,10 @@
+import shutil
 import unittest
 from tempfile import mkdtemp
-import shutil
 
-from rdflib.term import URIRef
-from rdflib.term import BNode
-from rdflib.term import Literal
-from rdflib.term import Variable
-from rdflib.namespace import Namespace
 from rdflib.graph import Graph
+from rdflib.namespace import Namespace
+from rdflib.term import BNode, Literal, URIRef, Variable
 
 LOG = Namespace("http://www.w3.org/2000/10/swap/log#")
 

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -1,7 +1,8 @@
 import unittest
-from rdflib import Graph, URIRef, Literal
-from tempfile import TemporaryDirectory
 from pathlib import Path, PurePath
+from tempfile import TemporaryDirectory
+
+from rdflib import Graph, Literal, URIRef
 
 
 class TestSerialize(unittest.TestCase):

--- a/test/test_serializer_hext.py
+++ b/test/test_serializer_hext.py
@@ -1,8 +1,10 @@
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).parent.parent.absolute()))
-from rdflib import Dataset, Graph, ConjunctiveGraph
 import json
+
+from rdflib import ConjunctiveGraph, Dataset, Graph
 
 
 def test_hext_graph():
@@ -33,18 +35,51 @@ def test_hext_graph():
     out = g.serialize(format="hext")
     # note: can't test for BNs in result as they will be different every time
     testing_lines = [
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p7", "true", "http://www.w3.org/2001/XMLSchema#boolean", "", ""]'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", ""]'],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p7", "true", "http://www.w3.org/2001/XMLSchema#boolean", "", ""]',
+        ],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", ""]',
+        ],
         [False, '["http://example.com/s1", "http://example.com/p2"'],
-        [False, '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", ""]'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p8", "false", "http://www.w3.org/2001/XMLSchema#boolean", "", ""]'],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", ""]',
+        ],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p8", "false", "http://www.w3.org/2001/XMLSchema#boolean", "", ""]',
+        ],
     ]
     for line in out.splitlines():
         for test in testing_lines:
@@ -97,24 +132,75 @@ def test_hext_cg():
     out = d.serialize(format="hext")
     # note: cant' test for BNs in result as they will be different ever time
     testing_lines = [
-        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o21", "globalId", "", ""]'],
-        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o22", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]'],
-        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o12", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o11", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g1"]'],
+        [
+            False,
+            '["http://example.com/s21", "http://example.com/p21", "http://example.com/o21", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s21", "http://example.com/p21", "http://example.com/o22", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s11", "http://example.com/p11", "http://example.com/o12", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s11", "http://example.com/p11", "http://example.com/o11", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g1"]',
+        ],
         [False, '["http://example.com/s1", "http://example.com/p2"'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
     ]
     for line in out.splitlines():
         for test in testing_lines:
@@ -162,24 +248,75 @@ def test_hext_dataset():
     out = d.serialize(format="hext")
     # note: cant' test for BNs in result as they will be different ever time
     testing_lines = [
-        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o21", "globalId", "", ""]'],
-        [False, '["http://example.com/s21", "http://example.com/p21", "http://example.com/o22", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]'],
-        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o12", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s11", "http://example.com/p11", "http://example.com/o11", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g2"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g1"]'],
+        [
+            False,
+            '["http://example.com/s21", "http://example.com/p21", "http://example.com/o21", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s21", "http://example.com/p21", "http://example.com/o22", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", ""]',
+        ],
+        [
+            False,
+            '["http://example.com/s11", "http://example.com/p11", "http://example.com/o12", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s11", "http://example.com/p11", "http://example.com/o11", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g2"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o2", "globalId", "", "http://example.com/g1"]',
+        ],
         [False, '["http://example.com/s1", "http://example.com/p2"'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
-        [False, '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", "http://example.com/g1"]'],
-        [False, '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]'],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "thingy", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2002/07/owl#Thing", "globalId", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 4 - English", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p6", "42", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p4", "2021-12-03", "http://www.w3.org/2001/XMLSchema#date", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p1", "http://example.com/o1", "globalId", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p5", "42", "http://www.w3.org/2001/XMLSchema#integer", "", "http://example.com/g1"]',
+        ],
+        [
+            False,
+            '["http://example.com/s1", "http://example.com/p3", "Object 3", "http://www.w3.org/2001/XMLSchema#string", "", "http://example.com/g1"]',
+        ],
     ]
     for line in out.splitlines():
         for test in testing_lines:
@@ -236,7 +373,7 @@ def test_hext_dataset_linecount():
     d.parse(
         Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
         format="hext",
-        publicID=d.default_context.identifier
+        publicID=d.default_context.identifier,
     )
     total_triples = 0
     # count all the triples in the Dataset
@@ -255,7 +392,7 @@ def test_roundtrip():
     d.parse(
         Path(__file__).parent / "test_parser_hext_multigraph.ndjson",
         format="hext",
-        publicID=d.default_context.identifier
+        publicID=d.default_context.identifier,
     )
     d.default_union = True
     with open(str(Path(__file__).parent / "test_parser_hext_multigraph.ndjson")) as i:

--- a/test/test_serializer_trix.py
+++ b/test/test_serializer_trix.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
 import unittest
-
-from rdflib.graph import ConjunctiveGraph
-from rdflib.term import URIRef, Literal
-from rdflib.graph import Graph
 from io import BytesIO
+
+from rdflib.graph import ConjunctiveGraph, Graph
+from rdflib.term import Literal, URIRef
 
 
 class TestTrixSerialize(unittest.TestCase):

--- a/test/test_serializer_turtle.py
+++ b/test/test_serializer_turtle.py
@@ -1,4 +1,4 @@
-from rdflib import Graph, URIRef, BNode, RDF, RDFS, Literal, Namespace
+from rdflib import RDF, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection
 from rdflib.plugins.serializers.turtle import TurtleSerializer
 

--- a/test/test_serializer_xml.py
+++ b/test/test_serializer_xml.py
@@ -1,9 +1,9 @@
-from rdflib.term import URIRef, BNode
-from rdflib.namespace import RDFS
 from io import BytesIO
-from rdflib.plugins.serializers.rdfxml import XMLSerializer
 
 from rdflib.graph import ConjunctiveGraph
+from rdflib.namespace import RDFS
+from rdflib.plugins.serializers.rdfxml import XMLSerializer
+from rdflib.term import BNode, URIRef
 
 
 class SerializerTestBase(object):

--- a/test/test_slice.py
+++ b/test/test_slice.py
@@ -1,5 +1,6 @@
-from rdflib import Graph, URIRef
 import unittest
+
+from rdflib import Graph, URIRef
 
 
 class GraphSlice(unittest.TestCase):

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -1,7 +1,7 @@
-from rdflib.plugins.sparql import sparql, prepareQuery
-from rdflib import Graph, URIRef, Literal, BNode, ConjunctiveGraph
-from rdflib.namespace import Namespace, RDF, RDFS
+from rdflib import BNode, ConjunctiveGraph, Graph, Literal, URIRef
 from rdflib.compare import isomorphic
+from rdflib.namespace import RDF, RDFS, Namespace
+from rdflib.plugins.sparql import prepareQuery, sparql
 from rdflib.term import Variable
 
 from .testutils import eq_

--- a/test/test_sparql_agg_undef.py
+++ b/test/test_sparql_agg_undef.py
@@ -1,4 +1,5 @@
 import pytest
+
 from rdflib import Graph, Literal, Variable
 
 query_tpl = """

--- a/test/test_sparql_construct_bindings.py
+++ b/test/test_sparql_construct_bindings.py
@@ -1,9 +1,11 @@
-from rdflib import Graph, URIRef, Literal, BNode
-from rdflib.plugins.sparql import prepareQuery
-from rdflib.compare import isomorphic
-
 import unittest
+
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.compare import isomorphic
+from rdflib.plugins.sparql import prepareQuery
+
 from .testutils import eq_
+
 
 class TestConstructInitBindings(unittest.TestCase):
     def test_construct_init_bindings(self):

--- a/test/test_sparql_datetime.py
+++ b/test/test_sparql_datetime.py
@@ -1,10 +1,12 @@
-from rdflib import Graph, URIRef, Literal, BNode, XSD
-from rdflib.plugins.sparql import prepareQuery
-from rdflib.compare import isomorphic
-import rdflib
-from .testutils import eq_
-from pprint import pprint
 import io
+from pprint import pprint
+
+import rdflib
+from rdflib import XSD, BNode, Graph, Literal, URIRef
+from rdflib.compare import isomorphic
+from rdflib.plugins.sparql import prepareQuery
+
+from .testutils import eq_
 
 
 def test_dateTime_dateTime_subs_issue():

--- a/test/test_sparql_operators.py
+++ b/test/test_sparql_operators.py
@@ -1,9 +1,10 @@
 import datetime
 
-import rdflib
-from rdflib.plugins.sparql import operators
-from rdflib.plugins.sparql import sparql
 import pytest
+
+import rdflib
+from rdflib.plugins.sparql import operators, sparql
+
 
 def test_date_cast():
     now = datetime.datetime.now()

--- a/test/test_sparql_parser.py
+++ b/test/test_sparql_parser.py
@@ -1,11 +1,12 @@
+import math
+import sys
+import unittest
+from typing import Set, Tuple
+
 from rdflib import Graph, Literal
-from rdflib.term import Node
 from rdflib.namespace import Namespace
 from rdflib.plugins.sparql.processor import processUpdate
-import unittest
-import sys
-import math
-from typing import Set, Tuple
+from rdflib.term import Node
 
 
 def triple_set(graph: Graph) -> Set[Tuple[Node, Node, Node]]:

--- a/test/test_sparql_prepare.py
+++ b/test/test_sparql_prepare.py
@@ -1,10 +1,8 @@
 import os
-from rdflib.plugins.sparql import prepareUpdate, prepareQuery
+
+from rdflib import Graph, URIRef
 from rdflib.namespace import FOAF
-from rdflib import (
-    Graph,
-    URIRef,
-)
+from rdflib.plugins.sparql import prepareQuery, prepareUpdate
 
 
 def test_prepare_update():

--- a/test/test_sparql_service.py
+++ b/test/test_sparql_service.py
@@ -1,6 +1,6 @@
-from rdflib import Graph, URIRef, Literal, Variable
-from rdflib.plugins.sparql import prepareQuery
+from rdflib import Graph, Literal, URIRef, Variable
 from rdflib.compare import isomorphic
+from rdflib.plugins.sparql import prepareQuery
 
 from . import helper
 

--- a/test/test_sparqlstore.py
+++ b/test/test_sparqlstore.py
@@ -1,20 +1,19 @@
-from rdflib import Graph, URIRef, Literal
+import re
+import socket
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
-import socket
 from threading import Thread
+from typing import Callable, ClassVar, Type
 from unittest.mock import patch
-from rdflib.namespace import RDF, XSD, XMLNS, FOAF, RDFS
-from rdflib.plugins.stores.sparqlstore import SPARQLConnector
-from typing import ClassVar, Callable, Type
+
 import pytest
-import re
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import FOAF, RDF, RDFS, XMLNS, XSD
+from rdflib.plugins.stores.sparqlstore import SPARQLConnector
 
 from . import helper
-from .testutils import (
-    MockHTTPResponse,
-    ServedSimpleHTTPMock,
-)
+from .testutils import MockHTTPResponse, ServedSimpleHTTPMock
 
 
 class TestSPARQLStoreGraph:

--- a/test/test_sparqlupdatestore.py
+++ b/test/test_sparqlupdatestore.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import re
-
-from rdflib import ConjunctiveGraph, URIRef, Literal, BNode, Graph
+import unittest
 from urllib.request import urlopen
+
+from rdflib import BNode, ConjunctiveGraph, Graph, Literal, URIRef
 
 HOST = "http://localhost:3031"
 DB = "/db/"
@@ -76,7 +76,8 @@ class TestSparql11(unittest.TestCase):
 
         # Test initBindings
         r = g.query(
-            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }", initBindings={"s": tarek},
+            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }",
+            initBindings={"s": tarek},
         )
         self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
@@ -117,11 +118,14 @@ class TestSparql11(unittest.TestCase):
             "%s" % list(self.graph),
         )
 
-        r = self.graph.query("SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }")
+        r = self.graph.query(
+            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }"
+        )
         self.assertEqual(2, len(list(r)), "two people like pizza")
 
         r = self.graph.query(
-            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }", initBindings={"s": tarek},
+            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }",
+            initBindings={"s": tarek},
         )
         self.assertEqual(1, len(list(r)), "i was asking only about tarek")
 
@@ -133,7 +137,9 @@ class TestSparql11(unittest.TestCase):
 
         g2.remove((bob, likes, pizza))
 
-        r = self.graph.query("SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }")
+        r = self.graph.query(
+            "SELECT * WHERE { ?s <urn:example:likes> <urn:example:pizza> . }"
+        )
         self.assertEqual(1, len(list(r)), "only tarek likes pizza")
 
     def testUpdate(self):
@@ -272,7 +278,10 @@ class TestSparql11(unittest.TestCase):
         r4strings.append("'''10: ad adsfj \n { \n sadfj'''")
 
         r4 = "\n".join(
-            ["INSERT DATA { <urn:example:michel> <urn:says> %s } ;" % s for s in r4strings]
+            [
+                "INSERT DATA { <urn:example:michel> <urn:says> %s } ;" % s
+                for s in r4strings
+            ]
         )
         g.update(r4)
         values = set()
@@ -303,7 +312,9 @@ class TestSparql11(unittest.TestCase):
         values = set()
         for v in g.objects(michel, hates):
             values.add(str(v))
-        self.assertEqual(values, set(["urn:example:foo'bar?baz;a=1&b=2#fragment", "'}"]))
+        self.assertEqual(
+            values, set(["urn:example:foo'bar?baz;a=1&b=2#fragment", "'}"])
+        )
 
         # Comments
         r6 = """

--- a/test/test_sparqlupdatestore_mock.py
+++ b/test/test_sparqlupdatestore_mock.py
@@ -1,8 +1,10 @@
-from rdflib.graph import ConjunctiveGraph
-from typing import ClassVar
-from rdflib import Namespace
-from .testutils import MockHTTPResponse, ServedSimpleHTTPMock
 import unittest
+from typing import ClassVar
+
+from rdflib import Namespace
+from rdflib.graph import ConjunctiveGraph
+
+from .testutils import MockHTTPResponse, ServedSimpleHTTPMock
 
 EG = Namespace("http://example.org/")
 

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -1,7 +1,8 @@
 import unittest
+
 from rdflib import Graph
-from rdflib.store import Store
 from rdflib.namespace import NamespaceManager
+from rdflib.store import Store
 
 
 class TestAbstractStore(unittest.TestCase):

--- a/test/test_store_berkeleydb.py
+++ b/test/test_store_berkeleydb.py
@@ -1,8 +1,9 @@
 import unittest
 from tempfile import mktemp
+
 from rdflib import ConjunctiveGraph, URIRef
-from rdflib.store import VALID_STORE
 from rdflib.plugins.stores.berkeleydb import has_bsddb
+from rdflib.store import VALID_STORE
 
 
 class BerkeleyDBTestCase(unittest.TestCase):

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -3,12 +3,12 @@ some more specific Literal tests are in test_literal.py
 """
 
 import base64
-import unittest
 import random
+import unittest
 
-from rdflib.term import URIRef, BNode, Literal, _is_valid_unicode
-from rdflib.graph import QuotedGraph, Graph
+from rdflib.graph import Graph, QuotedGraph
 from rdflib.namespace import XSD
+from rdflib.term import BNode, Literal, URIRef, _is_valid_unicode
 
 
 def uformat(s):

--- a/test/test_testutils.py
+++ b/test/test_testutils.py
@@ -1,13 +1,14 @@
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Optional
 
+import pytest
+
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.term import URIRef
-from .testutils import GraphHelper, file_uri_to_path
 
-import pytest
+from .testutils import GraphHelper, file_uri_to_path
 
 
 def check(

--- a/test/test_tokendatatype.py
+++ b/test/test_tokendatatype.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rdflib import Literal, XSD
+from rdflib import XSD, Literal
 
 
 class TokenDatatypeTest(unittest.TestCase):

--- a/test/test_translate_algebra.py
+++ b/test/test_translate_algebra.py
@@ -121,12 +121,12 @@ algebra_tests = [
     AlgebraTest(
         "test_graph_patterns__group_and_substr",
         'Test if a query with a variable that is used in the "GROUP BY" clause '
-        'and in the SUBSTR function gets properly translated into the query text.',
+        "and in the SUBSTR function gets properly translated into the query text.",
     ),
     AlgebraTest(
         "test_graph_patterns__group_and_nested_concat",
-        'Test if a query with a nested concat expression in the select clause which '
-        'uses a group variable gets properly translated into the query text.',
+        "Test if a query with a nested concat expression in the select clause which "
+        "uses a group variable gets properly translated into the query text.",
     ),
     AlgebraTest(
         "test_graph_patterns__having",

--- a/test/test_trig.py
+++ b/test/test_trig.py
@@ -1,6 +1,7 @@
-import unittest
-import rdflib
 import re
+import unittest
+
+import rdflib
 
 TRIPLE = (
     rdflib.URIRef("http://example.com/s"),

--- a/test/test_trig_w3c.py
+++ b/test/test_trig_w3c.py
@@ -2,16 +2,16 @@
 
 """
 
-from typing import Callable, Dict
-from rdflib import ConjunctiveGraph
-from rdflib.namespace import Namespace, split_uri
-from rdflib.compare import graph_diff, isomorphic
-from rdflib.term import Node, URIRef
-
+import os
 from test.manifest import RDFT, RDFTest, read_manifest
+from typing import Callable, Dict
+
 import pytest
 
-import os
+from rdflib import ConjunctiveGraph
+from rdflib.compare import graph_diff, isomorphic
+from rdflib.namespace import Namespace, split_uri
+from rdflib.term import Node, URIRef
 
 verbose = False
 

--- a/test/test_triple_store.py
+++ b/test/test_triple_store.py
@@ -1,8 +1,8 @@
 import unittest
 
-from rdflib.term import BNode, Literal
-from rdflib.namespace import RDFS
 from rdflib.graph import Graph
+from rdflib.namespace import RDFS
+from rdflib.term import BNode, Literal
 
 
 class GraphTest(unittest.TestCase):

--- a/test/test_trix_parse.py
+++ b/test/test_trix_parse.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 import os
+import unittest
+from test import TEST_DIR
 
 from rdflib.graph import ConjunctiveGraph
-import unittest
-
-from test import TEST_DIR
 
 
 class TestTrixParse(unittest.TestCase):

--- a/test/test_tsvresults.py
+++ b/test/test_tsvresults.py
@@ -1,5 +1,6 @@
 import unittest
 from io import StringIO
+
 from rdflib.plugins.sparql.results.tsvresults import TSVResultParser
 
 

--- a/test/test_turtle_quoting.py
+++ b/test/test_turtle_quoting.py
@@ -5,9 +5,10 @@ ntriples, nquads, trig and n3.
 """
 
 from typing import Callable, Dict, Iterable, List, Tuple
-import pytest
-from rdflib.graph import ConjunctiveGraph
 
+import pytest
+
+from rdflib.graph import ConjunctiveGraph
 from rdflib.plugins.parsers import ntriples
 from rdflib.term import Literal
 

--- a/test/test_turtle_w3c.py
+++ b/test/test_turtle_w3c.py
@@ -3,14 +3,16 @@ test suite."""
 
 import os
 from pathlib import Path
+from test.manifest import RDFT, RDFTest, read_manifest
 from typing import Callable, Dict, Set
+
+import pytest
+
 from rdflib import Graph
-from rdflib.namespace import Namespace, split_uri
 from rdflib.compare import graph_diff, isomorphic
+from rdflib.namespace import Namespace, split_uri
 from rdflib.term import Node, URIRef
 
-from test.manifest import RDFT, RDFTest, read_manifest
-import pytest
 from .testutils import file_uri_to_path
 
 verbose = False

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -56,9 +56,7 @@ def test_rdflib_query_exercise() -> None:
     graph.add((kb_https_uriref, predicate_q, literal_two))
     graph.add((kb_bnode, predicate_p, literal_one))
 
-    expected_nodes_using_predicate_q: Set[rdflib.IdentifiedNode] = {
-        kb_https_uriref
-    }
+    expected_nodes_using_predicate_q: Set[rdflib.IdentifiedNode] = {kb_https_uriref}
     computed_nodes_using_predicate_q: Set[rdflib.IdentifiedNode] = set()
     for triple in graph.triples((None, predicate_q, None)):
         computed_nodes_using_predicate_q.add(triple[0])

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,20 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import time
+import unittest
 from unittest.case import expectedFailure
-from rdflib.graph import Graph
-from rdflib.graph import QuotedGraph
-from rdflib.graph import ConjunctiveGraph
-from rdflib.term import BNode
-from rdflib.term import Literal
-from rdflib.term import URIRef
-from rdflib import util
-from rdflib import XSD
-from rdflib.exceptions import SubjectTypeError
-from rdflib.exceptions import PredicateTypeError
-from rdflib.exceptions import ObjectTypeError
-from rdflib.exceptions import ContextTypeError
+
+from rdflib import XSD, util
+from rdflib.exceptions import (ContextTypeError, ObjectTypeError, PredicateTypeError,
+                               SubjectTypeError)
+from rdflib.graph import ConjunctiveGraph, Graph, QuotedGraph
+from rdflib.term import BNode, Literal, URIRef
 
 n3source = """\
 @prefix : <http://www.w3.org/2000/10/swap/Primer#>.

--- a/test/test_variants.py
+++ b/test/test_variants.py
@@ -5,18 +5,8 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 from test.testutils import GraphHelper
-from typing import (
-    ClassVar,
-    Collection,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Pattern,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import (ClassVar, Collection, Dict, Iterable, List, Optional, Pattern,
+                    Tuple, Union, cast)
 
 import pytest
 from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -1,45 +1,30 @@
 from __future__ import print_function
 
-import os
-import sys
-from types import TracebackType
-import isodate
 import datetime
-import random
-
-from contextlib import AbstractContextManager, contextmanager
-from typing import (
-    Callable,
-    Iterable,
-    List,
-    Optional,
-    TYPE_CHECKING,
-    Type,
-    Iterator,
-    Set,
-    Tuple,
-    Dict,
-    Any,
-    TypeVar,
-    Union,
-    cast,
-    NamedTuple,
-)
-from urllib.parse import ParseResult, unquote, urlparse, parse_qs
-from traceback import print_exc
-from threading import Thread
-from http.server import BaseHTTPRequestHandler, HTTPServer, SimpleHTTPRequestHandler
 import email.message
+import os
+import random
+import sys
 import unittest
-
-from rdflib import BNode, Graph, ConjunctiveGraph
-from rdflib.term import Identifier, Literal, Node, URIRef
+from contextlib import AbstractContextManager, contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer, SimpleHTTPRequestHandler
+from pathlib import PurePath, PureWindowsPath
+from threading import Thread
+from traceback import print_exc
+from types import TracebackType
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, List,
+                    NamedTuple, Optional, Set, Tuple, Type, TypeVar, Union, cast)
 from unittest.mock import MagicMock, Mock
 from urllib.error import HTTPError
+from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 from urllib.request import urlopen
-from pathlib import PurePath, PureWindowsPath
+
+import isodate
 from nturl2path import url2pathname as nt_url2pathname
+
 import rdflib.compare
+from rdflib import BNode, ConjunctiveGraph, Graph
+from rdflib.term import Identifier, Literal, Node, URIRef
 
 if TYPE_CHECKING:
     import typing_extensions as te

--- a/test/type_check.py
+++ b/test/type_check.py
@@ -1,9 +1,7 @@
 import unittest
 
+from rdflib.exceptions import ObjectTypeError, PredicateTypeError, SubjectTypeError
 from rdflib.graph import Graph
-from rdflib.exceptions import SubjectTypeError
-from rdflib.exceptions import PredicateTypeError
-from rdflib.exceptions import ObjectTypeError
 from rdflib.term import URIRef
 
 foo = URIRef("foo")


### PR DESCRIPTION
Ref: #1159, https://github.com/RDFLib/rdflib/discussions/1589

## Proposed Changes

I just ran this in the project root: `$ black . && isort .`
