### PR TITLE
Enable showing typehints in sphinx function/method signature and content

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
 apidoc_module_dir = "../rdflib"
 apidoc_output_dir = "apidocs"
 autodoc_default_options = {"special-members": True}
+autodoc_typehints = "both"
 
 autosummary_generate = True
 

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -1,5 +1,5 @@
-sphinx==4.4.0
-sphinxcontrib-apidoc
 git+https://github.com/gniezen/n3pygments.git
 myst-parser
+sphinx<5
+sphinxcontrib-apidoc
 sphinxcontrib-kroki

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,13 +4,13 @@ doctest-ignore-unicode==0.1.2
 flake8
 flake8-black
 html5lib
+isort
 mypy
 myst-parser
 pytest
 pytest-cov
 pytest-subtests
-isort
-sphinx
+sphinx<5
 sphinxcontrib-apidoc
 sphinxcontrib-kroki
 types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ kwargs["extras_require"] = {
     "html": ["html5lib"],
     "tests": kwargs["tests_require"],
     "docs": [
+        "myst-parser",
         "sphinx < 5",
         "sphinxcontrib-apidoc",
-        "myst-parser",
         "sphinxcontrib-kroki",
     ],
 }


### PR DESCRIPTION
Enable showing typehints in sphinx function/method signature and content

With current config sphinx only adds type hints to method/function
signatures.

This patch changes the `autodoc_typehints` from the default of
`signature` to `both`, which is described by sphinx documentation as:
"Show typehints in the signature and as content of the function or method".

For more info see:
https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints

Other changes:

- Harmonize sphinx version restriction across different places where
  dependencies are defined.
- Sort requirements files.
