### PR TITLE
Added SPARQL unicode numeric codepoint escape tests

### DIFF
--- a/test/data/suites/rdflib/sparql/manifest.ttl
+++ b/test/data/suites/rdflib/sparql/manifest.ttl
@@ -5,7 +5,7 @@
 
 @prefix dawgt: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-@prefix :      <http://raw.github.com/RDFLib/rdflib/master/test/DAWG/rdflib/manifest.ttl#> .
+@prefix :      <http://raw.github.com/RDFLib/rdflib/master/test/data/rdflib-sparql/manifest.ttl#> .
 
 <> a mf:Manifest ;
 	rdfs:label "RDFLib Extra SPARQL tests" ;
@@ -40,6 +40,12 @@
     :bnode-ppath-mix-f
     :bnode-ppath-mix-g
     :bnode-ppath-mix-h
+
+    :test-codepoint-escape-01
+    :test-codepoint-escape-02
+    :test-codepoint-escape-03
+    :test-codepoint-escape-04
+    :test-codepoint-escape-bad
 
 	) .
 
@@ -363,3 +369,35 @@ From https://github.com/RDFLib/rdflib/issues/615, contributed by https://github.
            qt:data <bnode-ppath-mix.ttl> ] ;
     mf:result  <bnode-ppath-mix.srx>
     .
+
+:test-codepoint-escape-01 rdf:type   mf:PositiveSyntaxTest11 ;
+    dawgt:approval dawgt:Proposed ;
+    mf:name    "\\U unicode codepoint escaping in literal" ;
+    rdfs:comment """From https://github.com/RDFLib/rdflib/issues/1884, contributed by https://github.com/gjhiggins""" ;
+    mf:action  <syn-codepoint-escape-01.rq> ;.
+
+:test-codepoint-escape-02 rdf:type   mf:PositiveSyntaxTest11 ;
+    dawgt:approval dawgt:Proposed ;
+    rdfs:comment """From https://github.com/RDFLib/rdflib/issues/1884, contributed by https://github.com/gjhiggins""" ;
+    mf:name    "\\u unicode codepoint escaping in literal" ;
+    mf:action  <syn-codepoint-escape-02.rq> ;.
+
+:test-codepoint-escape-03 rdf:type   mf:PositiveSyntaxTest11 ;
+    dawgt:approval dawgt:Proposed ;
+    rdfs:comment """From https://github.com/RDFLib/rdflib/issues/1884, contributed by https://github.com/gjhiggins""" ;
+    mf:name    "\\u and \\U unicode codepoint escaping in literal" ;
+    mf:action  <syn-codepoint-escape-03.rq> ;.
+
+:test-codepoint-escape-04 rdf:type   mf:PositiveSyntaxTest11 ;
+    dawgt:approval dawgt:Proposed ;
+    rdfs:comment """From https://github.com/RDFLib/rdflib/issues/1884, contributed by https://github.com/gjhiggins""" ;
+    mf:name    "\\U and \\U unicode codepoints escaping in literal" ;
+    mf:action  <syn-codepoint-escape-04.rq> ;.
+
+:test-codepoint-escape-bad rdf:type   mf:NegativeSyntaxTest11 ;
+    dawgt:approval dawgt:Proposed ;
+    rdfs:comment """From https://github.com/RDFLib/rdflib/issues/1884, contributed by https://github.com/gjhiggins""" ;
+    mf:name    "Invalid multi-pass codepoint escaping (\\u then \\U)" ;
+    mf:description "Unescaping one escape sequence must not produce content that is used in another escape sequence" ;
+    mf:action  <syn-codepoint-escape-bad.rq> ;.
+

--- a/test/data/suites/rdflib/sparql/syn-codepoint-escape-01.rq
+++ b/test/data/suites/rdflib/sparql/syn-codepoint-escape-01.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+    ?s ?p "\U0001f46a" .
+}

--- a/test/data/suites/rdflib/sparql/syn-codepoint-escape-02.rq
+++ b/test/data/suites/rdflib/sparql/syn-codepoint-escape-02.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+    ?s ?p "\u00a71234" .
+}

--- a/test/data/suites/rdflib/sparql/syn-codepoint-escape-03.rq
+++ b/test/data/suites/rdflib/sparql/syn-codepoint-escape-03.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+    ?s ?p "\U0001f46a\u00a71234" .
+}

--- a/test/data/suites/rdflib/sparql/syn-codepoint-escape-04.rq
+++ b/test/data/suites/rdflib/sparql/syn-codepoint-escape-04.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+    ?s ?p "\U0001f46afoo\U0000005c" .
+}

--- a/test/data/suites/rdflib/sparql/syn-codepoint-escape-bad.rq
+++ b/test/data/suites/rdflib/sparql/syn-codepoint-escape-bad.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+    ?s ?p "\U0001HHHH" .
+}

--- a/test/test_w3c_spec/test_sparql_w3c.py
+++ b/test/test_w3c_spec/test_sparql_w3c.py
@@ -551,9 +551,22 @@ def test_dawg_data_sparql11(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest)
     testers[type](rdf_test)
 
 
+EXPECTED_FAILURES: Dict[str, str] = {}
+
+for test in [
+    "test-codepoint-escape-02",
+    "test-codepoint-escape-03",
+    "test-codepoint-escape-04",
+]:
+    EXPECTED_FAILURES[test] = "known codepoint escape issue"
+
+
 @pytest.mark.parametrize(
     "rdf_test_uri, type, rdf_test",
     read_manifest("test/data/suites/rdflib/sparql/manifest.ttl"),
 )
 def test_dawg_rdflib(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
+    suffix = rdf_test_uri.split("#")[1]
+    if suffix in EXPECTED_FAILURES:
+        pytest.xfail(EXPECTED_FAILURES[suffix])
     testers[type](rdf_test)


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

Added four (marked-as-xfail) unicode numeric codepoint escape tests
to the RDFLib-specific SPARQL test suite `test/data/suites/rdflib/sparql`.

Also:
- Fix the base URI in the RDFLib SPARQL test manifest.

Split off from #1891

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

