### PR TITLE
Made the N-triples parser more robust. Resolved #724

### DIFF
--- a/rdflib/plugins/parsers/ntriples.py
+++ b/rdflib/plugins/parsers/ntriples.py
@@ -7,10 +7,11 @@ Author: Sean B. Palmer, inamidst.com
 """
 
 import codecs
+import logging
 import re
 from io import BytesIO, StringIO, TextIOBase
 from typing import IO, TYPE_CHECKING, Optional, Pattern, TextIO, Union
-import logging
+
 from rdflib.compat import _string_escape_map, decodeUnicodeEscape
 from rdflib.exceptions import ParserError as ParseError
 from rdflib.parser import InputSource, Parser
@@ -116,7 +117,16 @@ class W3CNTriplesParser(object):
     `NTriplesParser`.
     """
 
-    __slots__ = ("_bnode_ids", "sink", "buffer", "file", "line", 'ignore_errors', 'line_number', 'current_line')
+    __slots__ = (
+        "_bnode_ids",
+        "sink",
+        "buffer",
+        "file",
+        "line",
+        'ignore_errors',
+        'line_number',
+        'current_line',
+    )
 
     def __init__(
         self, sink: Optional[Union[DummySink, "NTGraphSink"]] = None, bnode_context=None
@@ -138,7 +148,10 @@ class W3CNTriplesParser(object):
         self.ignore_errors = False
 
     def parse(
-        self, f: Union[TextIO, IO[bytes], codecs.StreamReader], bnode_context=None, ignore_errors = False,
+        self,
+        f: Union[TextIO, IO[bytes], codecs.StreamReader],
+        bnode_context=None,
+        ignore_errors=False,
     ):
 
         """
@@ -166,17 +179,21 @@ class W3CNTriplesParser(object):
         self.line_number = 0
         while True:
             self.line = self.readline()
-            self.line_number+=1
+            self.line_number += 1
             self.current_line = self.line
             if self.line is None:
                 break
             try:
                 self.parseline(bnode_context=bnode_context)
             except ParseError:
-            
+
                 if ignore_errors:
-                    #logging the invalid triples in the input file and ignoring them while creating the final graph
-                    logging.warning("Invalid triple at line #{}: {}; IGNORED".format(self.line_number, self.current_line))
+                    # logging the invalid triples in the input file and ignoring them while creating the final graph
+                    logging.warning(
+                        "Invalid triple at line #{}: {}; IGNORED".format(
+                            self.line_number, self.current_line
+                        )
+                    )
                     continue
                 else:
                     raise ParseError("Invalid line: {}".format(self.current_line))
@@ -232,11 +249,19 @@ class W3CNTriplesParser(object):
 
         if self.ignore_errors:
             if self.line == '':
-                logging.warning("Invalid triple at line #{}: {} (There is no full stop); CORRECTED".format(self.line_number, self.current_line))
-            elif self.line!= ".":
-                logging.warning("Invalid triple at line #{}: {} (Extra characters detected at the end of triple); CORRECTED".format(self.line_number, self.current_line))
-            self.line = "."         
-        
+                logging.warning(
+                    "Invalid triple at line #{}: {} (There is no full stop); CORRECTED".format(
+                        self.line_number, self.current_line
+                    )
+                )
+            elif self.line != ".":
+                logging.warning(
+                    "Invalid triple at line #{}: {} (Extra characters detected at the end of triple); CORRECTED".format(
+                        self.line_number, self.current_line
+                    )
+                )
+            self.line = "."
+
         self.eat(r_tail)
 
         if self.line:
@@ -256,7 +281,7 @@ class W3CNTriplesParser(object):
 
     def subject(self, bnode_context=None):
         # @@ Consider using dictionary cases
-        
+
         subj = self.uriref() or self.nodeid(bnode_context)
         if not subj:
             raise ParseError("Subject must be uriref or nodeID")

--- a/test/test_parsers/test_nt.py
+++ b/test/test_parsers/test_nt.py
@@ -1,4 +1,5 @@
 from codecs import ignore_errors
+
 from rdflib.graph import Graph
 from rdflib.term import URIRef
 
@@ -29,14 +30,14 @@ _:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/199
 class Test_NT_Parsing:
     def test_nt_1(self):
         ignore_errors = True
-        g = Graph().parse(data=DATA_1, format="nt", ignore_errors = ignore_errors)
+        g = Graph().parse(data=DATA_1, format="nt", ignore_errors=ignore_errors)
         if ignore_errors:
             assert len(g) == 9
         assert False
 
     def test_nt_2(self):
         ignore_errors = True
-        g = Graph().parse(data=DATA_2, format="nt", ignore_errors = ignore_errors)
+        g = Graph().parse(data=DATA_2, format="nt", ignore_errors=ignore_errors)
         if ignore_errors:
             assert len(g) == 5
         assert False

--- a/test/test_parsers/test_nt.py
+++ b/test/test_parsers/test_nt.py
@@ -1,0 +1,42 @@
+from codecs import ignore_errors
+from rdflib.graph import Graph
+from rdflib.term import URIRef
+
+DATA_1 = """<http://example.com#C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class>.
+<http://example.com#B> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:fIYNVPxd4.
+<http://example.com#B> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.com#A>.
+http://example.com#B <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class>.
+<http://example.com#p1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty>.
+<http://example.com#A <http://www.w3.org/2002/07/owl#unionOf> _:fIYNVPxd3.\t\n
+<http://example.com#A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class>.
+_: <http:www.w3.org/2002/07/owl#allValuesFrom> "karish".?
+_:fIYNVPxd4 <http://www.w3.org/2002/07/owl#onProperty> "<http://example.com#p1>". 
+_:fIYNVPxd4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction>.*&^%$#@!
+_:fIYNVPxd3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.com#B>.
+_:fIYNVPxd3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>.
+"""
+
+DATA_2 = """
+<http://example.org/#ThreeMemberList> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/#p> .
+<http://example.org/#ThreeMemberList> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:list2 \t
+_:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "false" defgvcsxa
+_:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:
+_:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/#r> .
+_:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+"""
+
+
+class Test_NT_Parsing:
+    def test_nt_1(self):
+        ignore_errors = True
+        g = Graph().parse(data=DATA_1, format="nt", ignore_errors = ignore_errors)
+        if ignore_errors:
+            assert len(g) == 9
+        assert False
+
+    def test_nt_2(self):
+        ignore_errors = True
+        g = Graph().parse(data=DATA_2, format="nt", ignore_errors = ignore_errors)
+        if ignore_errors:
+            assert len(g) == 5
+        assert False

--- a/test/test_parsers/test_nt.py
+++ b/test/test_parsers/test_nt.py
@@ -33,11 +33,9 @@ class Test_NT_Parsing:
         g = Graph().parse(data=DATA_1, format="nt", ignore_errors=ignore_errors)
         if ignore_errors:
             assert len(g) == 9
-        assert False
 
     def test_nt_2(self):
         ignore_errors = True
         g = Graph().parse(data=DATA_2, format="nt", ignore_errors=ignore_errors)
         if ignore_errors:
             assert len(g) == 5
-        assert False


### PR DESCRIPTION
Fixes #724 

# Summary of changes

Consider the given set of ill-formatted n-triples:

```
<http://example.org/#ThreeMemberList> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/#p> .
<http://example.org/#ThreeMemberList> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:list2 \t
_:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "false" defgvcsxa
_:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:
_:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/#r> .
_:list3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
```

There are formatting errors in triples 2, 3, and 4, and the current state of the NTriples parser would raise the below exception `rdflib.exceptions.ParserError: Invalid line:` **without specifying** the triple which was incorrect or the line number. 

We have made a series of changes to the existing state of the parser:
- Added a keyword argument `ignore_errors` to the `g.parse()` function in the file [ntriples.py](https://github.com/RDFLib/rdflib/compare/master...karish-grover:master#diff-91378596f5461879529f6f18f2e33714ab8787397df361260c3cb86c9f9465de).
- If ignore_`errors == False`, specified the triplet for user convenience, as shown below:-

`rdflib.exceptions.ParserError: Invalid line: <http://example.org/#ThreeMemberList> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:list2`

- If `ignore_errors == True`, then we added a few more functionalities that could be convenient to the users:- 
    - We ignore the faulted triples and add the triples which are in the correct format to the graph. 
    - This further logs the line number and triplet which is faulty as shown:

`WARNING  root:ntriples.py:179 Invalid triple at line #5: _:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:; IGNORED`

We have also added a mechanism to correct some of the faulted triples in the case when the trailing character after `(s, p, o)` is either multiple dots `.` or no dots, or any other characters (like `\t`). In this case, we correct the triples and add the corrected triples to the graph. This further logs the triple which was corrected as shown:-

`WARNING  root:ntriples.py:237 Invalid triple at line #4: _:list2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "false" defgvcsxa (Extra characters detected at the end of triple); CORRECTED`

We have also added a test file [test_nt.py](https://github.com/RDFLib/rdflib/compare/master...karish-grover:master#diff-459ef51a7fb3e0a6c0f21be8b3e7ff779a657bdc639bf9038e6db76a7cd8c3ad) containing tests for the same.

In addition to these changes, there can be a few more formatting faults that might be rectifiable during the runtime and we urge the reviewers to kindly let us know these changes so we can add them to this PR.
