### PR TITLE
black formatting for rdflib/store.py

### DIFF
--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -170,7 +170,6 @@ class Store(object):
             np.register(Variable, "V")
         return self.__node_pickler
 
-
     # Database management methods
     def create(self, configuration):
         self.dispatcher.dispatch(StoreCreatedEvent(configuration=configuration))


### PR DESCRIPTION
This somehow slipped by before pre-commit was in place, hopefully
pre-commit should now help us in future.
