### PR TITLE
Remove unused compatability function

### DIFF
--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -18,16 +18,6 @@ else:
         import xml.etree.ElementTree as etree
 
 
-try:
-    etree_register_namespace = etree.register_namespace
-except AttributeError:
-
-    import xml.etree.ElementTree as etreenative
-
-    def etree_register_namespace(prefix, uri):
-        etreenative._namespace_map[uri] = prefix
-
-
 def cast_bytes(s, enc="utf-8"):
     if isinstance(s, str):
         return s.encode(enc)


### PR DESCRIPTION


<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

This patch removes `rdflib.compat.etree_register_namespace` which was
needed before `xml.etree.register_namespace` was added in python 3.2,
however there is no code that uses it as is, so it serves no purpose
anymore.

```console
$ \rm -rf /var/tmp/rdflib-clean/
$ git clone --depth 1 --branch master git@github.com:RDFLib/rdflib.git /var/tmp/rdflib-clean/
Cloning into '/var/tmp/rdflib-clean'...
remote: Enumerating objects: 5392, done.
remote: Counting objects: 100% (5392/5392), done.
remote: Compressing objects: 100% (3837/3837), done.
remote: Total 5392 (delta 1213), reused 4996 (delta 1172), pack-reused 0
Receiving objects: 100% (5392/5392), 1.98 MiB | 1013.00 KiB/s, done.
Resolving deltas: 100% (1213/1213), done.
$ grep --exclude-dir={.tox,__pycache__,_build,build} -ri -e etree_register_namespace -e _namespace_map /var/tmp/rdflib-clean/
/var/tmp/rdflib-clean/rdflib/compat.py:    etree_register_namespace = etree.register_namespace
/var/tmp/rdflib-clean/rdflib/compat.py:    def etree_register_namespace(prefix, uri):
/var/tmp/rdflib-clean/rdflib/compat.py:        etreenative._namespace_map[uri] = prefix
$
```

I'm removing this primarily because it causes problems when running
pytype on rdflib:

```console
$ .venv/bin/pytype rdflib
...
File "/home/iwana/sw/d/github.com/iafork/rdflib.typing/rdflib/compat.py", line 28, in etree_register_namespace: No attribute '_namespace_map' on module 'xml.etree.ElementTree' [module-attr]
...
```




<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

