### PR TITLE
Resolve Issue 1427, allow prefixed names to be used as the endpoint in a SERVICE clause

### DIFF
--- a/examples/sparql_service_query_example.py
+++ b/examples/sparql_service_query_example.py
@@ -1,0 +1,18 @@
+from rdflib import Graph
+
+if __name__ == "__main__":
+    g = Graph()
+    g.bind("dbp", "https://dbpedia.org/")
+    qres = g.query(
+        """
+        SELECT ?s
+            WHERE {
+                SERVICE dbp:sparql {
+                    ?s a ?o .
+                }
+            }
+        LIMIT 3
+        """
+    )
+    for row in qres:
+        print(row.s)

--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -302,9 +302,24 @@ def evalPart(ctx: QueryContext, part: CompValue):
 
 def evalServiceQuery(ctx: QueryContext, part):
     res = {}
+    service_string = part.get("service_string", "")
+    match = re.match(
+        "^service (.*):(.*) [ \n]*{(.*)}[ \n]*$",
+        service_string,
+        re.DOTALL | re.I,
+    )
+    if match:
+        _prefix = match.group(1)
+        for prefix, namespace in ctx.graph.namespace_manager.namespaces():
+            if prefix == _prefix:
+                service_string = (
+                    f"SERVICE <{namespace}{match.group(2)}> {{{match.group(3)}}}"
+                )
+                break
+
     match = re.match(
         "^service <(.*)>[ \n]*{(.*)}[ \n]*$",
-        part.get("service_string", ""),
+        service_string,
         re.DOTALL | re.I,
     )
 


### PR DESCRIPTION
Fixed : #1427
## Summary of this PR:
Previously Federated queries(Remote Queries) don't have support for `BaseUrl` to be included as `Namespace`. So, queries that do have `URLRef` as `namespace` don't show up the result. 
### Previously
#### Code:
``` python
from rdflib import Graph

if __name__ == "__main__":
    g = Graph()
    g.bind("dbp", "https://dbpedia.org/")
    qres = g.query(
        """
        SELECT ?s
            WHERE {
                SERVICE dbp:sparql {
                    ?s a ?o .
                }
            }
        LIMIT 3
        """
    )
    for row in qres:
        print(row.s)

```
#### Result: No Result, No Error 
### Now

#### Result:
```
http://www.openlinksw.com/virtrdf-data-formats#default-iid
http://www.openlinksw.com/virtrdf-data-formats#default-iid-nullable
http://www.openlinksw.com/virtrdf-data-formats#default-iid-blank 
```
## Checklist of this PR:

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added example query that I used as sample for this code (file name =`examples/sparql_service_query_example.py`).
- [ ] Added tests for any changes that have a runtime impact.
- [ ] Checked that all tests and type checking passes.




