### PR TITLE
Improved tox config

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -20,29 +20,39 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - {
-              python-version: "3.7",
-              os: ubuntu-latest,
-              extensive-tests: true,
-            }
+          - python-version: "3.7"
+            os: ubuntu-latest
+            extensive-tests: true
+          - python-version: "3.8"
+            os: ubuntu-latest
+            TOX_EXTRA_COMMAND: "- isort --check-only --diff ."
+          - python-version: "3.9"
+            os: ubuntu-latest
+            TOX_EXTRA_COMMAND: "- black --check --diff ./rdflib"
+          - python-version: "3.10"
+            os: ubuntu-latest
+            TOX_EXTRA_COMMAND: "flake8 --exit-zero rdflib"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
       - uses: actions/setup-java@v2
         if: ${{ matrix.extensive-tests }}
         with:
           distribution: "temurin"
           java-version: "17"
-
+      - name: Setup env
+        shell: bash
+        run: |
+          MATRIX_PYTHON_VERSION=${{ matrix.python-version }}
+          echo "TOX_PYENV=py${MATRIX_PYTHON_VERSION//./}" >> ${GITHUB_ENV}
       - name: Get pip cache dir
         id: pip-cache
         shell: bash
         run: |
-          python -m ensurepip --upgrade
+          python -m ensurepip
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip
         uses: actions/cache@v2
@@ -59,13 +69,15 @@ jobs:
           key: ${{ matrix.os }}-xdg-v1-${{ hashFiles('**/with-fuseki.sh') }}
           restore-keys: |
             ${{ matrix.os }}-xdg-v1-
-      - name: Install dependencies
+      - name: Install python dependencies
         shell: bash
+        # Installing tox-gh-actions to get some enhancement to output rendering
+        # in github actions. Eventually we can maybe collapse the tox-envs job
+        # into this one but there are some limitations of tox-gh-actions which
+        # preclude doing that at the moment.
         run: |
-          pip install --default-timeout 60 -r requirements.txt
-          pip install --default-timeout 60 -r requirements.dev.txt
-          python setup.py install
-      - name: Install extra dev dependencies
+          python -m pip install tox tox-gh-actions
+      - name: Install system depdendencies for extensive tests
         if: ${{ matrix.extensive-tests }}
         shell: bash
         run: |
@@ -77,7 +89,6 @@ jobs:
               brew install berkeley-db@4
               export BERKELEYDB_DIR=$(brew --prefix berkeley-db@4)
           fi
-          pip install --default-timeout 60 -r requirements.dev-extra.txt
       - name: Validate
         shell: bash
         run: |
@@ -86,14 +97,19 @@ jobs:
           then
             1>&2 echo "Running with fuseki"
             test_harness+="./with-fuseki.sh"
+            TOX_PYENV_SUFFIX=-extensive
           fi
-          black --config pyproject.toml --check --diff ./rdflib || true
-          isort --check-only --diff . || true
-          flake8 --exit-zero rdflib
-          mypy --show-error-context --show-error-codes
-          "${test_harness[@]}" pytest -ra --cov
+          TOXENV="${{ matrix.TOXENV }}"
+          TOXENV="${TOX_PYENV}${TOX_PYENV_SUFFIX}${TOXENV:+,${TOXENV}}"
+          export TOXENV
+          export TOX_EXTRA_COMMAND="${{ matrix.TOX_EXTRA_COMMAND }}"
+          "${test_harness[@]}" python -m tox
   docs:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-env: ["docs"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{env.DEFAULT_PYTHON}}
@@ -110,15 +126,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: docs-pip-v1-${{
+          key: tox-${{ matrix.tox-env }}-pip-v1-${{
             hashFiles('**/setup.py', '**/requirements*.txt') }}
           restore-keys: |
-            docs-pip-v1-
+            tox-${{ matrix.tox-env }}-pip-v1-
       - name: Install dependencies
         shell: bash
         run: |
-          python -m pip install tox
-      - name: Build docs
+          python -m pip install tox tox-gh-actions
+      - name: Run ${{ matrix.tox-env }}
         shell: bash
         run: |
-          python -m tox -e docs
+          python -m tox -e ${{ matrix.tox-env }}

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -156,21 +156,26 @@ makes it easier to run validation on all supported python versions.
 
 .. code-block:: bash
 
-    # install tox
+    # Install tox.
     pip install tox
 
-    # list tox environments that run by default
+    # List the tox environments that run by default.
     tox -e
 
-    # list all tox environments
-    tox -a
-
-    # run default environment for all python versions
+    # Run the default environments.
     tox
 
-    # run a specific environment
+    # List all tox environments, including ones that don't run by default.
+    tox -a
+
+    # Run a specific environment.
     tox -e py37 # default environment with py37
-    tox -e py39-mypy # mypy environment with py39
+    tox -e py39-extra # extra tests with py39
+
+    # Override the test command.
+    # the below command will run `pytest test/test_translate_algebra.py`
+    # instead of the default pytest command.
+    tox -e py37,py39 -- pytest test/test_translate_algebra.py
 
 Writing documentation
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ kwargs["install_requires"] = [
     "importlib-metadata; python_version < '3.8.0'",
 ]
 kwargs["tests_require"] = [
-    "berkeleydb",
     "html5lib",
-    "networkx",
     "pytest",
     "pytest-cov",
     "pytest-subtests",
@@ -29,6 +27,16 @@ kwargs["extras_require"] = {
         "sphinx < 5",
         "sphinxcontrib-apidoc",
         "sphinxcontrib-kroki",
+    ],
+    "berkeleydb": ["berkeleydb"],
+    "networkx": ["networkx"],
+    "dev": [
+        "black==21.9b0",
+        "mypy",
+        "flake8",
+        "flake8-black",
+        "isort",
+        "types-setuptools",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ kwargs["extras_require"] = {
     "berkeleydb": ["berkeleydb"],
     "networkx": ["networkx"],
     "dev": [
-        "black==21.9b0",
+        "black==22.1.0",
         "mypy",
         "flake8",
         "flake8-black",

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,40 @@
 [tox]
 envlist =
-    py37,py38,py39,py310,precommit
+    py3{7,8,9,10},covreport,docs,precommit
 
 [testenv]
 setenv =
-    BERKELEYDB_DIR = /usr
+    extensive: BERKELEYDB_DIR = /usr
+    COVERAGE_FILE={toxinidir}/.coverage.{envname}
+    MYPY_CACHE_DIR={envdir}/.mypy_cache
+extras =
+    tests
+    dev
+    extensive: berkeleydb
+    extensive: networkx
 commands =
-    {envpython} -m mypy rdflib --show-error-context --show-error-codes
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    {envpython} -m pytest
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
+    {env:TOX_EXTRA_COMMAND:}
+    {env:TOX_MYPY_COMMAND:{envpython} -m mypy --show-error-context --show-error-codes}
+    {posargs:{envpython} -m pytest --cov --cov-report=}
 
-[testenv:cover]
-basepython =
-    python3.7
+[testenv:covreport]
+deps = coverage
+skip_install = true
+parallel_show_output = true
+depends = py3{7,8,9,10}{-extensive,}
+setenv =
+    COVERAGE_FILE=
 commands =
-    {envpython} -m pytest \
-		--cov-report term \
-		--cov-report html \
-		--cov
-
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
-
-[testenv:py3{7,8,9,10}-mypy]
-commands =
-    {envpython} -m mypy --show-error-context --show-error-codes
-deps =
-	-rrequirements.txt
-	-rrequirements.dev.txt
+    {envpython} -m coverage combine
+    {envpython} -m coverage report
 
 [testenv:docs]
-basepython =
-    python3.7
-deps =
-extras =
-    docs
+extras = docs
 passenv = TERM
 setenv =
     PYTHONHASHSEED = 0
 commands =
-    sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -n -T -b html -d {envdir}/doctree docs docs/_build/html
 
 [testenv:precommit{,all}]
 skip_install = true


### PR DESCRIPTION
- Removed some redundant options.
- Created a covreport environment for reporting coverage for all
environments.
- Make it possible to run a custom command instead of pytest.
- Make it possible to run an extra command
- Make it possible to change the mypy command
- Use extras instead of using requirements files.
- Improve rebuild speed of docs environment by not using an ephemeral doctree dir.

Also:

- Update setup.py
  - Remove berkleydb and networkx from tests_require and tests extra
    group as they are not always needed for tests.
  - Added separate extra groups for berkleydb and networkx
  - Added a dev extras group with dev tools.
- Update github actions
  - Use tox to run tests.
  - Run flake8 only once instead of for every OS and python version.
  - Change docs job to rather be more generic for potential future tox
    environments.


NOTE: Split off from #1672 