### PR TITLE
correct italic markup in plugin stores docs

### DIFF
--- a/docs/plugin_stores.rst
+++ b/docs/plugin_stores.rst
@@ -38,7 +38,7 @@ HDT               `<https://github.com/RDFLib/rdflib-hdt>`_            A Store b
 Oxigraph          `<https://github.com/oxigraph/oxrdflib>`_            Works with the `Pyoxigraph <https://oxigraph.org/pyoxigraph>`_ Python graph database library
 ================= ==================================================== =============================================================================================
 
-_If you have, or know of a Store implementation and would like it listed here, please submit a Pull Request!_
+*If you have, or know of a Store implementation and would like it listed here, please submit a Pull Request!*
 
 Use
 ---
@@ -56,7 +56,7 @@ You can use these stores like this:
     graph = Graph(store="BerkeleyDB")
 
 
-In some cases, you must explicitly _open_ and _close_ a store, for example:
+In some cases, you must explicitly *open* and *close* a store, for example:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->
Currently the doc file plugin_stores.rst uses `_` in a way that appears to be intended to produce italics in the final html render, which doesn't appear to be valid ReST markup for italics. It is Markdown markup for italics (hence me reading the intention of italics in the presence of the `_`s).

I have changed this to use (unescaped) `*`s for the italics, which works as seemed to be the desired behaviour.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [X] Checked that there aren't other open pull requests for
  the same change.
- [X] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.


# More Detail

Discovered this while working on PR #1976 , looking at other places where there might be that issue, but found this related one instead.

Before (i.e. live docs [here](https://rdflib.readthedocs.io/en/stable/plugin_stores.html?highlight=HDT#external)):

![Screenshot 2022-05-30 at 15 31 42](https://user-images.githubusercontent.com/20516159/171014502-e4584ccd-25cb-4fd5-8565-fb2d06127957.png)

After (local build of docs after change):

![Screenshot 2022-05-30 at 15 33 33](https://user-images.githubusercontent.com/20516159/171014592-f01f2042-c42f-4f5b-b565-43452bed65ee.png)

Similar caveats to PR #1976:

* My PR doesn't do anything to address this re-occuring in future. I don't think there's a 'rdflib apidoc styleguide' or anything that it belongs in as human-readable, and I don't think an automatic check makes sense here since someone could want to use *s to italicise something in the docs, so it really needs a human to check/catch this.
* After making the change, I generated the tests locally and checked the output to generate the 'after' screenshot above. I think this is all the testing needed for this change, but let me know if I should do anything else, or need to do anything related to contributing/releasing - sorry if I've missed a step here!