### PR TITLE
fix: propagate exceptions from SPARQL TSV result parser

### DIFF
--- a/rdflib/plugins/sparql/results/tsvresults.py
+++ b/rdflib/plugins/sparql/results/tsvresults.py
@@ -68,30 +68,24 @@ class TSVResultParser(ResultParser):
             # if reading from source returns bytes do utf-8 decoding
             source = codecs.getreader("utf-8")(source)
 
-        try:
-            r = Result("SELECT")
+        r = Result("SELECT")
 
-            header = source.readline()
+        header = source.readline()
 
-            r.vars = list(HEADER.parseString(header.strip(), parseAll=True))
-            r.bindings = []
-            while True:
-                line = source.readline()
-                if not line:
-                    break
-                line = line.strip("\n")
-                if line == "":
-                    continue
+        r.vars = list(HEADER.parseString(header.strip(), parseAll=True))
+        r.bindings = []
+        while True:
+            line = source.readline()
+            if not line:
+                break
+            line = line.strip("\n")
+            if line == "":
+                continue
 
-                row = ROW.parseString(line, parseAll=True)
-                r.bindings.append(dict(zip(r.vars, (self.convertTerm(x) for x in row))))
+            row = ROW.parseString(line, parseAll=True)
+            r.bindings.append(dict(zip(r.vars, (self.convertTerm(x) for x in row))))
 
-            return r
-
-        except ParseException as err:
-            print(err.line)
-            print(" " * (err.column - 1) + "^")
-            print(err)
+        return r
 
     def convertTerm(self, t):
         if t is NONE_VALUE:

--- a/test/test_sparql/test_result.py
+++ b/test/test_sparql/test_result.py
@@ -1,0 +1,53 @@
+import inspect
+import logging
+from io import StringIO
+from typing import Mapping, Sequence, Type, Union
+
+import pytest
+from pyparsing import ParseException
+
+from rdflib.query import Result
+from rdflib.term import Identifier, Literal, Variable
+
+BindingsType = Sequence[Mapping[Variable, Identifier]]
+ParseOutcomeType = Union[BindingsType, Type[Exception]]
+
+
+@pytest.mark.parametrize(
+    ("data", "format", "parse_outcome"),
+    [
+        pytest.param(
+            "a\n1",
+            "csv",
+            [{Variable("a"): Literal("1")}],
+            id="csv-okay-1c1r",
+        ),
+        pytest.param(
+            '?a\n"1"',
+            "tsv",
+            [{Variable("a"): Literal("1")}],
+            id="tsv-okay-1c1r",
+        ),
+        pytest.param(
+            "1,2,3\nhttp://example.com",
+            "tsv",
+            ParseException,
+            id="tsv-invalid",
+        ),
+    ],
+)
+def test_select_result_parse(
+    data: str, format: str, parse_outcome: ParseOutcomeType
+) -> None:
+    """
+    Round tripping of a select query through the serializer and parser of a
+    specific format results in an equivalent result object.
+    """
+    logging.debug("data = %s", data)
+
+    if inspect.isclass(parse_outcome) and issubclass(parse_outcome, Exception):
+        with pytest.raises(parse_outcome):
+            parsed_result = Result.parse(StringIO(data), format=format)
+    else:
+        parsed_result = Result.parse(StringIO(data), format=format)
+        assert parse_outcome == parsed_result.bindings


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

This patch changes the `TSVResultParser` to not eat exceptions, as this
results in silent failures that are hard to debug, and in general all
functions should either do what they say they will or create an error
indication to the caller, which in python is done with exceptions.

Fixes:
- https://github.com/RDFLib/rdflib/issues/1477


<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

