### PR TITLE
escape literal * symbol in `rdflib.paths` docs

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -64,8 +64,8 @@ Path(http://xmlns.com/foaf/0.1/knows / http://xmlns.com/foaf/0.1/name)
 >>> FOAF.name|FOAF.givenName
 Path(http://xmlns.com/foaf/0.1/name | http://xmlns.com/foaf/0.1/givenName)
 
-Modifiers (?, *, +) are done using * (the multiplication operator) and
-the strings '*', '?', '+', also defined as constants in this file.
+Modifiers (?, \*, +) are done using \* (the multiplication operator) and
+the strings '\*', '?', '+', also defined as constants in this file.
 
 >>> FOAF.knows*OneOrMore
 Path(http://xmlns.com/foaf/0.1/knows+)


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->
Currently, there are unescaped `*`s in the rdflib.paths docs, which get interpreted as italics markup in ReStructured Text when generating the docs.



This PR escapes them so that the `*` characters are visible and the text isn't in italics.



# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [X] Checked that there aren't other open pull requests for
  the same change.
- [X] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

# more details

The original reStructured Text in the `__doc__` for the module includes (see [here](https://github.com/RDFLib/rdflib/blob/4ded2eb380e15ed7babbf8a632fc502d75cae040/rdflib/paths.py#L67)):

```
Modifiers (?, *, +) are done using * (the multiplication operator) and
the strings '*', '?', '+', also defined as constants in this file.
```


But in the rendered html, the literal `*`s are missing, and the text is italicised between where two `*`s should be. See the red box below:

![Screenshot 2022-05-30 at 14 42 07](https://user-images.githubusercontent.com/20516159/171006100-43b926fb-855f-4848-9cb2-48f8ebbc655e.png)

This PR escapes them so that the `*` characters are visible and the text isn't in italics:

![Screenshot 2022-05-30 at 14 45 40](https://user-images.githubusercontent.com/20516159/171006111-1f69b711-697b-4fab-9954-9e348ca72f8a.png)

Happy to discuss the fix more if necessary even though it's a small change since:
* There are multiple ways to escape/include literal `*` characters in Restructured text. Notably ` ``*`` ` also gives the desired effect. I chose to use backslash since this is used elsewhere in the rdflib docs to escape things, e.g. in the same file [here](https://github.com/RDFLib/rdflib/blob/4ded2eb380e15ed7babbf8a632fc502d75cae040/rdflib/paths.py#L32)
* There are other unescaped `*`, for example [here](https://github.com/RDFLib/rdflib/blob/4ded2eb380e15ed7babbf8a632fc502d75cae040/rdflib/paths.py#L22) in the same file, but it looks like because they don't occur in a pair, ReStructured Text doesn't interpret them as italics markers, so the desired end behaviour in the html render is fine. Unclear if it's still worth checking through the docs and escaping all literal `*`s.
* My PR doesn't do anything to address this re-occuring in future. I don't think there's a 'rdflib apidoc styleguide' or anything that it belongs in as human-readable, and I don't think an automatic check makes sense here since someone could want to use `*`s to italicise something in the docs, so it really needs a human to check/catch this.

After making the change, I generated the tests locally and checked the output to generate the 'after' screenshot above. I think this is all the testing needed for this change, but let me know if I should do anything else, or need to do anything related to contributing/releasing - sorry if I've missed a step here!

# Fly-by thank you for RDF

Thank you for RDF, it's a great tool that is incredibly useful in my daily job. It's one of my favourite python packages in terms of how easy it is to use and the effort it saves me and the docs are great. The `rdflib.paths` feature is also a really cool feature that I only came across relatively recently (hence the PR).

