### PR TITLE
docs: switch to sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinxcontrib.apidoc",
     "sphinx.ext.autodoc",
     #'sphinx.ext.autosummary',
+    "sphinx_autodoc_typehints",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
@@ -42,8 +43,12 @@ extensions = [
 
 apidoc_module_dir = "../rdflib"
 apidoc_output_dir = "apidocs"
+
+# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 autodoc_default_options = {"special-members": True}
-autodoc_typehints = "both"
+
+# https://github.com/tox-dev/sphinx-autodoc-typehints
+always_document_param_types = True
 
 autosummary_generate = True
 

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -3,3 +3,4 @@ myst-parser
 sphinx<5
 sphinxcontrib-apidoc
 sphinxcontrib-kroki
+sphinx-autodoc-typehints

--- a/rdflib/_type_checking.py
+++ b/rdflib/_type_checking.py
@@ -1,0 +1,29 @@
+"""
+This module contains type aliases that should only be used when type checking
+as it would otherwise introduce a runtime dependency on `typing_extensions` for
+older python versions which is not desirable.
+
+This was made mainly to accommodate ``sphinx-autodoc-typehints`` which cannot
+recognize type aliases from imported files if the type aliases are defined
+inside ``if TYPE_CHECKING:``. So instead of placing the type aliases in normal
+modules inside ``TYPE_CHECKING`` guards they are in this file which should only
+be imported inside ``TYPE_CHECKING`` guards.
+
+.. important::
+    Things inside this module are not for use outside of RDFLib
+    and this module is not part the the RDFLib public API.
+"""
+
+import sys
+
+__all__ = [
+    "_NamespaceSetString",
+]
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal as PyLiteral
+else:
+    from typing_extensions import Literal as PyLiteral
+
+_NamespaceSetString = PyLiteral["core", "rdflib", "none"]

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -40,7 +40,7 @@ assert Literal  # avoid warning
 assert Namespace  # avoid warning
 
 if TYPE_CHECKING:
-    from rdflib.namespace import _NamespaceSetString
+    from rdflib._type_checking import _NamespaceSetString
 
 logger = logging.getLogger(__name__)
 

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -344,12 +344,7 @@ class ClosedNamespace(Namespace):
 XMLNS = Namespace("http://www.w3.org/XML/1998/namespace")
 
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import Literal as PyLiteral
-    else:
-        from typing_extensions import Literal as PyLiteral
-
-    _NamespaceSetString = PyLiteral["core", "rdflib", "none"]
+    from rdflib._type_checking import _NamespaceSetString
 
 
 class NamespaceManager(object):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,11 +6,8 @@ flake8-black
 html5lib
 isort
 mypy
-myst-parser
 pytest
 pytest-cov
 pytest-subtests
-sphinx<5
-sphinxcontrib-apidoc
-sphinxcontrib-kroki
 types-setuptools
+-r docs/sphinx-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ exclude = host,extras,transform,rdfs,pyRdfa,sparql,results,pyMicrodata
 [coverage:run]
 branch = True
 source = rdflib
+omit =
+    */_type_checking.py
 
 [coverage:report]
 # Regexes for lines to exclude from consideration

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ kwargs["extras_require"] = {
         "sphinx < 5",
         "sphinxcontrib-apidoc",
         "sphinxcontrib-kroki",
+        "sphinx-autodoc-typehints",
     ],
     "berkeleydb": ["berkeleydb"],
     "networkx": ["networkx"],


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Currently rdflib is relying on sphinx-autodoc's built in handling for type
hints, this however has some deficiencies as it does not handle stuff
inside `if TYPE_CHECKING:` and thus only work in cases where there are no
potential for circular dependencies.

This patch changes sphinx to use sphinx-autodoc-typehints instead, the
documentation generated by this plugin looks slightly different but as a
positive it correctly works with things defined inside `if TYPE_CHECKING:`
guards.

Also:
- moved the `_NamespaceSetString` type alias to `rdflib._type_checking`
  This is so that `sphinx-autodoc-typehints` recognizes it up, as it
  does not handle type aliases that are defined inside
  `if TYPE_CHECKING:` guards in imported files.
- remove sphinx requirements from `requirements.dev.txt` and
  replaced it with `-r docs/sphinx-requirements.txt` to reduce redundancy. 



<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

