### PR TITLE
`DefinedNamespaceMeta.__getitem__` is slow

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Iterable
 from unicodedata import category
 
@@ -183,10 +184,7 @@ class URIPattern(str):
 
 
 class DefinedNamespaceMeta(type):
-    """
-    Utility metaclass for generating URIRefs with a common prefix
-
-    """
+    """Utility metaclass for generating URIRefs with a common prefix."""
 
     _NS: Namespace
     _warn: bool = True
@@ -194,6 +192,7 @@ class DefinedNamespaceMeta(type):
     _extras: List[str] = []  # List of non-pythonesque items
     _underscore_num: bool = False  # True means pass "_n" constructs
 
+    @lru_cache(maxsize=None)
     def __getitem__(cls, name: str, default=None) -> URIRef:
         name = str(name)
         if str(name).startswith("__"):

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -170,7 +170,6 @@ class Store(object):
             np.register(Variable, "V")
         return self.__node_pickler
 
-
     # Database management methods
     def create(self, configuration):
         self.dispatcher.dispatch(StoreCreatedEvent(configuration=configuration))


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Cache the `__getitem__` method to improve performance.
