### PR TITLE
text: fix pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,22 @@ exclude = '''
   )/
 )
 '''
+
+[tool.pytest.ini_options]
+addopts = [
+   "--doctest-modules",
+   "--ignore=admin",
+   "--ignore=rdflib/extras/external_graph_libs.py",
+   "--ignore-glob=docs/*.py",
+]
+doctest_optionflags = "ALLOW_UNICODE"
+filterwarnings = [
+    # The below warning is a consequence of how pytest doctest detects mocks and how DefinedNamespace behaves when an undefined attribute is being accessed.
+    "ignore:Code. pytest_mock_example_attribute_that_shouldnt_exist is not defined in namespace .*:UserWarning",
+    # The below warning is a consequence of how pytest detects fixtures and how DefinedNamespace behaves when an undefined attribute is being accessed.
+    "ignore:Code. _pytestfixturefunction is not defined in namespace .*:UserWarning",
+]
+# log_cli = true
+# log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s %(levelname)-8s %(name)-12s %(filename)s:%(lineno)s:%(funcName)s %(message)s"
+log_cli_date_format = "%Y-%m-%dT%H:%M:%S"

--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -5,7 +5,7 @@ graphs that can be used and queried. The store that backs the graph
 
 >>> from rdflib import ConjunctiveGraph, URIRef, Namespace
 >>> g = ConjunctiveGraph()
->>> data = open("test/nquads.rdflib/example.nquads", "rb")
+>>> data = open("test/data/nquads.rdflib/example.nquads", "rb")
 >>> g.parse(data, format="nquads") # doctest:+ELLIPSIS
 <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
 >>> assert len(g.store) == 449

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,17 +70,3 @@ skip =
     build,
     dist,
     venv,
-
-[tool:pytest]
-addopts =
-   --doctest-modules
-   --ignore=test/translate_algebra
-   --ignore=admin
-   --ignore=rdflib/extras/external_graph_libs.py
-   --ignore-glob=docs/*.py
-doctest_optionflags = ALLOW_UNICODE
-filterwarnings =
-    # The below warning is a consequence of how pytest doctest detects mocks and how DefinedNamespace behaves when an undefined attribute is being accessed.
-    ignore:Code. pytest_mock_example_attribute_that_shouldnt_exist is not defined in namespace .*:UserWarning
-    # The below warning is a consequence of how pytest detects fixtures and how DefinedNamespace behaves when an undefined attribute is being accessed.
-    ignore:Code. _pytestfixturefunction is not defined in namespace .*:UserWarning

--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,3 @@ passenv = HOMEPATH  # needed on Windows
 commands =
     precommit: pre-commit run
     precommitall: pre-commit run --all-files
-
-[pytest]
-# log_cli = true
-# log_cli_level = DEBUG
-log_cli_format = %(asctime)s %(levelname)-8s %(name)-12s %(filename)s:%(lineno)s:%(funcName)s %(message)s
-log_cli_date_format=%Y-%m-%dT%H:%M:%S


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes
    
pytest was using config from `tox.ini` preferentially and ignoring config
from `setup.cfg`, as a side-effect doctests were not running on
code/docstrings in `rdflib/`.

The reason why some pytest config was in `tox.ini` instead of `setup.cfg`
was because of these issues:
- https://github.com/pypa/pip/issues/5182
- https://github.com/pytest-dev/pytest/issues/3062

As a compromise to fix this I have opted for moving all pytest config to
`pyproject.toml`:
- https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

This seems sensible as `pyproject.toml` is standarized by PEPs and
eventually most things from `setup.cfg` will end up in there anyway.

Also:
- remove the pytest ignore on `test/translate_algebra` as tests in there
  have been running and passing for some time.
- fixed path to test data in `rdflib/plugins/parsers/nquads.py`.



<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

