### PR TITLE
Address lingering instances of deprecated `tempfile.mktemp`

### DIFF
--- a/examples/berkeleydb_example.py
+++ b/examples/berkeleydb_example.py
@@ -18,12 +18,12 @@ Example 2: larger data
 import os
 from rdflib import ConjunctiveGraph, Namespace, Literal
 from rdflib.store import NO_STORE, VALID_STORE
-from tempfile import mktemp
+import tempfile
 
 
 def example_1():
     """Creates a ConjunctiveGraph and performs some BerkeleyDB tasks with it"""
-    path = mktemp()
+    path = tempfile.NamedTemporaryFile().name
 
     # Declare we are using a BerkeleyDB Store
     graph = ConjunctiveGraph("BerkeleyDB")

--- a/test/test_store/test_store_berkeleydb.py
+++ b/test/test_store/test_store_berkeleydb.py
@@ -1,4 +1,4 @@
-from tempfile import mktemp
+import tempfile
 
 import pytest
 
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def get_graph():
-    path = mktemp()
+    path = tempfile.NamedTemporaryFile().name
     g = ConjunctiveGraph("BerkeleyDB")
     rt = g.open(path, create=True)
     assert rt == VALID_STORE, "The underlying store is corrupt"


### PR DESCRIPTION
# Summary of changes
Updated two instances of lingering deprecated `tempfile.mktemp` usage to use current safe tempfile idiom.

# Checklist
- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

