### PR TITLE
parser accept kwargs added

### DIFF
--- a/rdflib/parser.py
+++ b/rdflib/parser.py
@@ -56,7 +56,7 @@ class Parser(object):
     def __init__(self):
         pass
 
-    def parse(self, source: "InputSource", sink: "Graph"):
+    def parse(self, source: "InputSource", sink: "Graph", **kwargs):
         pass
 
 


### PR DESCRIPTION
#Fixes 1859
# Summary of changes
As discussed in the thread, Graph.parse behaves like an interface and forwards the **kwargs on to the parser. This is now being reflected in the function definition. 

@edmondchuc 