### PR TITLE
Make `bind_namespaces` optional

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -332,7 +332,7 @@ class Graph(Node):
         identifier: Optional[Union[Node, str]] = None,
         namespace_manager: Optional[NamespaceManager] = None,
         base: Optional[str] = None,
-        bind_namespaces: str = "core"
+        bind_namespaces: Optional[str] = "core",
     ):
         super(Graph, self).__init__()
         self.base = base

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -336,7 +336,7 @@ class NamespaceManager(object):
 
     """
 
-    def __init__(self, graph: "Graph", bind_namespaces: str = "core"):
+    def __init__(self, graph: "Graph", bind_namespaces: Optional[str] = "core"):
         self.graph = graph
         self.__cache: Dict[str, Tuple[str, URIRef, str]] = {}
         self.__cache_strict: Dict[str, Tuple[str, URIRef, str]] = {}
@@ -348,7 +348,9 @@ class NamespaceManager(object):
 
         # bind Namespaces as per options.
         # default is core
-        if bind_namespaces == "core":
+        if bind_namespaces is None:
+            pass  # bind nothing
+        elif bind_namespaces == "core":
             # bind a few core RDF namespaces
             for prefix, ns in NAMESPACE_PREFIXES_CORE.items():
                 self.bind(prefix, ns)
@@ -365,8 +367,8 @@ class NamespaceManager(object):
             # work out remainder - namespaces without prefixes
             # only look those ones up
             raise NotImplementedError("Haven't got to this option yet")
-        else:  # bind_namespaces is None
-            pass  # bind nothing
+        else:
+            raise ValueError(f"Invalid bind_namespaces value {bind_namespaces!r}")
 
     def __contains__(self, ref: str) -> bool:
         # checks if a reference is in any of the managed namespaces with syntax

--- a/test/test_namespacemanager.py
+++ b/test/test_namespacemanager.py
@@ -1,5 +1,8 @@
 import sys
 from pathlib import Path
+
+import pytest
+
 sys.path.append(str(Path(__file__).parent.parent.absolute()))
 from rdflib import Graph
 from rdflib.namespace import NAMESPACE_PREFIXES_CORE, NAMESPACE_PREFIXES_RDFLIB
@@ -24,3 +27,14 @@ def test_rdflib_prefixes_bound():
 
 def test_cc_prefixes_bound():
     pass
+
+
+def test_no_prefixes_bound():
+    g = Graph(bind_namespaces=None)
+    assert len(list(g.namespaces())) == 0
+
+
+def test_invalid_prefixes_bound():
+    with pytest.raises(ValueError):
+        g = Graph(bind_namespaces="INVALID")
+        list(g.namespaces())


### PR DESCRIPTION
Use `None` to indicate no-namespace binding so that invalid values are
treated as errors.