### PR TITLE
Migrate more tests to pytest

### DIFF
--- a/test/test_graph/test_canonicalization.py
+++ b/test/test_graph/test_canonicalization.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from typing import Set, Tuple
-from unittest.case import expectedFailure
 
 import pytest
 from rdflib.term import Node
@@ -524,7 +523,7 @@ _TripleSet = Set[_Triple]
 
 
 class TestConsistency(unittest.TestCase):
-    @expectedFailure
+    @pytest.mark.xfail
     def test_consistent_ids(self) -> None:
         """
         This test verifies that `to_canonical_graph` creates consistent
@@ -566,7 +565,3 @@ class TestConsistency(unittest.TestCase):
         assert cg0_ts.issubset(
             cg1_ts
         ), "canonical triple set cg0_ts should be a subset of canonical triple set cg1_ts"
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_graph/test_slice.py
+++ b/test/test_graph/test_slice.py
@@ -1,9 +1,10 @@
 from rdflib import Graph, URIRef
+from test.data import tarek, likes, pizza, cheese, michel, bob, hates
 import unittest
 
 
 class GraphSlice(unittest.TestCase):
-    def testSlice(self):
+    def test_slice():
         """
         We pervert the slice object,
         and use start, stop, step as subject, predicate, object
@@ -12,70 +13,43 @@ class GraphSlice(unittest.TestCase):
         """
 
         def sl(x, y):
-            return self.assertEqual(len(list(x)), y)
+            return len(list(x)) == y
 
         def soe(x, y):
-            return self.assertEqual(set([a[2] for a in x]), set(y))  # equals objects
+            return set([a[2] for a in x]) == set(y)  # equals objects
 
-        g = self.graph
+        g = Graph()
+        g.add((tarek, likes, pizza))
+        g.add((tarek, likes, cheese))
+        g.add((michel, likes, pizza))
+        g.add((michel, likes, cheese))
+        g.add((bob, likes, cheese))
+        g.add((bob, hates, pizza))
+        g.add((bob, hates, michel))  # gasp!
 
         # Single terms are all trivial:
 
         # single index slices by subject, i.e. return triples((x,None,None))
         # tell me everything about "tarek"
-        sl(g[self.tarek], 2)
+        sl(g[tarek], 2)
 
         # single slice slices by s,p,o, with : used to split
         # tell me everything about "tarek" (same as above)
-        sl(g[self.tarek : :], 2)
+        sl(g[tarek : :], 2)
 
         # give me every "likes" relationship
-        sl(g[: self.likes :], 5)
+        sl(g[: likes :], 5)
 
         # give me every relationship to pizza
-        sl(g[:: self.pizza], 3)
+        sl(g[:: pizza], 3)
 
         # give me everyone who likes pizza
-        sl(g[: self.likes : self.pizza], 2)
+        sl(g[: likes : pizza], 2)
 
         # does tarek like pizza?
-        self.assertTrue(g[self.tarek : self.likes : self.pizza])
+        assert g[tarek : likes : pizza] is True
 
         # More intesting is using paths
 
         # everything hated or liked
-        sl(g[: self.hates | self.likes], 7)
-
-    def setUp(self):
-        self.graph = Graph()
-
-        self.michel = URIRef("michel")
-        self.tarek = URIRef("tarek")
-        self.bob = URIRef("bob")
-        self.likes = URIRef("likes")
-        self.hates = URIRef("hates")
-        self.pizza = URIRef("pizza")
-        self.cheese = URIRef("cheese")
-
-        self.addStuff()
-
-    def addStuff(self):
-        tarek = self.tarek
-        michel = self.michel
-        bob = self.bob
-        likes = self.likes
-        hates = self.hates
-        pizza = self.pizza
-        cheese = self.cheese
-
-        self.graph.add((tarek, likes, pizza))
-        self.graph.add((tarek, likes, cheese))
-        self.graph.add((michel, likes, pizza))
-        self.graph.add((michel, likes, cheese))
-        self.graph.add((bob, likes, cheese))
-        self.graph.add((bob, hates, pizza))
-        self.graph.add((bob, hates, michel))  # gasp!
-
-
-if __name__ == "__main__":
-    unittest.main()
+        sl(g[: hates | likes], 7)

--- a/test/test_graph/test_slice.py
+++ b/test/test_graph/test_slice.py
@@ -4,7 +4,7 @@ import unittest
 
 
 class GraphSlice(unittest.TestCase):
-    def test_slice():
+    def test_slice(self):
         """
         We pervert the slice object,
         and use start, stop, step as subject, predicate, object

--- a/test/test_literal/test_datetime.py
+++ b/test/test_literal/test_datetime.py
@@ -17,7 +17,7 @@ class TestRelativeBase(unittest.TestCase):
             "2008-12-01T18:02:00Z",
             datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"),
         )
-        self.assertEqual(x == x, True)
+        assert x == x
 
     def test_microseconds(self):
         dt1 = datetime(2009, 6, 15, 23, 37, 6, 522630)
@@ -25,53 +25,46 @@ class TestRelativeBase(unittest.TestCase):
 
         # datetime with microseconds should be cast as a literal with using
         # XML Schema dateTime as the literal datatype
-        self.assertEqual(str(l), "2009-06-15T23:37:06.522630")
-        self.assertEqual(l.datatype, XSD.dateTime)
+        assert str(l) == "2009-06-15T23:37:06.522630"
+        assert l.datatype == XSD.dateTime
 
         dt2 = l.toPython()
-        self.assertEqual(dt2, dt1)
+        assert dt2 == dt1
 
     def test_to_python(self):
         dt = "2008-12-01T18:02:00"
         l = Literal(dt, datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"))
 
-        self.assertTrue(isinstance(l.toPython(), datetime))
-        self.assertEqual(l.toPython().isoformat(), dt)
+        assert isinstance(l.toPython(), datetime)
+        assert l.toPython().isoformat() == dt
 
     def test_timezone_z(self):
         dt = "2008-12-01T18:02:00.522630Z"
         l = Literal(dt, datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"))
 
-        self.assertTrue(isinstance(l.toPython(), datetime))
-        self.assertEqual(
-            datetime_isoformat(
-                l.toPython(), DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT
-            ),
-            dt,
+        assert isinstance(l.toPython(), datetime)
+        assert datetime_isoformat(
+            l.toPython() == DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT, dt
         )
-        self.assertEqual(l.toPython().isoformat(), "2008-12-01T18:02:00.522630+00:00")
+        assert l.toPython().isoformat() == "2008-12-01T18:02:00.522630+00:00"
 
     def test_timezone_offset(self):
         dt = "2010-02-10T12:36:00+03:00"
         l = Literal(dt, datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"))
 
-        self.assertTrue(isinstance(l.toPython(), datetime))
-        self.assertEqual(l.toPython().isoformat(), dt)
+        assert isinstance(l.toPython(), datetime)
+        assert l.toPython().isoformat() == dt
 
     def test_timezone_offset_to_utc(self):
         dt = "2010-02-10T12:36:00+03:00"
         l = Literal(dt, datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"))
 
         utc_dt = l.toPython().astimezone(UTC)
-        self.assertEqual(datetime_isoformat(utc_dt), "2010-02-10T09:36:00Z")
+        assert datetime_isoformat(utc_dt) == "2010-02-10T09:36:00Z"
 
     def test_timezone_offset_millisecond(self):
         dt = "2011-01-16T19:39:18.239743+01:00"
         l = Literal(dt, datatype=URIRef("http://www.w3.org/2001/XMLSchema#dateTime"))
 
-        self.assertTrue(isinstance(l.toPython(), datetime))
-        self.assertEqual(l.toPython().isoformat(), dt)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert isinstance(l.toPython(), datetime)
+        assert l.toPython().isoformat() == dt

--- a/test/test_literal/test_duration.py
+++ b/test/test_literal/test_duration.py
@@ -10,37 +10,30 @@ from rdflib.term import Literal
 class TestDuration(unittest.TestCase):
     def test_to_python_timedelta(self):
         l = Literal("P4DT5H6M7S", datatype=XSD.dayTimeDuration)
-        self.assertTrue(isinstance(l.toPython(), timedelta))
-        self.assertEqual(l.toPython(), parse_duration("P4DT5H6M7S"))
+        assert isinstance(l.toPython(), timedelta)
+        assert l.toPython() == parse_duration("P4DT5H6M7S")
 
     def test_to_python_ym_duration(self):
         l = Literal("P1Y2M", datatype=XSD.yearMonthDuration)
-        self.assertTrue(isinstance(l.toPython(), Duration))
-        self.assertEqual(l.toPython(), parse_duration("P1Y2M"))
+        assert isinstance(l.toPython(), Duration)
+        assert l.toPython() == parse_duration("P1Y2M")
 
     def test_to_python_ymdhms_duration(self):
         l = Literal("P1Y2M4DT5H6M7S", datatype=XSD.duration)
-        self.assertTrue(isinstance(l.toPython(), Duration))
-        self.assertEqual(l.toPython(), parse_duration("P1Y2M4DT5H6M7S"))
+        assert isinstance(l.toPython(), Duration)
+        assert l.toPython() == parse_duration("P1Y2M4DT5H6M7S")
 
-    def test_equality(self):
+    def test_equalityself():
         x = Literal("P1Y2M3W4DT5H6M7S", datatype=XSD.duration)
         y = Literal("P1Y2M25DT5H6M7S", datatype=XSD.duration)
-        self.assertTrue(x == y)
+        assert x == y
 
     def test_duration_le(self):
-        self.assertTrue(
-            Literal("P4DT5H6M7S", datatype=XSD.duration)
-            < Literal("P8DT10H12M14S", datatype=XSD.duration)
+        assert Literal("P4DT5H6M7S", datatype=XSD.duration) < Literal(
+            "P8DT10H12M14S", datatype=XSD.duration
         )
 
     def test_duration_sum(self):
-        self.assertEqual(
-            Literal("P1Y2M4DT5H6M7S", datatype=XSD.duration)
-            + Literal("P1Y2M4DT5H6M7S", datatype=XSD.duration).toPython(),
-            Literal("P2Y4M8DT10H12M14S", datatype=XSD.duration),
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert Literal("P1Y2M4DT5H6M7S", datatype=XSD.duration) + Literal(
+            "P1Y2M4DT5H6M7S", datatype=XSD.duration
+        ).toPython() == Literal("P2Y4M8DT10H12M14S", datatype=XSD.duration)

--- a/test/test_literal/test_duration.py
+++ b/test/test_literal/test_duration.py
@@ -23,7 +23,7 @@ class TestDuration(unittest.TestCase):
         assert isinstance(l.toPython(), Duration)
         assert l.toPython() == parse_duration("P1Y2M4DT5H6M7S")
 
-    def test_equalityself():
+    def test_equalityself(self):
         x = Literal("P1Y2M3W4DT5H6M7S", datatype=XSD.duration)
         y = Literal("P1Y2M25DT5H6M7S", datatype=XSD.duration)
         assert x == y

--- a/test/test_literal/test_normalized_string.py
+++ b/test/test_literal/test_normalized_string.py
@@ -8,29 +8,24 @@ class NormalizedStringTest(unittest.TestCase):
     def test1(self):
         lit2 = Literal("\two\nw", datatype=XSD.normalizedString)
         lit = Literal("\two\nw", datatype=XSD.string)
-        self.assertFalse(str(lit) == str(lit2))
+        assert str(lit) != str(lit2)
 
     def test2(self):
         lit = Literal(
             "\tBeing a Doctor Is\n\ta Full-Time Job\r", datatype=XSD.normalizedString
         )
         st = Literal(" Being a Doctor Is  a Full-Time Job ", datatype=XSD.string)
-        self.assertFalse(Literal.eq(st, lit))
-        self.assertEqual(str(lit), str(st))
+        assert Literal.eq(st, lit) is False
+        assert str(lit) == str(st)
 
     def test3(self):
         lit = Literal("hey\nthere", datatype=XSD.normalizedString).n3()
-        self.assertTrue(
-            lit == '"hey there"^^<http://www.w3.org/2001/XMLSchema#normalizedString>'
-        )
+        assert lit == '"hey there"^^<http://www.w3.org/2001/XMLSchema#normalizedString>'
 
     def test4(self):
         lit = Literal(
             "hey\nthere\ta tab\rcarriage return", datatype=XSD.normalizedString
         )
         expected = Literal("""hey there a tab carriage return""", datatype=XSD.string)
-        self.assertEqual(str(lit), str(expected))
+        assert str(lit) == str(expected)
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_literal/test_term.py
+++ b/test/test_literal/test_term.py
@@ -20,14 +20,14 @@ class TestURIRefRepr(unittest.TestCase):
     see also test_literal.TestRepr
     """
 
-    def testSubclassNameAppearsInRepr(self):
+    def test_subclass_name_appears_in_repr(self):
         class MyURIRef(URIRef):
             pass
 
         x = MyURIRef("http://example.com/")
-        self.assertEqual(repr(x), uformat("MyURIRef(u'http://example.com/')"))
+        assert repr(x) == uformat("MyURIRef(u'http://example.com/')")
 
-    def testGracefulOrdering(self):
+    def test_graceful_ordering(self):
         u = URIRef("cake")
         g = Graph()
         a = u > u
@@ -37,21 +37,20 @@ class TestURIRefRepr(unittest.TestCase):
 
 
 class TestBNodeRepr(unittest.TestCase):
-    def testSubclassNameAppearsInRepr(self):
+    def test_subclass_name_appears_in_repr(self):
         class MyBNode(BNode):
             pass
 
         x = MyBNode()
-        self.assertTrue(repr(x).startswith("MyBNode("))
-
+        assert repr(x).startswith("MyBNode(")
 
 class TestLiteral(unittest.TestCase):
     def test_base64_values(self):
         b64msg = "cmRmbGliIGlzIGNvb2whIGFsc28gaGVyZSdzIHNvbWUgYmluYXJ5IAAR83UC"
         decoded_b64msg = base64.b64decode(b64msg)
         lit = Literal(b64msg, datatype=XSD.base64Binary)
-        self.assertEqual(lit.value, decoded_b64msg)
-        self.assertEqual(str(lit), b64msg)
+        assert lit.value == decoded_b64msg
+        assert str(lit) == b64msg
 
     def test_total_order(self):
         types = {
@@ -78,7 +77,7 @@ class TestLiteral(unittest.TestCase):
                 print(repr(l_), repr(l_.value))
             print(e)
             orderable = False
-        self.assertTrue(orderable)
+        assert orderable is True
 
         # also make sure that within a datetime things are still ordered:
         l1 = [
@@ -101,7 +100,7 @@ class TestLiteral(unittest.TestCase):
         ]
         l2 = list(l1)
         random.shuffle(l2)
-        self.assertListEqual(l1, sorted(l2))
+        assert l1 == sorted(l2)
 
     def test_literal_add(self):
         from decimal import Decimal
@@ -267,7 +266,7 @@ class TestLiteral(unittest.TestCase):
                     + (case[1] + case[2]).datatype
                 )
 
-            self.assertTrue(case_passed, "Case " + str(case[0]) + " failed")
+            assert case_passed, "Case " + str(case[0]) + " failed"
 
 
 class TestValidityFunctions(unittest.TestCase):
@@ -282,4 +281,4 @@ class TestValidityFunctions(unittest.TestCase):
             (b"foo\xf3\x02", False),
         )
         for val, expected in testcase_list:
-            self.assertEqual(_is_valid_unicode(val), expected)
+            assert _is_valid_unicode(val) == expected

--- a/test/test_literal/test_tokendatatype.py
+++ b/test/test_literal/test_tokendatatype.py
@@ -7,22 +7,22 @@ class TokenDatatypeTest(unittest.TestCase):
     def test1(self):
         lit2 = Literal("\two\nw", datatype=XSD.normalizedString)
         lit = Literal("\two\nw", datatype=XSD.string)
-        self.assertFalse(str(lit) == str(lit2))
+        assert str(lit) != str(lit2)
 
     def test2(self):
         lit = Literal("\tBeing a Doctor    Is\n\ta Full-Time Job\r", datatype=XSD.token)
         st = Literal("Being a Doctor Is a Full-Time Job", datatype=XSD.string)
-        self.assertFalse(Literal.eq(st, lit))
-        self.assertEqual(str(lit), str(st))
+        assert Literal.eq(st, lit) is False
+        assert str(lit) == str(st)
 
     def test3(self):
         lit = Literal("       hey\nthere      ", datatype=XSD.token).n3()
-        self.assertTrue(lit == '"hey there"^^<http://www.w3.org/2001/XMLSchema#token>')
+        assert lit == '"hey there"^^<http://www.w3.org/2001/XMLSchema#token>'
 
     def test4(self):
         lit = Literal("hey\nthere\ta tab\rcarriage return", datatype=XSD.token)
         expected = Literal("""hey there a tab carriage return""", datatype=XSD.string)
-        self.assertEqual(str(lit), str(expected))
+        assert str(lit) == str(expected)
 
     def test_whitespace_is_collapsed_and_trailing_whitespace_is_stripped(self):
         lit = Literal(
@@ -33,8 +33,5 @@ class TokenDatatypeTest(unittest.TestCase):
             "hey - white space is collapsed for xsd:token and preceding and trailing whitespace is stripped",
             datatype=XSD.string,
         )
-        self.assertEqual(str(lit), str(expected))
+        assert str(lit) == str(expected)
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_misc/test_b64_binary.py
+++ b/test/test_misc/test_b64_binary.py
@@ -12,17 +12,14 @@ class B64BinaryTestCase(unittest.TestCase):
         b64_str1 = base64.b64encode(str1.encode("utf-8")).decode()
         l1 = Literal(b64_str1, datatype=XSD.base64Binary)
         b_str1 = l1.toPython()
-        self.assertEqual(b_str1.decode("utf-8"), str1)
-        self.assertEqual(str(l1), b64_str1)
+        assert b_str1.decode("utf-8") == str1
+        assert str(l1) == b64_str1
 
         # b b64string
         b64_str1b = base64.b64encode(str1.encode("utf-8"))
         l1b = Literal(b64_str1b, datatype=XSD.base64Binary)
         b_str1b = l1b.toPython()
-        self.assertEqual(b_str1, b_str1b)
-        self.assertEqual(b_str1b.decode("utf-8"), str1)
-        self.assertEqual(str(l1b), b64_str1)
+        assert b_str1 == b_str1b
+        assert b_str1b.decode("utf-8") == str1
+        assert str(l1b) == b64_str1
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_misc/test_create_input_source.py
+++ b/test/test_misc/test_create_input_source.py
@@ -1,25 +1,16 @@
 import unittest
-
+import pytest
 from rdflib.parser import create_input_source
 
 
 class ParserTestCase(unittest.TestCase):
     def test_empty_arguments(self):
         """create_input_source() function must receive exactly one argument."""
-        self.assertRaises(
-            ValueError,
-            create_input_source,
-        )
+        with pytest.raises(ValueError):
+            create_input_source()
 
     def test_too_many_arguments(self):
         """create_input_source() function has a few conflicting arguments."""
-        self.assertRaises(
-            ValueError,
-            create_input_source,
-            source="a",
-            location="b",
-        )
+        with pytest.raises(ValueError):
+            create_input_source(source="a", location="b")
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_misc/test_parse_file_guess_format.py
+++ b/test/test_misc/test_parse_file_guess_format.py
@@ -8,6 +8,7 @@
 # mypy: warn_return_any, no_implicit_reexport, strict_equality
 
 import unittest
+import pytest
 import logging
 from pathlib import Path
 from shutil import copyfile
@@ -21,34 +22,34 @@ from rdflib.util import guess_format
 
 class FileParserGuessFormatTest(unittest.TestCase):
     def test_guess_format(self) -> None:
-        self.assertEqual(guess_format("example.trix"), "trix")
-        self.assertEqual(guess_format("local-file.jsonld"), "json-ld")
-        self.assertEqual(guess_format("local-file.json-ld"), "json-ld")
-        self.assertEqual(guess_format("/some/place/on/disk/example.json"), "json-ld")
-        self.assertEqual(guess_format("../../relative/place/on/disk/example.json"), "json-ld")
-        self.assertEqual(guess_format("example.rdf"), "xml")
-        self.assertEqual(guess_format("example.nt"), "nt")
-        self.assertEqual(guess_format("example.nq"), "nquads")
-        self.assertEqual(guess_format("example.nquads"), "nquads")
-        self.assertEqual(guess_format("example.n3"), "n3")
-        self.assertIsNone(guess_format("example.docx", None))
-        self.assertIsNone(guess_format("example", None))
-        self.assertIsNone(guess_format("example.mkv", None))
+        assert guess_format("example.trix") == "trix"
+        assert guess_format("local-file.jsonld") == "json-ld"
+        assert guess_format("local-file.json-ld") == "json-ld"
+        assert guess_format("/some/place/on/disk/example.json") == "json-ld"
+        assert guess_format("../../relative/place/on/disk/example.json") == "json-ld"
+        assert guess_format("example.rdf") == "xml"
+        assert guess_format("example.nt") == "nt"
+        assert guess_format("example.nq") == "nquads"
+        assert guess_format("example.nquads") == "nquads"
+        assert guess_format("example.n3") == "n3"
+        assert guess_format("example.docx", None) is None
+        assert guess_format("example", None) is None
+        assert guess_format("example.mkv", None) is None
 
     def test_jsonld(self) -> None:
         g = Graph()
-        self.assertIsInstance(g.parse("test/jsonld/1.1/manifest.jsonld"), Graph)
-        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.json"), Graph)
-        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.json-ld"), Graph)
-        self.assertIsInstance(g.parse("test/jsonld/file_ending_test_01.jsonld"), Graph)
+        assert isinstance(g.parse("test/jsonld/1.1/manifest.jsonld"), Graph)
+        assert isinstance(g.parse("test/jsonld/file_ending_test_01.json"), Graph)
+        assert isinstance(g.parse("test/jsonld/file_ending_test_01.json-ld"), Graph)
+        assert isinstance(g.parse("test/jsonld/file_ending_test_01.jsonld"), Graph)
 
     def test_ttl(self) -> None:
         g = Graph()
-        self.assertIsInstance(g.parse("test/w3c/turtle/IRI_subject.ttl"), Graph)
+        assert isinstance(g.parse("test/w3c/turtle/IRI_subject.ttl"), Graph)
 
     def test_n3(self) -> None:
         g = Graph()
-        self.assertIsInstance(g.parse("test/n3/example-lots_of_graphs.n3"), Graph)
+        assert isinstance(g.parse("test/n3/example-lots_of_graphs.n3"), Graph)
 
     def test_warning(self) -> None:
         g = Graph()
@@ -57,10 +58,10 @@ class FileParserGuessFormatTest(unittest.TestCase):
         with TemporaryDirectory() as tmpdirname:
             newpath = Path(tmpdirname).joinpath("no_file_ext")
             copyfile("test/rdf/Manifest.rdf", str(newpath))
-            with self.assertLogs(graph_logger, "WARNING"):
-                with self.assertRaises(ParserError):
+            with pytest.raises(ParserError, match=r"Could not guess RDF format"):
+                with pytest.warns(
+                    UserWarning,
+                    match="does not look like a valid URI, trying to serialize this will break.",
+                ) as logwarning:
                     g.parse(str(newpath))
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_misc/test_prefix_types.py
+++ b/test/test_misc/test_prefix_types.py
@@ -23,12 +23,7 @@ class PrefixTypesTest(unittest.TestCase):
     This is issue 161
     http://code.google.com/p/rdflib/issues/detail?id=161
     """
-
     def test(self):
-        s = graph.serialize(format="n3")
-        self.assertTrue("foaf:Document" in s)
-        self.assertTrue("xsd:date" in s)
-
-
-if __name__ == "__main__":
-    unittest.main()
+	    s = graph.serialize(format="n3")
+	    assert "foaf:Document" in s
+	    assert "xsd:date" in s

--- a/test/test_parsers/test_empty_xml_base.py
+++ b/test/test_parsers/test_empty_xml_base.py
@@ -36,11 +36,9 @@ baseUri = URIRef("http://example.com/")
 baseUri2 = URIRef("http://example.com/foo/bar")
 
 class TestEmptyBase(unittest.TestCase):
-    def setup(self, method):
+    def test_empty_base_ref(self):
         self.graph = ConjunctiveGraph()
         self.graph.parse(data=test_data, publicID=baseUri, format="xml")
-
-    def test_empty_base_ref(self):
         assert len(list(self.graph)) > 0, "There should be at least one statement in the graph"
         assert (
             baseUri,
@@ -50,11 +48,10 @@ class TestEmptyBase(unittest.TestCase):
 
 
 class TestRelativeBase(unittest.TestCase):
-    def setup(self, method):
-        self.graph = ConjunctiveGraph()
-        self.graph.parse(data=test_data2, publicID=baseUri2, format="xml")
 
     def test_relative_base_ref(self):
+        self.graph = ConjunctiveGraph()
+        self.graph.parse(data=test_data2, publicID=baseUri2, format="xml")
         assert len(self.graph) > 0, "There should be at least one statement in the graph"
         resolvedBase = URIRef("http://example.com/baz")
         assert (

--- a/test/test_parsers/test_empty_xml_base.py
+++ b/test/test_parsers/test_empty_xml_base.py
@@ -6,12 +6,10 @@ and RDF/XML dependence on it
 """
 
 from rdflib.graph import ConjunctiveGraph
+from rdflib.namespace import FOAF, RDF
 from rdflib.term import URIRef
-from rdflib.namespace import RDF, FOAF
-from io import StringIO
 
 import unittest
-
 
 test_data = """
 <rdf:RDF
@@ -37,37 +35,30 @@ test_data2 = """
 baseUri = URIRef("http://example.com/")
 baseUri2 = URIRef("http://example.com/foo/bar")
 
-
 class TestEmptyBase(unittest.TestCase):
-    def setUp(self):
+    def setup(self, method):
         self.graph = ConjunctiveGraph()
-        self.graph.parse(StringIO(test_data), publicID=baseUri, format="xml")
+        self.graph.parse(data=test_data, publicID=baseUri, format="xml")
 
-    def test_base_ref(self):
-        self.assertTrue(
-            len(list(self.graph)), "There should be at least one statement in the graph"
-        )
-        self.assertTrue(
-            (baseUri, RDF.type, FOAF.Document) in self.graph,
-            "There should be a triple with %s as the subject" % baseUri,
-        )
+    def test_empty_base_ref(self):
+        assert len(list(self.graph)) > 0, "There should be at least one statement in the graph"
+        assert (
+            baseUri,
+            RDF.type,
+            FOAF.Document,
+        ) in self.graph, f"There should be a triple with {baseUri} as the subject"
 
 
 class TestRelativeBase(unittest.TestCase):
-    def setUp(self):
+    def setup(self, method):
         self.graph = ConjunctiveGraph()
-        self.graph.parse(StringIO(test_data2), publicID=baseUri2, format="xml")
+        self.graph.parse(data=test_data2, publicID=baseUri2, format="xml")
 
-    def test_base_ref(self):
-        self.assertTrue(
-            len(self.graph), "There should be at least one statement in the graph"
-        )
+    def test_relative_base_ref(self):
+        assert len(self.graph) > 0, "There should be at least one statement in the graph"
         resolvedBase = URIRef("http://example.com/baz")
-        self.assertTrue(
-            (resolvedBase, RDF.type, FOAF.Document) in self.graph,
-            "There should be a triple with %s as the subject" % resolvedBase,
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert (
+            resolvedBase,
+            RDF.type,
+            FOAF.Document,
+        ) in self.graph, f"There should be a triple with {resolvedBase} as the subject"

--- a/test/test_parsers/test_n3parse_of_rdf_lists.py
+++ b/test/test_parsers/test_n3parse_of_rdf_lists.py
@@ -1,6 +1,3 @@
-# import os, sys, string
-import unittest
-
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 
@@ -29,24 +26,14 @@ _:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/199
 """
 
 
-def main():
-    unittest.main()
-
-
 class OWLCollectionTest(unittest.TestCase):
-    def testCollectionRDFXML(self):
+    def test_collection_rdfxml(self):
         g = Graph().parse(data=DATA, format="nt")
         g.namespace_manager.bind("owl", URIRef("http://www.w3.org/2002/07/owl#"))
-        print(g.serialize(format="pretty-xml"))
+        s = g.serialize(format="pretty-xml")
 
 
 class ListTest(unittest.TestCase):
-    def testFalseElement(self):
+    def test_false_element(self):
         g = Graph().parse(data=DATA_FALSE_ELEMENT, format="nt")
-        self.assertEqual(
-            len(list(g.items(URIRef("http://example.org/#ThreeMemberList")))), 3
-        )
-
-
-if __name__ == "__main__":
-    main()
+        assert len(list(g.items(URIRef("http://example.org/#ThreeMemberList")))) == 3

--- a/test/test_parsers/test_n3parse_of_rdf_lists.py
+++ b/test/test_parsers/test_n3parse_of_rdf_lists.py
@@ -1,3 +1,4 @@
+import unittest
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 

--- a/test/test_serializers/test_finalnewline.py
+++ b/test/test_serializers/test_finalnewline.py
@@ -2,7 +2,7 @@ from rdflib import ConjunctiveGraph, URIRef
 import rdflib.plugin
 
 
-def testFinalNewline():
+def test_finalnewline():
     """
     http://code.google.com/p/rdflib/issues/detail?id=5
     """

--- a/test/test_store/test_nodepickler.py
+++ b/test/test_store/test_nodepickler.py
@@ -32,7 +32,7 @@ class UtilTestCase(unittest.TestCase):
 """
         )
         b = np.loads(np.dumps(a))
-        self.assertEqual(a, b)
+        assert a == b
 
     def test_literal_cases(self):
         np = NodePickler()
@@ -40,15 +40,11 @@ class UtilTestCase(unittest.TestCase):
         for l in cases:
             a = Literal(l)
             b = np.loads(np.dumps(a))
-            self.assertEqual(a, b)
+            assert a == b
 
     def test_pickle(self):
         np = NodePickler()
         dump = pickle.dumps(np)
         np2 = pickle.loads(dump)
-        self.assertEqual(np._ids, np2._ids)
-        self.assertEqual(np._objects, np2._objects)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert np._ids == np2._ids
+        assert np._objects == np2._objects

--- a/test/test_tools/test_csv2rdf.py
+++ b/test/test_tools/test_csv2rdf.py
@@ -1,32 +1,31 @@
+import os
+import re
 import subprocess
 import unittest
 import sys
-from os import remove, close
 from tempfile import mkstemp
-from pathlib import Path
+from test.data import CONSISTENT_DATA_DIR
 
+REALESTATE_FILE_PATH = os.path.join(CONSISTENT_DATA_DIR, "csv", "realestate.csv")
 
 class CSV2RDFTest(unittest.TestCase):
-    def setUp(self):
-        self.REALESTATE_FILE_PATH = Path(__file__).parent.parent / "consistent_test_data" / "csv" / "realestate.csv"
-
     def test_csv2rdf_cli(self):
         completed = subprocess.run(
             [
                 sys.executable,
                 "-m",
                 "rdflib.tools.csv2rdf",
-                str(self.REALESTATE_FILE_PATH),
+                str(REALESTATE_FILE_PATH),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
         )
-        self.assertEqual(completed.returncode, 0)
-        self.assertRegex(completed.stderr, r"Converted \d+ rows into \d+ triples.")
-        self.assertRegex(completed.stderr, r"Took [\d\.]+ seconds.")
-        self.assertIn("<http://example.org/instances/0>", completed.stdout)
-        self.assertIn("<http://example.org/props/zip>", completed.stdout)
+        assert completed.returncode == 0
+        assert "Converted 19 rows into 228 triples." in completed.stderr
+        assert re.search(r"Took [\d\.]+ seconds\.", completed.stderr)
+        assert "<http://example.org/instances/0>" in completed.stdout
+        assert "<http://example.org/props/zip>" in completed.stdout
 
     def test_csv2rdf_cli_fileout(self):
         fh, fname = mkstemp()
@@ -37,11 +36,11 @@ class CSV2RDFTest(unittest.TestCase):
                 "rdflib.tools.csv2rdf",
                 "-o",
                 fname,
-                str(self.REALESTATE_FILE_PATH),
+                str(REALESTATE_FILE_PATH),
             ],
         )
-        self.assertEqual(completed.returncode, 0)
+        assert completed.returncode == 0
         with open(fname) as f:
-            self.assertGreater(len(f.readlines()), 0)
-        close(fh)
-        remove(fname)
+            assert len(f.readlines()) == 228
+        os.close(fh)
+        os.remove(fname)


### PR DESCRIPTION
# Summary of changes
Continued migration of unittests to pytest. I've changed my approach to follow @aucampia's lead, acknowledging that retaining the UnitTest class structure makes changes far more readily apparent. We're not done with test re-org yet (blacking in prospect) so the UnitTest structure can be removed at a later stage.

# Checklist
- [x] Checked that there aren't other open pull requests for the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
-  [x ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
