### PR TITLE
Use the correct warnings module

### DIFF
--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -6,8 +6,7 @@ import sys
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List
-
-from sphinx import warnings
+import warnings
 
 import rdflib.plugin
 import rdflib.plugins.sparql


### PR DESCRIPTION
Accidentally used the one from sphinx instead of the builtin one, this
fixes the situation.
