### PR TITLE
Passing "generate" option through in compute_qname_strict

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -538,14 +538,14 @@ class NamespaceManager(object):
         # only the strict output should bear the overhead
         namespace: str
         prefix: Optional[str]
-        prefix, namespace, name = self.compute_qname(uri)
+        prefix, namespace, name = self.compute_qname(uri, generate)
         if is_ncname(str(name)):
             return prefix, namespace, name
         else:
             if uri not in self.__cache_strict:
                 try:
                     namespace, name = split_uri(uri, NAME_START_CATEGORIES)
-                except ValueError as e:
+                except ValueError:
                     message = (
                         "This graph cannot be serialized to a strict format "
                         "because there is no valid way to shorten {}".format(uri)

--- a/test/test_namespacemanager.py
+++ b/test/test_namespacemanager.py
@@ -162,3 +162,11 @@ def test_nman_bind_namespaces(
         graph.namespace_manager = NamespaceManager(graph, selector)
     if isinstance(expected_result, dict):
         check_graph_ns(graph, expected_result)
+
+
+def test_compute_qname_no_generate() -> None:
+    g = Graph()  # 'core' bind_namespaces (default)
+    with pytest.raises(KeyError):
+        g.namespace_manager.compute_qname_strict(
+            'https://example.org/unbound/test', generate=False
+        )


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Passes through an option in the `compute_qname_strict` interface so it raises an error in the same case as the "non-strict" version.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [x] Considered adding an example in `./examples` for new features.
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

