### PR TITLE
change pytest.skip to pytest.xfail

### DIFF
--- a/test/test_dawg.py
+++ b/test/test_dawg.py
@@ -212,7 +212,7 @@ def update_test(t: RDFTest):
     query_path: PurePath = file_uri_to_path(query)
 
     if uri in skiptests:
-        pytest.skip()
+        pytest.xfail()
 
     try:
         g = Dataset()
@@ -359,7 +359,7 @@ def query_test(t: RDFTest):
     resfile_path = file_uri_to_path(resfile) if resfile else None
 
     if uri in skiptests:
-        pytest.skip()
+        pytest.xfail()
 
     def skip(reason="(none)"):
         print("Skipping %s from now on." % uri)

--- a/test/test_parsers/test_swap_n3.py
+++ b/test/test_parsers/test_swap_n3.py
@@ -71,7 +71,7 @@ class Envelope(object):
 def generictest(e):
     """Documentation"""
     if e.skip:
-        pytest.skip("%s skipped, known issue" % e.name)
+        pytest.xfail("%s skipped, known issue" % e.name)
     g = rdflib.Graph()
     for i in [rdf, rdfs, xsd, owl, test, n3test, rdft, triage, mf, qt]:
         g.bind(str(i), i)


### PR DESCRIPTION
# Fix for issue #1793
# Summary of changes
Change `pytest.skip` to `pytest.xfail` in `test/test_dawg.py` and `test/test_parsers/test_swap_n3.py`

# Checklist
- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

