### PR TITLE
Issue 166 in SPARQLWrapper solved

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,6 +45,7 @@ Niklas Lindström
 Pierre-Antoine Champin
 Phil Dawes
 Phillip Pearson
+Pritish Wadhwa
 Ron Alford
 Remi Chateauneu
 Sidnei da Silva

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -422,15 +422,24 @@ def _findVars(x, res):
     """
     Find all variables in a tree
     """
+    seenVars = set()
     if isinstance(x, Variable):
-        res.add(x)
+        if x not in seenVars:
+            res.append(x)
+            seenVars.add(x)        
     if isinstance(x, CompValue):
         if x.name == "Bind":
-            res.add(x.var)
+            if x not in seenVars:
+                res.append(x)
+                seenVars.add(x)
             return x  # stop recursion and finding vars in the expr
         elif x.name == "SubSelect":
             if x.projection:
-                res.update(v.var or v.evar for v in x.projection)
+                tempList = [v.var or v.evar for v in x.projection]
+                for a in tempList:
+                    if a not in seenVars:
+                        res.append(a)
+                        seenVars.add(a)
             return x
 
 
@@ -548,7 +557,7 @@ def translate(q):
     q.where = traverse(q.where, visitPost=translatePath)
 
     # TODO: Var scope test
-    VS = set()
+    VS = list()
     traverse(q.where, functools.partial(_findVars, res=VS))
 
     # all query types have a where part

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -416,7 +416,8 @@ def _aggs(e, A):
         aggvar = Variable("__agg_%d__" % len(A))
         e["res"] = aggvar
         return aggvar
-    
+
+
 def _findVars(x, res):
     """
     Find all variables in a tree
@@ -425,7 +426,7 @@ def _findVars(x, res):
     if isinstance(x, Variable):
         if x not in seenVars:
             res.append(x)
-            seenVars.add(x)        
+            seenVars.add(x)
     if isinstance(x, CompValue):
         if x.name == "Bind":
             if x.var not in seenVars:
@@ -440,6 +441,7 @@ def _findVars(x, res):
                         res.append(a)
                         seenVars.add(a)
             return x
+
 
 def _addVars(x, children):
     """

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -429,9 +429,9 @@ def _findVars(x, res):
             seenVars.add(x)        
     if isinstance(x, CompValue):
         if x.name == "Bind":
-            if x not in seenVars:
-                res.append(x)
-                seenVars.add(x)
+            if x.var not in seenVars:
+                res.append(x.var)
+                seenVars.add(x.var)
             return x  # stop recursion and finding vars in the expr
         elif x.name == "SubSelect":
             if x.projection:

--- a/test/test_issues/test_issue166.py
+++ b/test/test_issues/test_issue166.py
@@ -1,0 +1,10 @@
+import pytest
+from rdflib import Graph
+import rdflib
+
+
+def test_issue_166() -> None:
+    g = Graph()
+    query="SELECT * { ?a ?b ?c } LIMIT 10"
+    qres=g.query(query)
+    assert(qres.vars == [rdflib.term.Variable('a'), rdflib.term.Variable('b'), rdflib.term.Variable('c')])

--- a/test/test_issues/test_issue166.py
+++ b/test/test_issues/test_issue166.py
@@ -1,10 +1,15 @@
 import pytest
-from rdflib import Graph
+
 import rdflib
+from rdflib import Graph
 
 
 def test_issue_166() -> None:
     g = Graph()
-    query="SELECT * { ?a ?b ?c } LIMIT 10"
-    qres=g.query(query)
-    assert(qres.vars == [rdflib.term.Variable('a'), rdflib.term.Variable('b'), rdflib.term.Variable('c')])
+    query = "SELECT * { ?a ?b ?c } LIMIT 10"
+    qres = g.query(query)
+    assert qres.vars == [
+        rdflib.term.Variable('a'),
+        rdflib.term.Variable('b'),
+        rdflib.term.Variable('c'),
+    ]


### PR DESCRIPTION
The order of ResultRows for a SELECT * query was randomized and was changing. This is unexpected because other SPARQL engines seem to generally apply the order of variables as they occur in the WHERE block.

Sample code:

query="SELECT * { ?a ?b ?c } LIMIT 10"
qres=g.query(query)
print(qres.vars)

Expected output:
[rdflib.term.Variable('a'), rdflib.term.Variable('b'), rdflib.term.Variable('c')]

Real output:
[rdflib.term.Variable('c'), rdflib.term.Variable('a'), rdflib.term.Variable('b')] (first run)
[rdflib.term.Variable('a'), rdflib.term.Variable('b'), rdflib.term.Variable('c')] (second run)
[rdflib.term.Variable('b'), rdflib.term.Variable('a'), rdflib.term.Variable('c')] (third run)
[rdflib.term.Variable('a'), rdflib.term.Variable('c'), rdflib.term.Variable('b')] (fourth run)
[you get the idea]

(Tested on the HDT edition of DBpedia 2016, created with g = rdflib.Graph(store=rdflib_hdt.HDTStore(rdf_file)), but that shouldn't matter.)

This was corrected without interfering with the time complexity and the output is now as it should be (as shown in the expected output) 
