### PR TITLE
Resolve Issue1834, change default format type for serialize() function for SPARQLResult from "xml" to "ttl"

### DIFF
--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -218,7 +218,7 @@ class Result(object):
         self,
         destination: Optional[Union[str, IO]] = None,
         encoding: str = "utf-8",
-        format: str = "xml",
+        format: str = "ttl",
         **args,
     ) -> Optional[bytes]:
         """


### PR DESCRIPTION
Closes #1834 
As stated in the issue, the previous default format type for serialize() function for SPARQLResult was "xml". It was required to change it to "ttl" to match the default format type like in rdflib Graph. 