### PR TITLE
Remove redundant type ignores and fix typing errors

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -576,4 +576,4 @@ Term = namedtuple(
     "Term",
     "id, name, type, container, index, language, reverse, context," "prefix, protected",
 )
-Term.__new__.__defaults__ = (UNDEF, UNDEF, UNDEF, UNDEF, False, UNDEF, False, False)  # type: ignore[attr-defined]
+Term.__new__.__defaults__ = (UNDEF, UNDEF, UNDEF, UNDEF, False, UNDEF, False, False)

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1968,8 +1968,7 @@ def _isEqualXMLNode(
         if TYPE_CHECKING:
             assert isinstance(node, xml.dom.minidom.DocumentType)
             assert isinstance(other, xml.dom.minidom.DocumentType)
-        # type error: "DocumentType" has no attribute "system"
-        return node.publicId == other.publicId and node.systemId == other.system.Id  # type: ignore[attr-defined]
+        return node.publicId == other.publicId and node.systemId == other.systemId
 
     else:
         # should not happen, in fact

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1906,14 +1906,12 @@ def _isEqualXMLNode(
         # to worry about that, which is a bonus...
         n_keys = [
             k
-            # type error: Item "Element" of "Union[Document, Element]" has no attribute "attributes"
-            for k in node.attributes.keysNS()  # type: ignore[union-attr]
+            for k in node.attributes.keysNS()
             if k[0] != "http://www.w3.org/2000/xmlns/"
         ]
         o_keys = [
             k
-            # type error: Item "Element" of "Union[Document, Element]" has no attribute "attributes"
-            for k in other.attributes.keysNS()  # type: ignore[union-attr]
+            for k in other.attributes.keysNS()
             if k[0] != "http://www.w3.org/2000/xmlns/"
         ]
         if len(n_keys) != len(o_keys):
@@ -1968,9 +1966,10 @@ def _isEqualXMLNode(
 
     elif node.nodeType == XMLNode.DOCUMENT_TYPE_NODE:
         if TYPE_CHECKING:
-            assert isinstance(node, xml.dom.minidom.Document)
-            assert isinstance(other, xml.dom.minidom.Document)
-        return node.publicId == other.publicId and node.systemId == other.system.Id
+            assert isinstance(node, xml.dom.minidom.DocumentType)
+            assert isinstance(other, xml.dom.minidom.DocumentType)
+        # type error: "DocumentType" has no attribute "system"
+        return node.publicId == other.publicId and node.systemId == other.system.Id  # type: ignore[attr-defined]
 
     else:
         # should not happen, in fact


### PR DESCRIPTION
This seems to be related to changes in typeshed and mypy.

Also fixed comparison done by `_isEqualXMLNode` for
`node.nodeType == XMLNode.DOCUMENT_TYPE_NODE`,
it was comparing `node.systemId == other.system.Id`
instead of `node.systemId == other.systemId`.
