### PR TITLE
resolve issue1868, add a method to expand qname to URI

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -590,6 +590,26 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
+    def expand_qname(self, curie):
+        """
+        Expand a qname (aka CURIE) of the form <prefix:element>, e.g. "rdf:type"
+        into its full expression:
+
+        >>> g = Graph()
+        >>> g.namespace_manager.expand_qname("rdf:type")
+        http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+
+        Returns None if a namespace is not bound to the prefix or the prefix
+        is malformed.
+
+        """
+        if (
+            isinstance(curie, str)
+            and (prefix := curie.split(":")[0])
+            and (ns := self.store.namespace(prefix))
+        ):
+            return str(ns) + curie.split(":")[1]
+
     def bind(
         self,
         prefix: Optional[str],

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -603,12 +603,20 @@ class NamespaceManager(object):
         is malformed.
 
         """
-        if (
-            isinstance(curie, str)
-            and (prefix := curie.split(":")[0])
-            and (ns := self.store.namespace(prefix))
-        ):
-            return str(ns) + curie.split(":")[1]
+        # TODO: When we drop support for 3.7 ...
+        # if (
+        #     isinstance(curie, str)
+        #     and (prefix := curie.split(":")[0])
+        #     and (ns := self.store.namespace(prefix))
+        # ):
+        #     return str(ns) + curie.split(":")[1]
+
+        if isinstance(curie, str) and ":" in curie:
+            ns = self.store.namespace(curie.split(":")[0])
+            if ns is not None:
+                return (
+                    str(self.store.namespace(curie.split(":")[0])) + curie.split(":")[1]
+                )
 
     def bind(
         self,

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -590,29 +590,24 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
-    def expand_qname(self, curie: str) -> Union[str, None]:
+    def expand_curie(self, curie: str) -> Union[str, None]:
         """
         Expand a qname (aka CURIE) of the form <prefix:element>, e.g. "rdf:type"
         into its full expression:
 
         >>> import rdflib
         >>> g = rdflib.Graph()
-        >>> g.namespace_manager.expand_qname("rdf:type")
+        >>> g.namespace_manager.expand_curie("rdf:type")
         'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
 
-        Returns None if a namespace is not bound to the prefix or the prefix
-        is malformed.
+        Returns None if a namespace is not bound to the prefix.
 
         """
-        # TODO: When we drop support for 3.7 ...
-        # if (
-        #     isinstance(curie, str)
-        #     and (prefix := curie.split(":")[0])
-        #     and (ns := self.store.namespace(prefix))
-        # ):
-        #     return str(ns) + curie.split(":")[1]
-
-        if isinstance(curie, str) and ":" in curie:
+        if not type(curie) is str:
+            raise TypeError("Argument must be a string.")
+        elif ":" not in curie or curie.split(":")[0] == "" or curie.split(":")[1] == "":
+            raise ValueError("Malformed curie argument, format should be e.g. “foaf:name”.")
+        else:
             ns = self.store.namespace(curie.split(":")[0])
             if ns is not None:
                 return str(ns) + curie.split(":")[1]

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -590,7 +590,7 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
-    def expand_qname(self, curie):
+    def expand_qname(self, curie: str) -> Union[str, None]:
         """
         Expand a qname (aka CURIE) of the form <prefix:element>, e.g. "rdf:type"
         into its full expression:
@@ -616,6 +616,7 @@ class NamespaceManager(object):
             ns = self.store.namespace(curie.split(":")[0])
             if ns is not None:
                 return str(ns) + curie.split(":")[1]
+        return None
 
     def bind(
         self,

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -614,9 +614,7 @@ class NamespaceManager(object):
         if isinstance(curie, str) and ":" in curie:
             ns = self.store.namespace(curie.split(":")[0])
             if ns is not None:
-                return (
-                    str(self.store.namespace(curie.split(":")[0])) + curie.split(":")[1]
-                )
+                return str(ns) + curie.split(":")[1]
 
     def bind(
         self,

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -598,7 +598,7 @@ class NamespaceManager(object):
         >>> import rdflib
         >>> g = rdflib.Graph()
         >>> g.namespace_manager.expand_qname("rdf:type")
-        http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
 
         Returns None if a namespace is not bound to the prefix or the prefix
         is malformed.

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -606,7 +606,9 @@ class NamespaceManager(object):
         if not type(curie) is str:
             raise TypeError("Argument must be a string.")
         elif ":" not in curie or curie.split(":")[0] == "" or curie.split(":")[1] == "":
-            raise ValueError("Malformed curie argument, format should be e.g. “foaf:name”.")
+            raise ValueError(
+                "Malformed curie argument, format should be e.g. “foaf:name”."
+            )
         else:
             ns = self.store.namespace(curie.split(":")[0])
             if ns is not None:

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -595,7 +595,8 @@ class NamespaceManager(object):
         Expand a qname (aka CURIE) of the form <prefix:element>, e.g. "rdf:type"
         into its full expression:
 
-        >>> g = Graph()
+        >>> import rdflib
+        >>> g = rdflib.Graph()
         >>> g.namespace_manager.expand_qname("rdf:type")
         http://www.w3.org/1999/02/22-rdf-syntax-ns#type
 

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -600,10 +600,11 @@ class NamespaceManager(object):
         >>> g.namespace_manager.expand_curie("rdf:type")
         rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
 
-        Returns `None` if a namespace is not bound to the prefix.
+        Raises exception if a namespace is not bound to the prefix.
+
         """
         if not type(curie) is str:
-            raise TypeError("Argument must be a string.")
+            raise TypeError(f"Argument must be a string, not {type(curie).__name__}.")
         parts = curie.split(":", 1)
         if len(parts) != 2 or len(parts[0]) < 1:
             raise ValueError(
@@ -612,7 +613,10 @@ class NamespaceManager(object):
         ns = self.store.namespace(parts[0])
         if ns is not None:
             return URIRef(f"{str(ns)}{parts[1]}")
-        return None
+        else:
+            raise ValueError(
+                f"Prefix \"{curie.split(':')[0]}\" not bound to any namespace."
+            )
 
     def bind(
         self,

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -590,7 +590,7 @@ class NamespaceManager(object):
 
             return self.__cache_strict[uri]
 
-    def expand_curie(self, curie: str) -> Union[str, None]:
+    def expand_curie(self, curie: str) -> Union[URIRef, None]:
         """
         Expand a qname (aka CURIE) of the form <prefix:element>, e.g. "rdf:type"
         into its full expression:
@@ -612,7 +612,7 @@ class NamespaceManager(object):
         else:
             ns = self.store.namespace(curie.split(":")[0])
             if ns is not None:
-                return str(ns) + curie.split(":")[1]
+                return URIRef(str(ns) + curie.split(":")[1])
         return None
 
     def bind(

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -261,7 +261,7 @@ class TestNamespacePrefix:
         ref = URIRef("http://www.w3.org/2002/07/owl#real")
         assert ref in OWL, "OWL does not include owl:real"
 
-    def test_expand_qname(self):
+    def test_expand_qname(self) -> None:
         g = Graph()
 
         assert (

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -264,14 +264,17 @@ class TestNamespacePrefix:
     def test_expand_curie(self) -> None:
         g = Graph()
 
-        assert (
-            g.namespace_manager.expand_curie("rdf:type")
-            == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        assert g.namespace_manager.expand_curie("rdf:type") == URIRef(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         )
+
+        assert g.namespace_manager.expand_curie("rdf:type") == RDF.type
 
         g.bind("ex", Namespace("urn:example:"))
 
-        assert g.namespace_manager.expand_curie("ex:tarek") == "urn:example:tarek"
+        assert g.namespace_manager.expand_curie("ex:tarek") == URIRef(
+            "urn:example:tarek"
+        )
 
     @pytest.mark.parametrize(
         "invalid_curie",

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -260,3 +260,40 @@ class TestNamespacePrefix:
 
         ref = URIRef("http://www.w3.org/2002/07/owl#real")
         assert ref in OWL, "OWL does not include owl:real"
+
+    def test_expand_qname(self):
+        """Test sequential assignment of unknown prefixes"""
+        g = Graph()
+
+        assert (
+            g.namespace_manager.expand_qname("rdf:type")
+            == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        )
+
+        assert (
+            g.namespace_manager.expand_qname("rdf:")
+            == "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        )
+
+        g.bind("ex", Namespace("urn:example:"))
+
+        assert g.namespace_manager.expand_qname("ex:tarek") == "urn:example:tarek"
+
+    @pytest.mark.parametrize(
+        "invalid_curie",
+        [
+            ("em:tarek"),
+            ("em:"),
+            ("em"),
+            (":"),
+            (":type"),
+            ("í"),
+            (" :"),
+            (""),
+            ("\n"),
+            (None),
+        ],
+    )
+    def test_expand_qname_invalid_curie(self, invalid_curie: str) -> None:
+        g = Graph()
+        assert g.namespace_manager.expand_qname(invalid_curie) is None

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -262,7 +262,6 @@ class TestNamespacePrefix:
         assert ref in OWL, "OWL does not include owl:real"
 
     def test_expand_qname(self):
-        """Test sequential assignment of unknown prefixes"""
         g = Graph()
 
         assert (
@@ -295,5 +294,6 @@ class TestNamespacePrefix:
         ],
     )
     def test_expand_qname_invalid_curie(self, invalid_curie: str) -> None:
+        """Test use of invalid CURIEs"""
         g = Graph()
         assert g.namespace_manager.expand_qname(invalid_curie) is None

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -264,7 +264,6 @@ class TestNamespacePrefix:
         ref = URIRef("http://www.w3.org/2002/07/owl#real")
         assert ref in OWL, "OWL does not include owl:real"
 
-
     def test_expand_curie_exception_messages(self) -> None:
         g = Graph()
 

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -264,20 +264,6 @@ class TestNamespacePrefix:
         ref = URIRef("http://www.w3.org/2002/07/owl#real")
         assert ref in OWL, "OWL does not include owl:real"
 
-    def test_expand_curie(self) -> None:
-        g = Graph()
-
-        assert g.namespace_manager.expand_curie("rdf:type") == URIRef(
-            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-        )
-
-        assert g.namespace_manager.expand_curie("rdf:type") == RDF.type
-
-        g.bind("ex", Namespace("urn:example:"))
-
-        assert g.namespace_manager.expand_curie("ex:tarek") == URIRef(
-            "urn:example:tarek"
-        )
 
     def test_expand_curie_exception_messages(self) -> None:
         g = Graph()

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -277,24 +277,27 @@ class TestNamespacePrefix:
         "invalid_curie",
         [
             ("em:tarek", None),
-            ("em:", ValueError),
-            ("em", ValueError),
-            (":", ValueError),
-            (":type", ValueError),
-            ("í", ValueError),
-            (" :", ValueError),
-            ("", ValueError),
-            ("\n", ValueError),
-            (None, TypeError),
-            (99, TypeError),
-            (URIRef("urn:example:"), TypeError),
+            ("em:", "ValueError"),
+            ("em", "ValueError"),
+            (":", "ValueError"),
+            (":type", "ValueError"),
+            ("í", "ValueError"),
+            (" :", "ValueError"),
+            ("", "ValueError"),
+            ("\n", "ValueError"),
+            (None, "TypeError"),
+            (99, "TypeError"),
+            (URIRef("urn:example:"), "TypeError"),
         ],
     )
     def test_expand_curie_invalid_curie(self, invalid_curie: str) -> None:
         """Test use of invalid CURIEs"""
         g = Graph()
-        if invalid_curie[1] is not None:
-            with pytest.raises(invalid_curie[1]):
+        if invalid_curie[1] == "ValueError":
+            with pytest.raises(ValueError):
+                assert g.namespace_manager.expand_curie(invalid_curie[0])
+        elif invalid_curie[1] == "TypeError":
+            with pytest.raises(TypeError):
                 assert g.namespace_manager.expand_curie(invalid_curie[0])
         else:
             assert g.namespace_manager.expand_curie(invalid_curie[0]) is None


### PR DESCRIPTION
# Summary of changes
In response to issue #1868:
> “I sometimes need use the reverse of qname() to make the URI input more human-friendly. It would be great if we have something like resolve_qname() which would translate a qname ns:obj back to http://example.com/ns#object”

Seems a reasonable enough request and trivial to resolve... add NamespaceManager method `expand_qname` and tests.

# Checklist
- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [x] Considered adding an example in `./examples` for new features.
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

