### PR TITLE
Introduce WGS84 DefinedNamespace

### DIFF
--- a/rdflib/namespace/_WGS84.py
+++ b/rdflib/namespace/_WGS84.py
@@ -1,0 +1,31 @@
+from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
+
+
+class WGS84(DefinedNamespace):
+    """
+    Basic Geo (WGS84 lat/long) Vocabulary
+
+    The HTML Specification for the vocabulary can be found
+    `here <https://www.w3.org/2003/01/geo/>`.
+    """
+
+    _NS = Namespace("https://www.w3.org/2003/01/geo/wgs84_pos#")
+
+    # http://www.w3.org/2000/01/rdf-schema#Datatype
+    SpatialThing: URIRef
+    Point: URIRef
+
+    # http://www.w3.org/2002/07/owl#DatatypeProperty
+    alt: URIRef
+
+    # NOTE: this is not in the official vocabulary, but it is used by dbpedia
+    # and will commonly be treated as a de-facto term. It's range appears to be
+    # a structured string literal. E.g.,
+    # > _:something geo:geometry "POINT(-76.348335266113 39.536666870117)"
+    geometry: URIRef
+
+    lat: URIRef  # http://www.w3.org/2003/01/geo/wgs84_pos#lat
+    lat_long: URIRef
+    location: URIRef
+    long: URIRef

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -75,6 +75,7 @@ The following namespaces are available by directly importing from rdflib:
 * TIME
 * VANN
 * VOID
+* WGS84
 * XSD
 
 .. code-block:: pycon
@@ -373,6 +374,7 @@ class NamespaceManager(object):
         self.bind("time", TIME)
         self.bind("vann", VANN)
         self.bind("void", VOID)
+        self.bind("wgs84", WGS84)
         self.bind("xsd", XSD)
 
         # Namespace bindings.
@@ -777,4 +779,5 @@ from rdflib.namespace._SSN import SSN
 from rdflib.namespace._TIME import TIME
 from rdflib.namespace._VANN import VANN
 from rdflib.namespace._VOID import VOID
+from rdflib.namespace._WGS84 import WGS84
 from rdflib.namespace._XSD import XSD


### PR DESCRIPTION
The _WGS84 namespace was introduced to the namespace package matching the
convention of other namespaces. The comment style of the GEO vocabulary was
mimicked for consistency. wgs84:geometry was given additional documentation
because it is not a standard term in the namespace. It was included because it
is used by dbpedia. The prefix 'wgs84' was adopted for the namespace so that it
would not conflict with the current usage of 'geo' for GeoSPARQL.

Fixes #1709 

## Proposed Changes

  - Introduce _WGSS84 namespace
  - Export the namespace as `rdflib.namespace.WGS84`
  - Add `wgs84` as a default prefix for the namespace
