### PR TITLE
Fix `None`/undefined handing in GROUP_CONCAT

### DIFF
--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -207,10 +207,17 @@ class GroupConcat(Accumulator):
     def update(self, row, aggregator):
         try:
             value = _eval(self.expr, row)
+            # skip UNDEF
+            if isinstance(value, NotBoundError):
+                return
             self.value.append(value)
             if self.distinct:
                 self.seen.add(value)
         # skip UNDEF
+        # NOTE: It seems like this is not the way undefined values occur, they
+        # come through not as exceptions but as values. This is left here
+        # however as it may occur in some cases.
+        # TODO: Consider removing this.
         except NotBoundError:
             pass
 

--- a/test/test_sparql/test_sparql.py
+++ b/test/test_sparql/test_sparql.py
@@ -705,6 +705,112 @@ def test_operator_exception(
             [{Variable('bound'): Literal(False)}],
             id="select-bind-notexists-const-true",
         ),
+        pytest.param(
+            """
+            PREFIX dce: <http://purl.org/dc/elements/1.1/>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            SELECT
+                ?class
+                (
+                    GROUP_CONCAT(
+                        DISTINCT( STR( ?source ) );
+                        separator="|"
+                    ) AS ?sources
+                )
+            {
+                ?class a rdfs:Class.
+                OPTIONAL { ?class dce:source ?source. }
+            }
+            GROUP BY ?class ORDER BY ?class
+            """,
+            [
+                {
+                    Variable("class"): RDFS.Class,
+                    Variable("sources"): Literal(""),
+                },
+                {
+                    Variable("class"): RDFS.Container,
+                    Variable("sources"): Literal(""),
+                },
+                {
+                    Variable("class"): RDFS.ContainerMembershipProperty,
+                    Variable("sources"): Literal(""),
+                },
+                {
+                    Variable("class"): RDFS.Datatype,
+                    Variable("sources"): Literal(""),
+                },
+                {
+                    Variable("class"): RDFS.Literal,
+                    Variable("sources"): Literal(""),
+                },
+                {
+                    Variable("class"): RDFS.Resource,
+                    Variable("sources"): Literal(""),
+                },
+            ],
+            id="select-group-concat-optional-one",
+        ),
+        pytest.param(
+            """
+            PREFIX dce: <http://purl.org/dc/elements/1.1/>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            SELECT
+                ?vocab
+                (
+                    GROUP_CONCAT(
+                        DISTINCT( STR( ?source ) );
+                        separator="|"
+                    ) AS ?sources
+                )
+            {
+                ?class a rdfs:Class.
+                ?class rdfs:isDefinedBy ?vocab.
+                OPTIONAL { ?class dce:source ?source. }
+            }
+            GROUP BY ?vocab ORDER BY ?vocab
+            """,
+            [
+                {
+                    Variable("vocab"): URIRef(f"{RDFS}"),
+                    Variable("sources"): Literal(""),
+                },
+            ],
+            id="select-group-concat-optional-many",
+        ),
+        pytest.param(
+            """
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            SELECT
+                ?predicate
+                (
+                    GROUP_CONCAT(
+                        DISTINCT( STR( ?vocab ) );
+                        separator="|"
+                    ) AS ?vocabs
+                )
+            {
+
+                VALUES ?types { rdf:Property rdfs:Class }.
+                VALUES ?predicate { rdf:type }.
+                ?thing ?predicate ?types.
+                OPTIONAL {
+                  ?thing rdfs:isDefinedBy ?vocab.
+                }
+            }
+            GROUP BY ?predicate ORDER BY ?predicate
+            """,
+            [
+                {
+                    Variable("predicate"): RDF.type,
+                    Variable("vocabs"): Literal(
+                        "http://www.w3.org/2000/01/rdf-schema#"
+                    ),
+                },
+            ],
+            id="select-group-concat-optional-many",
+        ),
     ],
 )
 def test_queries(


### PR DESCRIPTION
# Summary of changes

`GROUP_CONCAT` was stringifying undefined values as `None`. This is
because `GroupConcat` was expecting undefined values to raise an
exception, but this was not happenning.

This patch changes `GROUP_CONCAT` to correctly detect undefined values.

Fixes #1467

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
