### PR TITLE
Apply IdentifiedNode to Graph iterators

### DIFF
--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -511,7 +511,9 @@ class _TripleCanonicalizer(object):
         if stats is not None:
             stats["color_count"] = len(coloring)
 
-        bnode_labels: Dict[Node, str] = dict([(c.nodes[0], c.hash_color()) for c in coloring])
+        bnode_labels: Dict[Node, str] = dict(
+            [(c.nodes[0], c.hash_color()) for c in coloring]
+        )
         if stats is not None:
             stats["canonicalize_triples_runtime"] = _total_seconds(
                 datetime.now() - start_coloring
@@ -521,7 +523,9 @@ class _TripleCanonicalizer(object):
             yield result
 
     def _canonicalize_bnodes(
-        self, triple: Tuple[IdentifiedNode, IdentifiedNode, Node], labels: Dict[Node, str]
+        self,
+        triple: Tuple[IdentifiedNode, IdentifiedNode, Node],
+        labels: Dict[Node, str],
     ):
         for term in triple:
             if isinstance(term, BNode):

--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -93,7 +93,7 @@ __all__ = [
 ]
 
 from rdflib.graph import Graph, ConjunctiveGraph, ReadOnlyGraphAggregate
-from rdflib.term import BNode, Node, URIRef
+from rdflib.term import BNode, Node, URIRef, IdentifiedNode
 from hashlib import sha256
 
 from datetime import datetime
@@ -214,7 +214,7 @@ Stats = Dict[str, Union[int, str]]
 class Color:
     def __init__(
         self,
-        nodes: List[Node],
+        nodes: List[IdentifiedNode],
         hashfunc: HashFunc,
         color: ColorItemTuple = (),
         hash_cache: HashCache = None,
@@ -511,7 +511,7 @@ class _TripleCanonicalizer(object):
         if stats is not None:
             stats["color_count"] = len(coloring)
 
-        bnode_labels = dict([(c.nodes[0], c.hash_color()) for c in coloring])
+        bnode_labels: Dict[Node, str] = dict([(c.nodes[0], c.hash_color()) for c in coloring])
         if stats is not None:
             stats["canonicalize_triples_runtime"] = _total_seconds(
                 datetime.now() - start_coloring
@@ -521,7 +521,7 @@ class _TripleCanonicalizer(object):
             yield result
 
     def _canonicalize_bnodes(
-        self, triple: Tuple[Node, Node, Node], labels: Dict[Node, str]
+        self, triple: Tuple[IdentifiedNode, IdentifiedNode, Node], labels: Dict[Node, str]
     ):
         for term in triple:
             if isinstance(term, BNode):

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -18,7 +18,7 @@ import random
 from rdflib.namespace import Namespace, RDF
 from rdflib import plugin, exceptions, query, namespace
 import rdflib.term
-from rdflib.term import BNode, Node, URIRef, Literal, Genid
+from rdflib.term import BNode, IdentifiedNode, Node, URIRef, Literal, Genid
 from rdflib.paths import Path
 from rdflib.store import Store
 from rdflib.serializer import Serializer
@@ -453,8 +453,8 @@ class Graph(Node):
         return self
 
     def triples(
-        self, triple: Tuple[Optional[Node], Union[None, Path, Node], Optional[Node]]
-    ):
+        self, triple: Tuple[Optional[IdentifiedNode], Union[None, Path, IdentifiedNode], Optional[Node]]
+    ) -> Iterable[Tuple[IdentifiedNode, IdentifiedNode, Node]]:
         """Generator over the triple store
 
         Returns triples that match the given triple pattern. If triple pattern
@@ -672,7 +672,7 @@ class Graph(Node):
         self.add((subject, predicate, object_))
         return self
 
-    def subjects(self, predicate=None, object=None, unique=False) -> Iterable[Node]:
+    def subjects(self, predicate: Union[None, Path, IdentifiedNode]=None, object: Optional[Node]=None, unique: bool=False) -> Iterable[IdentifiedNode]:
         """A generator of (optionally unique) subjects with the given
         predicate and object"""
         if not unique:
@@ -691,7 +691,7 @@ class Graph(Node):
                         )
                         raise
 
-    def predicates(self, subject=None, object=None, unique=False) -> Iterable[Node]:
+    def predicates(self, subject: Optional[IdentifiedNode]=None, object: Optional[Node]=None, unique: bool=False) -> Iterable[IdentifiedNode]:
         """A generator of (optionally unique) predicates with the given
         subject and object"""
         if not unique:
@@ -710,7 +710,7 @@ class Graph(Node):
                         )
                         raise
 
-    def objects(self, subject=None, predicate=None, unique=False) -> Iterable[Node]:
+    def objects(self, subject: Optional[IdentifiedNode]=None, predicate: Union[None, Path, IdentifiedNode]=None, unique: bool=False) -> Iterable[Node]:
         """A generator of (optionally unique) objects with the given
         subject and predicate"""
         if not unique:
@@ -730,8 +730,8 @@ class Graph(Node):
                         raise
 
     def subject_predicates(
-        self, object=None, unique=False
-    ) -> Generator[Tuple[Node, Node], None, None]:
+        self, object: Optional[Node]=None, unique: bool=False
+    ) -> Generator[Tuple[IdentifiedNode, IdentifiedNode], None, None]:
         """A generator of (optionally unique) (subject, predicate) tuples
         for the given object"""
         if not unique:
@@ -751,8 +751,8 @@ class Graph(Node):
                         raise
 
     def subject_objects(
-        self, predicate=None, unique=False
-    ) -> Generator[Tuple[Node, Node], None, None]:
+        self, predicate: Union[None, Path, IdentifiedNode]=None, unique: bool=False
+    ) -> Generator[Tuple[IdentifiedNode, Node], None, None]:
         """A generator of (optionally unique) (subject, object) tuples
         for the given predicate"""
         if not unique:
@@ -772,8 +772,8 @@ class Graph(Node):
                         raise
 
     def predicate_objects(
-        self, subject=None, unique=False
-    ) -> Generator[Tuple[Node, Node], None, None]:
+        self, subject: Optional[IdentifiedNode]=None, unique: bool=False
+    ) -> Generator[Tuple[IdentifiedNode, Node], None, None]:
         """A generator of (optionally unique) (predicate, object) tuples
         for the given subject"""
         if not unique:

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -457,19 +457,19 @@ class Graph(Node):
         triple: Tuple[
             Optional[IdentifiedNode], Union[None, Path, IdentifiedNode], Optional[Node]
         ],
-    ) -> Iterable[Tuple[IdentifiedNode, IdentifiedNode, Node]]:
+    ) -> Iterable[Tuple[IdentifiedNode, Union[IdentifiedNode, Path], Node]]:
         """Generator over the triple store
 
         Returns triples that match the given triple pattern. If triple pattern
         does not provide a context, all contexts will be searched.
         """
-        s, p, o = triple
-        if isinstance(p, Path):
-            for _s, _o in p.eval(self, s, o):
-                yield _s, p, _o
+        (s0, p0, o0) = triple
+        if isinstance(p0, Path):
+            for s1, o1 in p0.eval(self, s0, o0):
+                yield s1, p0, o1
         else:
-            for (s, p, o), cg in self.__store.triples((s, p, o), context=self):
-                yield s, p, o
+            for (s2, p2, o2), cg in self.__store.triples(triple, context=self):
+                yield s2, p2, o2
 
     def __getitem__(self, item):
         """

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -453,7 +453,10 @@ class Graph(Node):
         return self
 
     def triples(
-        self, triple: Tuple[Optional[IdentifiedNode], Union[None, Path, IdentifiedNode], Optional[Node]]
+        self,
+        triple: Tuple[
+            Optional[IdentifiedNode], Union[None, Path, IdentifiedNode], Optional[Node]
+        ],
     ) -> Iterable[Tuple[IdentifiedNode, IdentifiedNode, Node]]:
         """Generator over the triple store
 
@@ -672,7 +675,12 @@ class Graph(Node):
         self.add((subject, predicate, object_))
         return self
 
-    def subjects(self, predicate: Union[None, Path, IdentifiedNode]=None, object: Optional[Node]=None, unique: bool=False) -> Iterable[IdentifiedNode]:
+    def subjects(
+        self,
+        predicate: Union[None, Path, IdentifiedNode] = None,
+        object: Optional[Node] = None,
+        unique: bool = False,
+    ) -> Iterable[IdentifiedNode]:
         """A generator of (optionally unique) subjects with the given
         predicate and object"""
         if not unique:
@@ -691,7 +699,12 @@ class Graph(Node):
                         )
                         raise
 
-    def predicates(self, subject: Optional[IdentifiedNode]=None, object: Optional[Node]=None, unique: bool=False) -> Iterable[IdentifiedNode]:
+    def predicates(
+        self,
+        subject: Optional[IdentifiedNode] = None,
+        object: Optional[Node] = None,
+        unique: bool = False,
+    ) -> Iterable[IdentifiedNode]:
         """A generator of (optionally unique) predicates with the given
         subject and object"""
         if not unique:
@@ -710,7 +723,12 @@ class Graph(Node):
                         )
                         raise
 
-    def objects(self, subject: Optional[IdentifiedNode]=None, predicate: Union[None, Path, IdentifiedNode]=None, unique: bool=False) -> Iterable[Node]:
+    def objects(
+        self,
+        subject: Optional[IdentifiedNode] = None,
+        predicate: Union[None, Path, IdentifiedNode] = None,
+        unique: bool = False,
+    ) -> Iterable[Node]:
         """A generator of (optionally unique) objects with the given
         subject and predicate"""
         if not unique:
@@ -730,7 +748,7 @@ class Graph(Node):
                         raise
 
     def subject_predicates(
-        self, object: Optional[Node]=None, unique: bool=False
+        self, object: Optional[Node] = None, unique: bool = False
     ) -> Generator[Tuple[IdentifiedNode, IdentifiedNode], None, None]:
         """A generator of (optionally unique) (subject, predicate) tuples
         for the given object"""
@@ -751,7 +769,7 @@ class Graph(Node):
                         raise
 
     def subject_objects(
-        self, predicate: Union[None, Path, IdentifiedNode]=None, unique: bool=False
+        self, predicate: Union[None, Path, IdentifiedNode] = None, unique: bool = False
     ) -> Generator[Tuple[IdentifiedNode, Node], None, None]:
         """A generator of (optionally unique) (subject, object) tuples
         for the given predicate"""
@@ -772,7 +790,7 @@ class Graph(Node):
                         raise
 
     def predicate_objects(
-        self, subject: Optional[IdentifiedNode]=None, unique: bool=False
+        self, subject: Optional[IdentifiedNode] = None, unique: bool = False
     ) -> Generator[Tuple[IdentifiedNode, Node], None, None]:
         """A generator of (optionally unique) (predicate, object) tuples
         for the given subject"""

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -464,9 +464,7 @@ class Graph(Node):
     @overload
     def triples(
         self,
-        triple: Tuple[
-            Optional[IdentifiedNode], Path, Optional[Node]
-        ],
+        triple: Tuple[Optional[IdentifiedNode], Path, Optional[Node]],
     ) -> Iterable[Tuple[IdentifiedNode, Path, Node]]:
         ...
 

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -182,8 +182,8 @@ No vars specified:
 
 
 from functools import total_ordering
-from rdflib.term import URIRef, Node
-from typing import Union, Callable, TYPE_CHECKING
+from rdflib.term import URIRef, Node, IdentifiedNode
+from typing import Union, Callable, TYPE_CHECKING, Optional, Iterator, Tuple
 
 if TYPE_CHECKING:
     from rdflib import Graph
@@ -205,7 +205,12 @@ class Path(object):
     __truediv__: Callable[["Path", Union["URIRef", "Path"]], "SequencePath"]
     __mul__: Callable[["Path", str], "MulPath"]
 
-    def eval(self, graph: "Graph", subj=None, obj=None):
+    def eval(
+        self,
+        graph: "Graph",
+        subj: Optional[IdentifiedNode] = None,
+        obj: Optional[Node] = None,
+    ) -> Iterator[Tuple[IdentifiedNode, Node]]:
         raise NotImplementedError()
 
     def __lt__(self, other):

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -183,7 +183,10 @@ No vars specified:
 
 from functools import total_ordering
 from rdflib.term import URIRef, Node
-from typing import Union, Callable
+from typing import Union, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rdflib import Graph
 
 
 # property paths
@@ -202,7 +205,7 @@ class Path(object):
     __truediv__: Callable[["Path", Union["URIRef", "Path"]], "SequencePath"]
     __mul__: Callable[["Path", str], "MulPath"]
 
-    def eval(self, graph, subj=None, obj=None):
+    def eval(self, graph: "Graph", subj=None, obj=None):
         raise NotImplementedError()
 
     def __lt__(self, other):

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -206,7 +206,7 @@ class PrettyXMLSerializer(Serializer):
 
         subject: IdentifiedNode
         # Write out subjects that can not be inline
-        for subject in store.subjects():  # type: ignore[assignment]
+        for subject in store.subjects():
             if (None, None, subject) in store:
                 if (subject, None, subject) in store:
                     self.subject(subject, 1)
@@ -217,7 +217,7 @@ class PrettyXMLSerializer(Serializer):
         # write out BNodes last (to ensure they can be inlined where possible)
         bnodes = set()
 
-        for subject in store.subjects():  # type: ignore[assignment]
+        for subject in store.subjects():
             if isinstance(subject, BNode):
                 bnodes.add(subject)
                 continue

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -187,7 +187,9 @@ class PrettyXMLSerializer(Serializer):
         self.writer = writer = XMLWriter(stream, nm, encoding)
         namespaces = {}
 
-        possible: Set[Node] = set(store.predicates()).union(store.objects(None, RDF.type))
+        possible: Set[Node] = set(store.predicates()).union(
+            store.objects(None, RDF.type)
+        )
 
         for predicate in possible:
             prefix, namespace, local = nm.compute_qname_strict(predicate)

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -5,7 +5,7 @@ from rdflib.namespace import Namespace, RDF, RDFS  # , split_uri
 from rdflib.plugins.parsers.RDFVOC import RDFVOC
 
 from rdflib.graph import Graph
-from rdflib.term import Identifier, URIRef, Literal, BNode
+from rdflib.term import Identifier, URIRef, Literal, BNode, Node, IdentifiedNode
 from rdflib.util import first, more_than
 from rdflib.collection import Collection
 from rdflib.serializer import Serializer
@@ -187,7 +187,9 @@ class PrettyXMLSerializer(Serializer):
         self.writer = writer = XMLWriter(stream, nm, encoding)
         namespaces = {}
 
-        possible = set(store.predicates()).union(store.objects(None, RDF.type))
+        possible: Set[Node] = set()
+        possible |= set(store.predicates())
+        possible |= set(store.objects(None, RDF.type))
 
         for predicate in possible:
             prefix, namespace, local = nm.compute_qname_strict(predicate)
@@ -204,7 +206,7 @@ class PrettyXMLSerializer(Serializer):
 
         writer.namespaces(namespaces.items())
 
-        subject: Identifier
+        subject: IdentifiedNode
         # Write out subjects that can not be inline
         for subject in store.subjects():  # type: ignore[assignment]
             if (None, None, subject) in store:
@@ -234,7 +236,7 @@ class PrettyXMLSerializer(Serializer):
         # Set to None so that the memory can get garbage collected.
         self.__serialized = None  # type: ignore[assignment]
 
-    def subject(self, subject: Identifier, depth: int = 1):
+    def subject(self, subject: IdentifiedNode, depth: int = 1):
         store = self.store
         writer = self.writer
 

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -293,7 +293,9 @@ class Store(object):
 
     def triples(
         self,
-        triple_pattern: Tuple[Optional["IdentifiedNode"], Optional["IdentifiedNode"], Optional["Node"]],
+        triple_pattern: Tuple[
+            Optional["IdentifiedNode"], Optional["IdentifiedNode"], Optional["Node"]
+        ],
         context=None,
     ):
         """


### PR DESCRIPTION
Fixes #1696 

## Proposed Changes

  - Use `IdentifiedNode` on `Graph.triples()` and related methods
  - Apply type signature revisions to `compare.py` and `rdf-xml` serializer.
  - (More to come after discussion on #1696 settles.)

Note the `Graph` signature updates should also be propagated to `Graph` subclasses before this is merged.