### PR TITLE
Update reference to black.toml

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -87,7 +87,7 @@ jobs:
             1>&2 echo "Running with fuseki"
             test_harness+="./with-fuseki.sh"
           fi
-          black --config black.toml --check --diff ./rdflib || true
+          black --config pyproject.toml --check --diff ./rdflib || true
           isort --check-only --diff . || true
           flake8 --exit-zero rdflib
           mypy --show-error-context --show-error-codes


### PR DESCRIPTION
Updates #1692 

## Proposed Changes

  - Update Github workflow to no longer refer to black.toml

This could be reduced further and cut the `--config` flag.  I personally prefer the explicit reference, for the ease of finding configuration parameters.