### PR TITLE
Fix for issue1957 sparql parser percent encoded reserved chars

### DIFF
--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -227,8 +227,17 @@ PN_LOCAL = Regex(
 )
 
 
+percent_encoded_reserved_chars_re = re.compile(
+    """%2[0-13-9a-cfA-CF]|%3[abdfABDF]|%40|%5[bdBD]"""
+)
+
+
 def _hexExpand(match):
-    return chr(int(match.group(0)[1:], 16))
+    return (
+        match.group(0)
+        if percent_encoded_reserved_chars_re.match(match.group(0))
+        else chr(int(match.group(0)[1:], 16))
+    )
 
 
 PN_LOCAL.setParseAction(lambda x: re.sub("(%s)" % PERCENT_re, _hexExpand, x[0]))

--- a/test/test_issues/test_issue1957.py
+++ b/test/test_issues/test_issue1957.py
@@ -45,4 +45,8 @@ def test_sparql_parse_reserved_char_percent_encoded(reserved_char_percent_encode
     g.parse(data=data, format="ttl")
     res = g.query(q)
 
-    assert list(res) != []
+    assert list(res)[0][0] == rdflib.term.Literal('value')
+
+    assert reserved_char_percent_encoded in str(
+        rdflib.plugins.sparql.parser.parseQuery(q)
+    )

--- a/test/test_issues/test_issue1957.py
+++ b/test/test_issues/test_issue1957.py
@@ -1,4 +1,5 @@
 import pytest
+
 import rdflib
 
 

--- a/test/test_issues/test_issue1957.py
+++ b/test/test_issues/test_issue1957.py
@@ -1,0 +1,47 @@
+import pytest
+import rdflib
+
+
+@pytest.mark.parametrize(
+    "reserved_char_percent_encoded",
+    [
+        "%20",
+        "%21",
+        "%23",
+        "%24",
+        "%25",
+        "%26",
+        "%27",
+        "%28",
+        "%29",
+        "%2A",
+        "%2B",
+        "%2C",
+        "%2F",
+        "%3A",
+        "%3B",
+        "%3D",
+        "%3F",
+        "%40",
+        "%5B",
+        "%5D",
+    ],
+)
+def test_sparql_parse_reserved_char_percent_encoded(reserved_char_percent_encoded):
+    data = f"""@prefix : <https://www.example.co/reserved/language#> .
+
+<https://www.example.co/reserved/root> :_id "01G39WKRH76BGY5D3SKDHJP2SX" ;
+    :transcript{reserved_char_percent_encoded}data [ :_id "01G39WKRH7JYRX78X7FG4RCNYF" ;
+            :_key "transcript{reserved_char_percent_encoded}data" ;
+            :value "value" ;
+            :value_id "01G39WKRH7PVK1DXQHWT08DZA8" ] ."""
+
+    q = f"""PREFIX : <https://www.example.co/reserved/language#>
+    SELECT  ?o 
+    WHERE {{ ?s :transcript{reserved_char_percent_encoded}data/:value ?o . }}"""
+
+    g = rdflib.Graph()
+    g.parse(data=data, format="ttl")
+    res = g.query(q)
+
+    assert list(res) != []


### PR DESCRIPTION
# Summary of changes
Seems like [`_hexExpand`](https://github.com/RDFLib/rdflib/blob/6ed2ef48ed38679bcdafe7cae250a2ef4b315e7b/rdflib/plugins/sparql/parser.py#L230) internal SPARQL parser function inappropriately expands [percent-encoded reserved characters](https://en.wikipedia.org/wiki/Percent-encoding). Added an exclusionary regexp to disable this behaviour and a parameterized test which checks SPARQL parser processing of the set of percent-encoded reserved chars

# Checklist


- [x] Checked that there aren't other open pull requests for the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
