### PR TITLE
Remove singly-used alias obviated by IdentifiedNode

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1808,7 +1808,7 @@ class ConjunctiveGraph(Graph):
         # hint on InputSource (TODO/FIXME).
         g_id: str = publicID and publicID or source.getPublicId()
         if not isinstance(g_id, Node):
-            g_id = URIRef(g_id)  # type: ignore[arg-type]
+            g_id = URIRef(g_id)
 
         context = Graph(store=self.store, identifier=g_id)
         context.remove((None, None, None))  # hmm ?

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -18,7 +18,7 @@ import random
 from rdflib.namespace import Namespace, RDF
 from rdflib import plugin, exceptions, query, namespace
 import rdflib.term
-from rdflib.term import BNode, Node, URIRef, Literal, Genid
+from rdflib.term import BNode, IdentifiedNode, Node, URIRef, Literal, Genid
 from rdflib.paths import Path
 from rdflib.store import Store
 from rdflib.serializer import Serializer
@@ -43,9 +43,8 @@ assert Namespace  # avoid warning
 
 logger = logging.getLogger(__name__)
 
-# Type aliases to make unpacking what's going on a little more human friendly
-ContextNode = Union[BNode, URIRef]
-DatasetQuad = Tuple[Node, URIRef, Node, Optional[ContextNode]]
+# Type aliase to make unpacking what's going on a little more human friendly
+DatasetQuad = Tuple[Node, URIRef, Node, Optional[IdentifiedNode]]
 
 __doc__ = """\
 

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -2037,11 +2037,9 @@ class Dataset(ConjunctiveGraph):
             else:
                 yield s, p, o, c.identifier
 
-    # FIXME: Currently graph identifiers/context can be any Node, even
-    # though this goes outside of the RDF 1.1. specificiation. This should be
-    # fixed, but the fix should not only fix the return value here but also
-    # narrow the type annotations of Graph.__new__.
-    def __iter__(self) -> Generator[Tuple[Node, URIRef, Node, Optional[Node]], None, None]:
+    def __iter__(
+        self,
+    ) -> Generator[Tuple[Node, URIRef, Node, Optional[IdentifiedNode]], None, None]:
         """Iterates over all quads in the store"""
         return self.quads((None, None, None, None))
 

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -44,7 +44,8 @@ assert Namespace  # avoid warning
 logger = logging.getLogger(__name__)
 
 # Type aliase to make unpacking what's going on a little more human friendly
-DatasetQuad = Tuple[Node, URIRef, Node, Optional[IdentifiedNode]]
+ContextNode = Union[IdentifiedNode, Literal, str, None]
+DatasetQuad = Tuple[Node, URIRef, Node, Optional[ContextNode]]
 
 __doc__ = """\
 


### PR DESCRIPTION
ContextNode did not appear anywhere else in the code base.

This PR has no associated Issue.

## Proposed Changes
  - Remove `ContextNode` from `/rdflib/graph.py`.
  - Import `IdentifiedNode` into `/rdflib/graph.py`.