### PR TITLE
Rework turtle-like test suites

### DIFF
--- a/test/README.rst
+++ b/test/README.rst
@@ -50,56 +50,56 @@ EARL test reports can be generated using the EARL reporter plugin from ``earl.py
 
 When this plugin is enabled it will create an ``earl:Assertion`` for every test that has a ``rdf_test_uri`` parameter which can be either a string or an ``URIRef``.
 
-To enable the EARL reporter plugin an output file path must be supplied to pytest with ``--earl-report``. The report will be written to this location in turtle format.
+To enable the EARL reporter plugin an output file path must be supplied to pytest with ``--earl-output-file``. The report will be written to this location in turtle format.
 
 Some examples of generating test reports:
 
 .. code-block:: bash
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-jsonld-local.ttl \
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-jsonld-local.ttl \
       test/jsonld/test_localsuite.py
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-jsonld-v1.1.ttl \
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-jsonld-v1.1.ttl \
       test/jsonld/test_onedotone.py
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-jsonld-v1.0.ttl \
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-jsonld-v1.0.ttl \
       test/jsonld/test_testsuite.py
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-sparql.ttl \
-      test/test_dawg.py
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-sparql.ttl \
+      test/test_w3c_spec/test_sparql_w3c.py
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-nquads.ttl \
-      test/test_nquads_w3c.py
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-nquads.ttl \
+      test/test_w3c_spec/test_nquads_w3c.py
 
    pytest \
-      --earl-asserter-homepage=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-nt.ttl \
-      test/test_nt_w3c.py
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-nt.ttl \
+      test/test_w3c_spec/test_nt_w3c.py
 
    pytest \
-      --earl-asserter-uri=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-trig.ttl \
-      test/test_trig_w3c.py
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-trig.ttl \
+      test/test_w3c_spec/test_trig_w3c.py
 
    pytest \
-      --earl-asserter-uri=http://example.com \
-      --earl-asserter-name 'Example Name' \
-      --earl-report=/var/tmp/earl/earl-turtle.ttl \
-      test/test_turtle_w3c.py
+      --earl-assertor-homepage=http://example.com \
+      --earl-assertor-name 'Example Name' \
+      --earl-output-file=/var/tmp/earl/earl-turtle.ttl \
+      test/test_w3c_spec/test_turtle_w3c.py

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,9 +5,9 @@ pytest.register_assert_rewrite("test.utils")
 from rdflib import Graph
 
 from .data import TEST_DATA_DIR
-from .utils.earl import EarlReporter
+from .utils.earl import EARLReporter  # noqa: E402
 
-pytest_plugins = [EarlReporter.__module__]
+pytest_plugins = [EARLReporter.__module__]
 
 # This is here so that asserts from these modules are formatted for human
 # readibility.

--- a/test/test_w3c_spec/test_nquads_w3c.py
+++ b/test/test_w3c_spec/test_nquads_w3c.py
@@ -1,42 +1,92 @@
 """This runs the nquads tests for the W3C RDF Working Group's N-Quads
 test suite."""
-
-
-import os
+import logging
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
 from test.utils.namespace import RDFT
-from typing import Callable, Dict
+from typing import Optional
 
 import pytest
 
-from rdflib import ConjunctiveGraph
-from rdflib.term import Node, URIRef
+from rdflib.graph import Dataset
 
-verbose = False
+logger = logging.getLogger(__name__)
 
-
-def nquads(test):
-    g = ConjunctiveGraph()
-
-    try:
-        g.parse(test.action, format="nquads")
-        if not test.syntax:
-            raise AssertionError("Input shouldn't have parsed!")
-    except:
-        if test.syntax:
-            raise
+REMOTE_BASE_IRI = "http://www.w3.org/2013/NQuadsTests/"
+LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/nquads/"
+ENCODING = "utf-8"
+MAPPER = URIMapper.from_mappings(
+    (REMOTE_BASE_IRI, ensure_suffix(LOCAL_BASE_DIR.as_uri(), "/"))
+)
+VALID_TYPES = {RDFT.TestNQuadsPositiveSyntax, RDFT.TestNQuadsNegativeSyntax}
 
 
-testers: Dict[Node, Callable[[RDFTest], None]] = {
-    RDFT.TestNQuadsPositiveSyntax: nquads,
-    RDFT.TestNQuadsNegativeSyntax: nquads,
+def check_entry(entry: ManifestEntry) -> None:
+    assert entry.action is not None
+    assert entry.type in VALID_TYPES
+    action_path = entry.uri_mapper.to_local_path(entry.action)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "action = %s\n%s", action_path, action_path.read_text(encoding=ENCODING)
+        )
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+    dataset = Dataset()
+    with ExitStack() as xstack:
+        if entry.type == RDFT.TestNQuadsNegativeSyntax:
+            catcher = xstack.enter_context(pytest.raises(Exception))
+        dataset.parse(action_path, publicID=entry.action, format="nquads")
+    if catcher is not None:
+        assert catcher.value is not None
+
+    if entry.type == RDFT.TestNQuadsPositiveSyntax:
+        graph_data = dataset.serialize(format="nquads")
+        result_dataset = Dataset()
+        result_dataset.parse(data=graph_data, publicID=entry.action, format="nquads")
+        GraphHelper.assert_cgraph_isomorphic(
+            dataset, result_dataset, exclude_bnodes=True
+        )
+        GraphHelper.assert_sets_equals(
+            dataset, result_dataset, bnode_handling=BNodeHandling.COLLAPSE
+        )
+
+
+MARK_DICT = {
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-02": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-03": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-04": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-05": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-01": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-02": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-03": pytest.mark.skip(
+        reason="accepts badly escaped literal"
+    ),
 }
 
 
 @pytest.mark.parametrize(
-    "rdf_test_uri, type, rdf_test",
-    read_manifest(os.path.join(TEST_DATA_DIR, "suites", "w3c/nquads/manifest.ttl")),
+    ["manifest_entry"],
+    params_from_sources(
+        MAPPER,
+        ManifestEntry,
+        LOCAL_BASE_DIR / "manifest.ttl",
+        mark_dict=MARK_DICT,
+        report_prefix="rdflib_w3c_nquads",
+    ),
 )
-def test_manifest(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
-    testers[type](rdf_test)
+def test_entry(manifest_entry: ManifestEntry) -> None:
+    check_entry(manifest_entry)

--- a/test/test_w3c_spec/test_nt_w3c.py
+++ b/test/test_w3c_spec/test_nt_w3c.py
@@ -1,42 +1,96 @@
-"""This runs the nt tests for the W3C RDF Working Group's N-Quads
+"""This runs the nt tests for the W3C RDF Working Group's N-Triples
 test suite."""
-import os
+import logging
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
 from test.utils.namespace import RDFT
-from typing import Callable, Dict
+from typing import Optional
 
 import pytest
 
-from rdflib import Graph
-from rdflib.term import Node, URIRef
+from rdflib.graph import Graph
 
-verbose = False
+logger = logging.getLogger(__name__)
 
-
-def nt(test):
-    g = Graph()
-
-    try:
-        g.parse(test.action, format="nt")
-        if not test.syntax:
-            raise AssertionError("Input shouldn't have parsed!")
-    except:
-        if test.syntax:
-            raise
+REMOTE_BASE_IRI = "http://www.w3.org/2013/N-TriplesTests/"
+LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/ntriples/"
+ENCODING = "utf-8"
+MAPPER = URIMapper.from_mappings(
+    (REMOTE_BASE_IRI, ensure_suffix(LOCAL_BASE_DIR.as_uri(), "/"))
+)
+VALID_TYPES = {RDFT.TestNTriplesPositiveSyntax, RDFT.TestNTriplesNegativeSyntax}
 
 
-testers: Dict[Node, Callable[[RDFTest], None]] = {
-    RDFT.TestNTriplesPositiveSyntax: nt,
-    RDFT.TestNTriplesNegativeSyntax: nt,
+def check_entry(entry: ManifestEntry) -> None:
+    assert entry.action is not None
+    assert entry.type in VALID_TYPES
+    action_path = entry.uri_mapper.to_local_path(entry.action)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "action = %s\n%s", action_path, action_path.read_text(encoding=ENCODING)
+        )
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+    graph = Graph()
+    with ExitStack() as xstack:
+        if entry.type == RDFT.TestNTriplesNegativeSyntax:
+            catcher = xstack.enter_context(pytest.raises(Exception))
+        graph.parse(action_path, publicID=entry.action, format="ntriples")
+    if catcher is not None:
+        assert catcher.value is not None
+
+    if entry.type == RDFT.TestNTriplesPositiveSyntax:
+        graph_data = graph.serialize(format="ntriples")
+        result_graph = Graph()
+        result_graph.parse(data=graph_data, publicID=entry.action, format="ntriples")
+        GraphHelper.assert_isomorphic(graph, result_graph)
+        GraphHelper.assert_sets_equals(
+            graph, result_graph, bnode_handling=BNodeHandling.COLLAPSE
+        )
+
+
+MARK_DICT = {
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-02": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-03": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-04": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-uri-05": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-01": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-02": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-03": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#nt-syntax-bad-esc-04": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#minimal_whitespace": pytest.mark.xfail(
+        reason="Not parsing valid N-Triples syntax."
+    ),
 }
 
 
 @pytest.mark.parametrize(
-    "rdf_test_uri, type, rdf_test",
-    read_manifest(
-        os.path.join(TEST_DATA_DIR, "suites", "w3c/ntriples/manifest.ttl"), legacy=True
+    ["manifest_entry"],
+    params_from_sources(
+        MAPPER,
+        ManifestEntry,
+        LOCAL_BASE_DIR / "manifest.ttl",
+        mark_dict=MARK_DICT,
+        report_prefix="rdflib_w3c_ntriples",
     ),
 )
-def test_manifest(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
-    testers[type](rdf_test)
+def test_entry(manifest_entry: ManifestEntry) -> None:
+    check_entry(manifest_entry)

--- a/test/test_w3c_spec/test_trig_w3c.py
+++ b/test/test_w3c_spec/test_trig_w3c.py
@@ -1,98 +1,196 @@
 """Runs the tests for the W3C RDF Working Group's TriG test suite.
 
 """
-
-import os
+import logging
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
 from test.utils.namespace import RDFT
-from typing import Callable, Dict
+from typing import Optional
 
 import pytest
 
-from rdflib import ConjunctiveGraph
-from rdflib.compare import graph_diff, isomorphic
-from rdflib.namespace import Namespace, split_uri
-from rdflib.term import Node, URIRef
+from rdflib.graph import Dataset
 
-verbose = False
+logger = logging.getLogger(__name__)
 
-
-def trig(test):
-    g = ConjunctiveGraph()
-
-    try:
-        base = "http://www.w3.org/2013/TriGTests/" + split_uri(test.action)[1]
-
-        g.parse(test.action, publicID=base, format="trig")
-        if not test.syntax:
-            raise AssertionError("Input shouldn't have parsed!")
-
-        if test.result:  # eval test
-            res = ConjunctiveGraph()
-            res.parse(test.result, format="nquads")
-
-            if verbose:
-
-                both, first, second = graph_diff(g, res)
-                if not first and not second:
-                    return
-
-                print("===============================")
-                print("TriG")
-                print(g.serialize(format="nquads"))
-                print("===============================")
-                print("NQuads")
-                print(res.serialize(format="nquads"))
-                print("===============================")
-
-                print("Diff:")
-                # print "%d triples in both"%len(both)
-                print("TriG Only:")
-                for t in first:
-                    print(t)
-
-                print("--------------------")
-                print("NQuads Only")
-                for t in second:
-                    print(t)
-                raise Exception("Graphs do not match!")
-
-            assert isomorphic(
-                g, res
-            ), "graphs must be the same, expected\n%s\n, got\n%s" % (
-                g.serialize(),
-                res.serialize(),
-            )
-
-    except:
-        if test.syntax:
-            raise
-
-
-testers: Dict[Node, Callable[[RDFTest], None]] = {
-    RDFT.TestTrigPositiveSyntax: trig,
-    RDFT.TestTrigNegativeSyntax: trig,
-    RDFT.TestTrigEval: trig,
-    RDFT.TestTrigNegativeEval: trig,
+REMOTE_BASE_IRI = "http://www.w3.org/2013/TriGTests/"
+LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/trig/"
+ENCODING = "utf-8"
+MAPPER = URIMapper.from_mappings(
+    (REMOTE_BASE_IRI, ensure_suffix(LOCAL_BASE_DIR.as_uri(), "/"))
+)
+VALID_TYPES = {
+    RDFT.TestTrigEval,
+    RDFT.TestTrigPositiveSyntax,
+    RDFT.TestTrigNegativeSyntax,
+    RDFT.TestTrigNegativeEval,
 }
 
-NAMESPACE = Namespace(
-    "https://dvcs.w3.org/hg/rdf/raw-file/default/trig/tests/manifest.ttl#"
-)
-EXPECTED_FAILURES: Dict[str, str] = {}
+# NOTE: `rdft:TestTrigNegativeEval` entries does not have `mf:result` as suggested
+# by <https://www.w3.org/TR/rdf11-testcases/#evaluation-tests>, instead they seem
+# to be regular `rdft:TestTrigNegativeSyntax`. For example, see `trig-eval-bad-01`
+# <https://www.w3.org/2013/TrigTests/manifest.ttl>
 
-if os.name == "nt":
-    for test in ["literal_with_LINE_FEED", "trig-subm-15", "trig-subm-16"]:
-        EXPECTED_FAILURES[test] = "Issue with nt parser and line endings on windows"
+
+def check_entry(entry: ManifestEntry) -> None:
+    assert entry.action is not None
+    assert entry.type in VALID_TYPES
+    action_path = entry.uri_mapper.to_local_path(entry.action)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "action = %s\n%s", action_path, action_path.read_text(encoding=ENCODING)
+        )
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+    dataset = Dataset()
+    with ExitStack() as xstack:
+        if entry.type in (RDFT.TestTrigNegativeSyntax, RDFT.TestTrigNegativeEval):
+            catcher = xstack.enter_context(pytest.raises(Exception))
+        dataset.parse(action_path, publicID=entry.action, format="trig")
+
+    if catcher is not None:
+        assert catcher.value is not None
+
+    if entry.type == RDFT.TestTrigEval:
+        assert entry.result is not None
+        result_source = entry.uri_mapper.to_local_path(entry.result)
+        result_dataset = Dataset()
+        result_dataset.parse(result_source, publicID=entry.action, format="nquads")
+        GraphHelper.assert_cgraph_isomorphic(
+            dataset, result_dataset, exclude_bnodes=True
+        )
+        GraphHelper.assert_sets_equals(
+            dataset, result_dataset, bnode_handling=BNodeHandling.COLLAPSE
+        )
+
+
+MARK_DICT = {
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-base-04": pytest.mark.xfail(
+        reason="accepts @base in the wrong place"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-base-05": pytest.mark.xfail(
+        reason="accepts BASE in the wrong place"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-prefix-06": pytest.mark.xfail(
+        reason="accepts @prefix in the wrong place"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-prefix-07": pytest.mark.xfail(
+        reason="accepts PREFIX in the wrong place"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-LITERAL2_with_langtag_and_datatype": pytest.mark.xfail(
+        reason="accepts literal with langtag and datatype"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-uri-01": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-uri-02": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-uri-03": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-uri-04": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-uri-05": pytest.mark.xfail(
+        reason="accepts an invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-04": pytest.mark.xfail(
+        reason="allows literal as subject"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-05": pytest.mark.xfail(
+        reason="allows literal as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-06": pytest.mark.xfail(
+        reason="allows BNodes as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-07": pytest.mark.xfail(
+        reason="allows BNodes as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-kw-04": pytest.mark.xfail(
+        reason="accepts 'true' as a subject"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-kw-05": pytest.mark.xfail(
+        reason="accepts 'true' as a predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-n3-extras-03": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-n3-extras-04": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-n3-extras-06": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-12": pytest.mark.xfail(
+        reason="ingores bad triples"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-14": pytest.mark.xfail(
+        reason="accepts literal as subject"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-15": pytest.mark.xfail(
+        reason="accepts literal as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-16": pytest.mark.xfail(
+        reason="accepts BNode as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-struct-17": pytest.mark.xfail(
+        reason="accepts BNode as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-esc-02": pytest.mark.xfail(
+        reason="accepts badly escaped literals"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-esc-03": pytest.mark.xfail(
+        reason="accepts badly escaped literals"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-esc-04": pytest.mark.xfail(
+        reason="accepts badly escaped literals"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-string-06": pytest.mark.xfail(
+        reason="accepts badly quoted literals"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-string-07": pytest.mark.xfail(
+        reason="accepts badly quoted literals"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-eval-bad-01": pytest.mark.xfail(reason="accepts bad IRI"),
+    f"{REMOTE_BASE_IRI}#trig-eval-bad-02": pytest.mark.xfail(reason="accepts bad IRI"),
+    f"{REMOTE_BASE_IRI}#trig-eval-bad-03": pytest.mark.xfail(reason="accepts bad IRI"),
+    f"{REMOTE_BASE_IRI}#trig-eval-bad-04": pytest.mark.xfail(reason="accepts bad IRI"),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-ln-dash-start": pytest.mark.xfail(
+        reason="accepts dash in start of local name"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-list-01": pytest.mark.xfail(
+        reason="ignores badly formed quad"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-list-02": pytest.mark.xfail(
+        reason="ignores badly formed quad"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-list-03": pytest.mark.xfail(
+        reason="ignores badly formed quad"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-syntax-bad-list-04": pytest.mark.xfail(
+        reason="ignores badly formed quad"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-graph-bad-01": pytest.mark.xfail(
+        reason="accepts GRAPH with no name"
+    ),
+    f"{REMOTE_BASE_IRI}#trig-graph-bad-07": pytest.mark.xfail(
+        reason="accepts nested GRAPH"
+    ),
+}
 
 
 @pytest.mark.parametrize(
-    "rdf_test_uri, type, rdf_test",
-    read_manifest(os.path.join(TEST_DATA_DIR, "suites/w3c/trig/manifest.ttl")),
+    ["manifest_entry"],
+    params_from_sources(
+        MAPPER,
+        ManifestEntry,
+        LOCAL_BASE_DIR / "manifest.ttl",
+        mark_dict=MARK_DICT,
+        report_prefix="rdflib_w3c_trig",
+    ),
 )
-def test_manifest(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
-    suffix = rdf_test_uri.split("#")[1]
-    if suffix in EXPECTED_FAILURES:
-        pytest.xfail(EXPECTED_FAILURES[suffix])
-    testers[type](rdf_test)
+def test_entry(manifest_entry: ManifestEntry) -> None:
+    check_entry(manifest_entry)

--- a/test/test_w3c_spec/test_turtle_w3c.py
+++ b/test/test_w3c_spec/test_turtle_w3c.py
@@ -1,86 +1,169 @@
-"""This runs the turtle tests for the W3C RDF Working Group's N-Quads
+"""This runs the turtle tests for the W3C RDF Working Group's Turtle
 test suite."""
 
-import os
+import logging
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
 from test.utils.namespace import RDFT
-from typing import Callable, Dict
+from typing import Optional
 
 import pytest
 
-from rdflib import Graph
-from rdflib.compare import graph_diff, isomorphic
-from rdflib.namespace import Namespace, split_uri
-from rdflib.term import Node, URIRef
+from rdflib.graph import Graph
 
-verbose = False
+logger = logging.getLogger(__name__)
 
-
-def turtle(test: RDFTest):
-    g = Graph()
-
-    try:
-        base = "http://www.w3.org/2013/TurtleTests/" + split_uri(test.action)[1]
-
-        g.parse(test.action, publicID=base, format="turtle")
-        if not test.syntax:
-            raise AssertionError("Input shouldn't have parsed!")
-
-        if test.result:  # eval test
-            res = Graph()
-            assert not isinstance(test.result, tuple)
-            res.parse(test.result, format="nt")
-
-            if verbose:
-                both, first, second = graph_diff(g, res)
-                if not first and not second:
-                    return
-                print("Diff:")
-                # print "%d triples in both"%len(both)
-                print("Turtle Only:")
-                for t in first:
-                    print(t)
-
-                print("--------------------")
-                print("NT Only")
-                for t in second:
-                    print(t)
-                raise Exception("Graphs do not match!")
-
-            assert isomorphic(
-                g, res
-            ), "graphs must be the same, expected\n%s\n, got\n%s" % (
-                g.serialize(),
-                res.serialize(),
-            )
-
-    except:
-        if test.syntax:
-            raise
-
-
-testers: Dict[Node, Callable[[RDFTest], None]] = {
-    RDFT.TestTurtlePositiveSyntax: turtle,
-    RDFT.TestTurtleNegativeSyntax: turtle,
-    RDFT.TestTurtleEval: turtle,
-    RDFT.TestTurtleNegativeEval: turtle,
+REMOTE_BASE_IRI = "http://www.w3.org/2013/TurtleTests/"
+LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/turtle/"
+ENCODING = "utf-8"
+MAPPER = URIMapper.from_mappings(
+    (REMOTE_BASE_IRI, ensure_suffix(LOCAL_BASE_DIR.as_uri(), "/"))
+)
+VALID_TYPES = {
+    RDFT.TestTurtlePositiveSyntax,
+    RDFT.TestTurtleNegativeSyntax,
+    RDFT.TestTurtleEval,
+    RDFT.TestTurtleNegativeEval,
 }
 
-NAMESPACE = Namespace("http://www.w3.org/2013/TurtleTests/manifest.ttl#")
-EXPECTED_FAILURES: Dict[str, str] = {}
+# NOTE: `rdft:TestTrigNegativeEval` entries does not have `mf:result` as suggested
+# by <https://www.w3.org/TR/rdf11-testcases/#evaluation-tests>, instead they seem
+# to be regular `rdft:TestTrigNegativeSyntax`. For example, see `trig-eval-bad-01`
+# <https://www.w3.org/2013/TrigTests/manifest.ttl>
 
-if os.name == "nt":
-    for test in ["literal_with_LINE_FEED", "turtle-subm-15", "turtle-subm-16"]:
-        EXPECTED_FAILURES[test] = "Issue with nt parser and line endings on windows"
+
+def check_entry(entry: ManifestEntry) -> None:
+    assert entry.action is not None
+    assert entry.type in VALID_TYPES
+    action_path = entry.uri_mapper.to_local_path(entry.action)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "action = %s\n%s", action_path, action_path.read_text(encoding=ENCODING)
+        )
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+    graph = Graph()
+    with ExitStack() as xstack:
+        if entry.type in (RDFT.TestTurtleNegativeSyntax, RDFT.TestTurtleNegativeEval):
+            catcher = xstack.enter_context(pytest.raises(Exception))
+        graph.parse(action_path, publicID=entry.action, format="turtle")
+
+    if catcher is not None:
+        assert catcher.value is not None
+
+    if entry.type == RDFT.TestTurtleEval:
+        assert entry.result is not None
+        result_source = entry.uri_mapper.to_local_path(entry.result)
+        result_graph = Graph()
+        result_graph.parse(result_source, publicID=entry.action, format="ntriples")
+        GraphHelper.assert_isomorphic(graph, result_graph)
+        GraphHelper.assert_sets_equals(
+            graph, result_graph, bnode_handling=BNodeHandling.COLLAPSE
+        )
+
+
+MARK_DICT = {
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype": pytest.mark.xfail(
+        reason="accepts literal with both language and datatype"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-uri-01": pytest.mark.xfail(
+        reason="accepts invalid IRIs"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-uri-02": pytest.mark.xfail(
+        reason="accepts invalid IRIs"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-uri-03": pytest.mark.xfail(
+        reason="accepts invalid IRIs"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-uri-04": pytest.mark.xfail(
+        reason="accepts invalid IRIs"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-uri-05": pytest.mark.xfail(
+        reason="accepts invalid IRIs"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-04": pytest.mark.xfail(
+        reason="accepts literal as subject"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-05": pytest.mark.xfail(
+        reason="accepts literal as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-06": pytest.mark.xfail(
+        reason="accepts blank node as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-07": pytest.mark.xfail(
+        reason="accepts blank node as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-kw-04": pytest.mark.xfail(
+        reason="accepts 'true' as subject"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-kw-05": pytest.mark.xfail(
+        reason="accepts 'true' as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-n3-extras-03": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-n3-extras-04": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-n3-extras-06": pytest.mark.xfail(
+        reason="accepts N3 paths"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-14": pytest.mark.xfail(
+        reason="accepts Literal as subject"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-15": pytest.mark.xfail(
+        reason="accepts Literal as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-16": pytest.mark.xfail(
+        reason="accepts blank node as as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-struct-17": pytest.mark.xfail(
+        reason="accepts blank node as as predicate"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-esc-02": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-esc-03": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-esc-04": pytest.mark.xfail(
+        reason="accepts badly escaped literal"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-string-06": pytest.mark.xfail(
+        reason="accepts badly quoted string"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-string-07": pytest.mark.xfail(
+        reason="accepts badly quoted string"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-eval-bad-01": pytest.mark.xfail(
+        reason="accepts invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-eval-bad-02": pytest.mark.xfail(
+        reason="accepts invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-eval-bad-03": pytest.mark.xfail(
+        reason="accepts invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-eval-bad-04": pytest.mark.xfail(
+        reason="accepts invalid IRI"
+    ),
+    f"{REMOTE_BASE_IRI}#turtle-syntax-bad-ln-dash-start": pytest.mark.xfail(
+        reason="accepts dash at the start of local name production"
+    ),
+}
 
 
 @pytest.mark.parametrize(
-    "rdf_test_uri, type, rdf_test",
-    read_manifest(os.path.join(TEST_DATA_DIR, "suites/w3c/turtle/manifest.ttl")),
+    ["manifest_entry"],
+    params_from_sources(
+        MAPPER,
+        ManifestEntry,
+        LOCAL_BASE_DIR / "manifest.ttl",
+        mark_dict=MARK_DICT,
+        report_prefix="rdflib_w3c_turtle",
+    ),
 )
-def test_manifest(rdf_test_uri: URIRef, type: Node, rdf_test: RDFTest):
-    suffix = rdf_test_uri.split("#")[1]
-    if suffix in EXPECTED_FAILURES:
-        pytest.xfail(EXPECTED_FAILURES[suffix])
-    testers[type](rdf_test)
+def test_entry(manifest_entry: ManifestEntry) -> None:
+    check_entry(manifest_entry)

--- a/test/utils/dawg_manifest.py
+++ b/test/utils/dawg_manifest.py
@@ -1,0 +1,200 @@
+import logging
+from dataclasses import dataclass, field
+from test.utils import MarkListType, marks_to_list
+from test.utils.graph import GraphSource, GraphSourceType
+from test.utils.iri import URIMapper
+from test.utils.namespace import MF
+from typing import (
+    Callable,
+    Collection,
+    Generator,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+from urllib.parse import urljoin
+
+import pytest
+from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
+
+from rdflib.graph import Graph
+from rdflib.namespace import RDF
+from rdflib.term import IdentifiedNode, Identifier, URIRef
+
+POFilterType = Tuple[Optional[URIRef], Optional[URIRef]]
+POFiltersType = Iterable[POFilterType]
+
+MarkType = Union[MarkDecorator, Collection[Union[MarkDecorator, Mark]]]
+MarksDictType = Mapping[
+    str, Union[MarkDecorator, Collection[Union[MarkDecorator, Mark]]]
+]
+ManifestEntryMarkerType = Callable[["ManifestEntry"], Optional[MarkType]]
+IdentifierT = TypeVar("IdentifierT", bound=Identifier)
+
+
+@dataclass
+class ManifestEntry:
+    manifest: "Manifest"
+    identifier: URIRef
+    type: IdentifiedNode = field(init=False)
+    action: Optional[IdentifiedNode] = field(init=False)
+    result: Optional[IdentifiedNode] = field(init=False)
+
+    def __post_init__(self) -> None:
+        type = self.value(RDF.type, IdentifiedNode)
+        assert type is not None
+        self.type = type
+
+        self.action = self.value(MF.action, IdentifiedNode)
+        self.result = self.value(MF.result, IdentifiedNode)
+
+    @property
+    def graph(self) -> Graph:
+        return self.manifest.graph
+
+    @property
+    def uri_mapper(self) -> URIMapper:
+        return self.manifest.uri_mapper
+
+    def param(
+        self,
+        mark_dict: Optional[MarksDictType] = None,
+        markers: Optional[Iterable[ManifestEntryMarkerType]] = None,
+    ) -> ParameterSet:
+        id = f"{self.identifier}"
+        marks: MarkListType = []
+        if mark_dict is not None:
+            marks = marks_to_list(mark_dict.get(id, marks))
+        if markers is not None:
+            for marker in markers:
+                opt_marks = marker(self)
+                if opt_marks is not None:
+                    opt_marks = marks_to_list(opt_marks)
+                    marks.extend(opt_marks)
+        return pytest.param(self, id=f"{self.identifier}", marks=marks)
+
+    def value(
+        self, predicate: Identifier, value_type: Type[IdentifierT]
+    ) -> Optional[IdentifierT]:
+        value = self.graph.value(self.identifier, predicate)
+        if value is not None:
+            assert isinstance(value, value_type)
+        return value
+
+    def check_filters(self, filters: POFiltersType) -> bool:
+        for filter in filters:
+            if (self.identifier, filter[0], filter[1]) in self.graph:
+                return True
+        return False
+
+
+@dataclass
+class Manifest:
+    uri_mapper: URIMapper
+    graph: Graph
+    identifier: IdentifiedNode
+    report_prefix: Optional[str] = None
+
+    @classmethod
+    def from_graph(
+        cls,
+        uri_mapper: URIMapper,
+        graph: Graph,
+        report_prefix: Optional[str] = None,
+    ) -> Generator["Manifest", None, None]:
+        for identifier in graph.subjects(RDF.type, MF.Manifest):
+            assert isinstance(identifier, IdentifiedNode)
+            manifest = Manifest(
+                uri_mapper,
+                graph,
+                identifier,
+                report_prefix,
+            )
+            yield manifest
+            yield from manifest.included()
+
+    @classmethod
+    def from_sources(
+        cls,
+        uri_mapper: URIMapper,
+        *sources: GraphSourceType,
+        report_prefix: Optional[str] = None,
+    ) -> Generator["Manifest", None, None]:
+        for source in sources:
+            logging.debug("source(%s) = %r", id(source), source)
+            source = GraphSource.from_source(source)
+            source_path_uri = source.path.absolute().as_uri()
+            local_base = urljoin(source_path_uri, ".")
+            public_id = uri_mapper.to_remote(local_base)
+            logging.debug(
+                "source = %s, source_path_uri = %s, local_base = %s, public_id = %s",
+                source,
+                source_path_uri,
+                local_base,
+                public_id,
+            )
+            graph = source.load(public_id=public_id)
+            yield from cls.from_graph(
+                uri_mapper,
+                graph,
+                report_prefix,
+            )
+
+    def included(self) -> Generator["Manifest", None, None]:
+        for includes in self.graph.objects(self.identifier, MF.include):
+            for include in self.graph.items(includes):
+                include_local_path = self.uri_mapper.to_local_path(include)
+                yield from Manifest.from_sources(
+                    self.uri_mapper,
+                    include_local_path,
+                    report_prefix=self.report_prefix,
+                )
+
+    def entires(
+        self,
+        entry_type: Type["ManifestEntryT"],
+        exclude: Optional[POFiltersType] = None,
+        include: Optional[POFiltersType] = None,
+    ) -> Generator["ManifestEntryT", None, None]:
+        for entries in self.graph.objects(self.identifier, MF.entries):
+            for entry_iri in self.graph.items(entries):
+                entry = entry_type(self, entry_iri)
+                if exclude is not None and entry.check_filters(exclude):
+                    continue
+                if include is not None and not entry.check_filters(include):
+                    continue
+                yield entry
+
+    def params(
+        self,
+        entry_type: Type["ManifestEntryT"],
+        exclude: Optional[POFiltersType] = None,
+        include: Optional[POFiltersType] = None,
+        mark_dict: Optional[MarksDictType] = None,
+        markers: Optional[Iterable[ManifestEntryMarkerType]] = None,
+    ) -> Generator["ParameterSet", None, None]:
+        for entry in self.entires(entry_type, exclude, include):
+            yield entry.param(mark_dict, markers)
+
+
+def params_from_sources(
+    uri_mapper: URIMapper,
+    entry_type: Type["ManifestEntryT"],
+    *sources: GraphSourceType,
+    exclude: Optional[POFiltersType] = None,
+    include: Optional[POFiltersType] = None,
+    mark_dict: Optional[MarksDictType] = None,
+    markers: Optional[Iterable[ManifestEntryMarkerType]] = None,
+    report_prefix: Optional[str] = None,
+) -> Generator["ParameterSet", None, None]:
+    for manifest in Manifest.from_sources(
+        uri_mapper, *sources, report_prefix=report_prefix
+    ):
+        yield from manifest.params(entry_type, include, exclude, mark_dict, markers)
+
+
+ManifestEntryT = TypeVar("ManifestEntryT", bound=ManifestEntry)

--- a/test/utils/earl.py
+++ b/test/utils/earl.py
@@ -3,17 +3,33 @@ PYTEST_DONT_REWRITE
 """
 import enum
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from test.utils.namespace import EARL, RDFT
-from typing import TYPE_CHECKING, Generator, Optional, Tuple, cast
+from test.utils import GraphHelper
+from test.utils.dawg_manifest import ManifestEntry
+from test.utils.namespace import EARL, MF, RDFT
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    OrderedDict,
+    Set,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
+import _pytest.config.argparsing
 import pytest
 from pytest import Item
 
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 from rdflib.namespace import DC, DOAP, FOAF
-from rdflib.term import IdentifiedNode, Node
+from rdflib.plugins.stores.memory import Memory
 
 if TYPE_CHECKING:
     from _pytest.main import Session
@@ -23,144 +39,180 @@ if TYPE_CHECKING:
     from pluggy._result import _Result
 
 
-class EarlReport:
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from rdflib.graph import _TripleType
+
+
+TEST_REPORTS_DIR = Path(__file__).parent.parent.parent / "test_reports"
+
+RDFLIB_PROJECT_IRI = URIRef("https://github.com/RDFLib/rdflib")
+
+
+@dataclass(eq=False)
+class EARLReport:
     """
     This is a helper class for building an EARL report graph.
     """
 
-    def __init__(
-        self,
-        asserter_uri: Optional[str] = None,
-        asserter_homepage: Optional[str] = None,
-        asserter_name: Optional[str] = None,
-    ) -> None:
-        self.graph = graph = Graph()
-        graph.bind("foaf", FOAF)
-        graph.bind("earl", EARL)
-        graph.bind("doap", DOAP)
-        graph.bind("dc", DC)
-
-        self.asserter: IdentifiedNode
-        asserter: IdentifiedNode
-        if asserter_uri is not None or asserter_homepage is not None:
-            # cast to remove Optional because mypy is not smart enough to
-            # figure out that it won't be optional.
-            asserter_ref = cast(
-                str, asserter_homepage if asserter_uri is None else asserter_uri
-            )
-            self.asserter = asserter = URIRef(asserter_ref)
-            graph.add((asserter, RDF.type, FOAF.Person))
-        else:
-            self.asserter = asserter = BNode()
-            graph.add((asserter, RDF.type, FOAF.Person))
-        if asserter_name:
-            graph.add((asserter, FOAF.name, Literal(asserter_name)))
-        if asserter_homepage:
-            graph.add((asserter, FOAF.homepage, URIRef(asserter_homepage)))
-
-        self.project = project = URIRef("https://github.com/RDFLib/rdflib")
-
-        graph.add((project, DOAP.homepage, project))
-        graph.add((project, DOAP.name, Literal("RDFLib")))
-        graph.add((project, RDF.type, DOAP.Project))
-        graph.add((project, DOAP["programming-language"], Literal("Python")))
-        graph.add(
-            (
-                project,
-                DOAP.description,
-                Literal(
-                    (
-                        "RDFLib is a Python library for working with RDF, "
-                        "a simple yet powerful language for representing information."
-                    ),
-                    lang="en",
-                ),
-            )
-        )
-
-        self.now = Literal(datetime.now())
+    reporter: "EARLReporter"
+    output_file: Path
+    assertions: List[Tuple[URIRef, Set["_TripleType"]]] = field(
+        init=False, default_factory=list, repr=False
+    )
 
     def add_test_outcome(
         self, test_id: URIRef, outcome: URIRef, info: Optional[Literal] = None
-    ) -> Tuple[Node, Node]:
-        graph = self.graph
-        assertion = BNode()
-        graph.add((assertion, RDF.type, EARL.Assertion))
-        graph.add((assertion, EARL.test, test_id))
-        graph.add((assertion, EARL.subject, self.project))
-        graph.add((assertion, EARL.mode, EARL.automatic))
-        if self.asserter:
-            graph.add((assertion, EARL.assertedBy, self.asserter))
-
+    ):
+        triples: Set["_TripleType"] = set()
+        assertion = BNode(f"{test_id}")
+        triples.add((assertion, RDF.type, EARL.Assertion))
+        triples.add((assertion, EARL.test, test_id))
+        triples.add((assertion, EARL.subject, self.reporter.project_iri))
+        triples.add((assertion, EARL.mode, EARL.automatic))
+        triples.add((assertion, EARL.assertedBy, self.reporter.assertor_iri))
         result = BNode()
-        graph.add((assertion, EARL.result, result))
-        graph.add((result, RDF.type, EARL.TestResult))
-        graph.add((result, DC.date, self.now))
-        graph.add((result, EARL.outcome, outcome))
+        triples.add((assertion, EARL.result, result))
+        triples.add((result, RDF.type, EARL.TestResult))
+        if self.reporter.add_datetime:
+            triples.add((result, DC.date, self.reporter.asserted_at))
+        triples.add((result, EARL.outcome, outcome))
         if info:
-            graph.add((result, EARL.info, info))
+            triples.add((result, EARL.info, info))
+        self.assertions.append((test_id, triples))
 
-        return graph, result
+    def write(self) -> None:
+        sorted_assertion = sorted(
+            self.assertions, key=lambda assertion: f"{assertion[0]}"
+        )
+        if sorted_assertion:
+            logger.debug("sorted_assertion[-1] = %r", sorted_assertion[-1])
+        graph = self.reporter.make_report_graph()
+        for assertion in sorted_assertion:
+            for triple in assertion[1]:
+                graph.add(triple)
+        self.output_file.parent.mkdir(parents=True, exist_ok=True)
+        graph.serialize(format="turtle", destination=self.output_file)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: _pytest.config.argparsing.Parser):
     group = parser.getgroup("terminal reporting")
     group.addoption(
-        "--earl-report",
+        "--earl-output-dir",
         action="store",
-        dest="earl_path",
+        dest="earl_output_dir",
+        metavar="dir",
+        default=f"{TEST_REPORTS_DIR}",
+        help="create EARL reports in the given directory.",
+    )
+
+    group.addoption(
+        "--earl-output-file",
+        action="store",
+        dest="earl_output_file",
         metavar="path",
         default=None,
-        help="create EARL report file at given path.",
+        help="write EARL report in the given file",
     )
 
     group.addoption(
-        "--earl-asserter-uri",
+        "--earl-output-suffix",
         action="store",
-        dest="earl_asserter_uri",
-        metavar="uri",
-        default=None,
-        help="Set the EARL asserter URI, defaults to the asserter homepage if not set.",
+        dest="earl_output_suffix",
+        metavar="path",
+        default="-latest",
+        help="suffix to use for prefix-defined test reports, defaults to '-latest'",
     )
 
     group.addoption(
-        "--earl-asserter-homepage",
+        "--earl-assertor-iri",
         action="store",
-        dest="earl_asserter_homepage",
+        dest="earl_assertor_iri",
+        metavar="iri",
+        default=RDFLIB_PROJECT_IRI,
+        help=f"Set the EARL assertor IRI, defaults to the assertor homepage if that is set, or to {RDFLIB_PROJECT_IRI} if no homepage is set.",
+    )
+
+    group.addoption(
+        "--earl-assertor-homepage",
+        action="store",
+        dest="earl_assertor_homepage",
         metavar="URL",
         default=None,
-        help="Set the EARL asserter homepage.",
+        help="Set the EARL assertor homepage.",
     )
 
     group.addoption(
-        "--earl-asserter-name",
+        "--earl-assertor-name",
         action="store",
-        dest="earl_asserter_name",
+        dest="earl_assertor_name",
         metavar="name",
         default=None,
-        help="Set the EARL asserter name.",
+        help="Set the EARL assertor name.",
+    )
+
+    group.addoption(
+        "--earl-log-level",
+        action="store",
+        dest="earl_log_level",
+        metavar="level",
+        default=None,
+        help="log level for EARL plugin itself",
+    )
+
+    group.addoption(
+        "--earl-omit-datetime",
+        action="store_false",
+        dest="earl_add_datetime",
+        default=True,
+        help="Don't write datetime to result",
     )
 
 
-def pytest_configure(config):
-    earl_path = config.option.earl_path
-    if earl_path:
-        config._earl = EarlReporter(
-            Path(earl_path),
-            EarlReport(
-                asserter_uri=config.option.earl_asserter_uri,
-                asserter_name=config.option.earl_asserter_name,
-                asserter_homepage=config.option.earl_asserter_homepage,
-            ),
-        )
-        config.pluginmanager.register(config._earl)
+FromT = TypeVar("FromT")
+ToT = TypeVar("ToT")
 
 
-def pytest_unconfigure(config):
-    earl = getattr(config, "_excel", None)
-    if earl:
-        del config._earl
-        config.pluginmanager.unregister(earl)
+def convert_optional(
+    optional: Optional[FromT], converter: Callable[[FromT], ToT]
+) -> Optional[ToT]:
+    if optional is not None:
+        return converter(optional)
+    return None
+
+
+PYTEST_PLUGIN_NAME = "rdflib_earl_reporter"
+
+
+def pytest_configure(config: pytest.Config):
+
+    if config.option.earl_log_level is not None:
+        log_level = config.option.earl_log_level
+        logger.setLevel(log_level)
+
+    earl_reporter = EARLReporter(
+        assertor_iri=URIRef(config.option.earl_assertor_iri),
+        output_dir=Path(config.option.earl_output_dir),
+        output_suffix=config.option.earl_output_suffix,
+        output_file=convert_optional(config.option.earl_output_file, Path),
+        assertor_homepage=convert_optional(
+            config.option.earl_assertor_homepage, URIRef
+        ),
+        assertor_name=convert_optional(config.option.earl_assertor_name, Literal),
+        add_datetime=config.option.earl_add_datetime,
+    )
+    logger.debug("registering earl_reporter = %s", earl_reporter)
+    config.pluginmanager.register(earl_reporter, PYTEST_PLUGIN_NAME)
+
+
+def pytest_unconfigure(config: pytest.Config):
+    earl_reporter: Optional[EARLReporter] = config.pluginmanager.get_plugin(
+        PYTEST_PLUGIN_NAME
+    )
+    logger.debug("earl_reporter = %s", earl_reporter)
+    if earl_reporter:
+        config.pluginmanager.unregister(earl_reporter, PYTEST_PLUGIN_NAME)
 
 
 # https://docs.pytest.org/en/latest/reference.html#pytest.hookspec.pytest_runtest_protocol
@@ -185,17 +237,106 @@ class TestReportHelper:
             None,
         )
 
+    @classmethod
+    def get_manifest_entry(cls, report: "TestReport") -> Optional[ManifestEntry]:
+        return next(
+            (
+                cast(ManifestEntry, item[1])
+                for item in report.user_properties
+                if item[0] == MF.ManifestEntry
+            ),
+            None,
+        )
 
-class EarlReporter:
+
+@dataclass(eq=False)
+class EARLReporter:
     """
     This class is a pytest plugin that will write a EARL report with results for
     every pytest which has a rdf_test_uri parameter that is a string or an
     URIRef.
     """
 
-    def __init__(self, output_path: Path, report: Optional[EarlReport] = None) -> None:
-        self.report = report if report is not None else EarlReport()
-        self.output_path = output_path
+    assertor_iri: URIRef
+    output_dir: Path
+    output_suffix: str
+    output_file: Optional[Path] = None
+    assertor_name: Optional[Literal] = None
+    assertor_homepage: Optional[URIRef] = None
+    add_datetime: bool = True
+    extra_triples: Set["_TripleType"] = field(default_factory=set)
+    prefix_reports: Dict[str, EARLReport] = field(init=True, default_factory=dict)
+    report: Optional[EARLReport] = field(init=True, default=None)
+
+    def __post_init__(self) -> None:
+        if self.assertor_homepage is not None:
+            self.assertor_iri = self.assertor_homepage
+
+        if self.assertor_name:
+            self.extra_triples.add((self.assertor_iri, FOAF.name, self.assertor_name))
+        if self.assertor_homepage:
+            self.extra_triples.add(
+                (self.assertor_iri, FOAF.homepage, URIRef(self.assertor_homepage))
+            )
+
+        self.project_iri = RDFLIB_PROJECT_IRI
+
+        self.extra_triples.add((self.project_iri, DOAP.homepage, self.project_iri))
+        self.extra_triples.add((self.project_iri, DOAP.name, Literal("RDFLib")))
+        self.extra_triples.add((self.project_iri, RDF.type, DOAP.Project))
+        self.extra_triples.add(
+            (self.project_iri, DOAP["programming-language"], Literal("Python"))
+        )
+        self.extra_triples.add(
+            (
+                self.project_iri,
+                DOAP.description,
+                Literal(
+                    (
+                        "RDFLib is a Python library for working with RDF, "
+                        "a simple yet powerful language for representing information."
+                    ),
+                    lang="en",
+                ),
+            )
+        )
+
+        self.asserted_at = Literal(datetime.now())
+
+        if self.output_file:
+            self.report = EARLReport(self, self.output_file)
+
+    def setup_report_graph(self, graph: Graph) -> None:
+        GraphHelper.add_triples(graph, self.extra_triples)
+        graph.bind("foaf", FOAF)
+        graph.bind("earl", EARL)
+        graph.bind("doap", DOAP)
+        graph.bind("dc", DC)
+
+    def make_report_graph(self) -> Graph:
+        graph = Graph(store=OrderedMemory())
+        self.setup_report_graph(graph)
+        return graph
+
+    def make_report_with_prefix(self, report_prefix: str) -> EARLReport:
+        output_file = self.output_dir / f"{report_prefix}{self.output_suffix}.ttl"
+        return EARLReport(self, output_file)
+
+    def get_report_for(self, entry: Optional[ManifestEntry]) -> Optional[EARLReport]:
+        if self.report:
+            return self.report
+        if entry is None:
+            return None
+        manifest = entry.manifest
+        logger.debug("manifest = %s", manifest)
+        if manifest.report_prefix is None:
+            return None
+        report = self.prefix_reports.get(manifest.report_prefix)
+        if report is None:
+            report = self.prefix_reports[
+                manifest.report_prefix
+            ] = self.make_report_with_prefix(manifest.report_prefix)
+        return report
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(
@@ -209,31 +350,63 @@ class EarlReporter:
             return
         callspec: "CallSpec2" = getattr(item, "callspec")
         rdf_test_uri = callspec.params.get("rdf_test_uri")
-        if rdf_test_uri is None:
-            return
-        if not isinstance(rdf_test_uri, URIRef) and not isinstance(rdf_test_uri, str):
-            logging.warning("rdf_test_uri parameter is not a URIRef or a str")
-            return
-        if not isinstance(rdf_test_uri, URIRef):
-            rdf_test_uri = URIRef(rdf_test_uri)
+        if rdf_test_uri is not None:
+            if isinstance(rdf_test_uri, str):
+                rdf_test_uri = URIRef(rdf_test_uri)
+            if isinstance(rdf_test_uri, URIRef):
+                report.user_properties.append((RDFT.Test, rdf_test_uri))
+            else:
+                logger.warning(
+                    "rdf_test_uri parameter is not a URIRef or a str, ignoring it"
+                )
 
-        report.user_properties.append((RDFT.Test, rdf_test_uri))
+        manifest_entry = callspec.params.get("manifest_entry")
+        if manifest_entry is not None:
+            report.user_properties.append((MF.ManifestEntry, manifest_entry))
+
+    @classmethod
+    def get_rdf_test_uri(
+        cls, rdf_test_uri: Optional[URIRef], manifest_entry: Optional[ManifestEntry]
+    ) -> Optional[URIRef]:
+        if rdf_test_uri is not None:
+            return rdf_test_uri
+        if manifest_entry is not None:
+            return manifest_entry.identifier
+        return None
 
     def append_result(self, report: "TestReport", test_result: TestResult) -> None:
         rdf_test_uri = TestReportHelper.get_rdf_test_uri(report)
+        manifest_entry = TestReportHelper.get_manifest_entry(report)
+        rdf_test_uri = self.get_rdf_test_uri(rdf_test_uri, manifest_entry)
+        logger.debug(
+            "rdf_test_uri = %s, manifest_entry = %s", rdf_test_uri, manifest_entry
+        )
         if rdf_test_uri is None:
-            # No RDF test
+            # nothing to report with
+            return
+        earl_report = self.get_report_for(manifest_entry)
+        logger.debug("earl_report = %s, test_result = %s", earl_report, test_result)
+        if earl_report is None:
             return
         if test_result is TestResult.PASS:
-            self.report.add_test_outcome(rdf_test_uri, EARL.passed)
+            earl_report.add_test_outcome(rdf_test_uri, EARL.passed)
         elif test_result is TestResult.FAIL:
-            self.report.add_test_outcome(rdf_test_uri, EARL.failed)
-        elif (test_result) is TestResult.SKIP:
-            self.report.add_test_outcome(rdf_test_uri, EARL.untested)
+            earl_report.add_test_outcome(rdf_test_uri, EARL.failed)
+        elif test_result is TestResult.SKIP:
+            earl_report.add_test_outcome(rdf_test_uri, EARL.untested)
         else:
-            self.report.add_test_outcome(rdf_test_uri, EARL.cantTell)
+            earl_report.add_test_outcome(rdf_test_uri, EARL.cantTell)
 
     def pytest_runtest_logreport(self, report: "TestReport") -> None:
+        logger.debug(
+            "report: passed = %s, failed = %s, skipped = %s, when = %s, outcome = %s, keywords = %s",
+            report.passed,
+            report.failed,
+            report.skipped,
+            report.when,
+            report.outcome,
+            report.keywords,
+        )
         if report.passed:
             if report.when == "call":  # ignore setup/teardown
                 self.append_result(report, TestResult.PASS)
@@ -243,7 +416,29 @@ class EarlReporter:
             else:
                 self.append_result(report, TestResult.ERROR)
         elif report.skipped:
-            self.append_result(report, TestResult.SKIP)
+            if "skip" in report.keywords:
+                self.append_result(report, TestResult.SKIP)
+            elif "xfail" in report.keywords:
+                self.append_result(report, TestResult.FAIL)
+            else:
+                self.append_result(report, TestResult.ERROR)
 
     def pytest_sessionfinish(self, session: "Session"):
-        self.report.graph.serialize(format="turtle", destination=self.output_path)
+        if self.report is not None:
+            self.report.write()
+        for report in self.prefix_reports.values():
+            report.write()
+
+    def make_report(self, output_file: Path) -> EARLReport:
+        return EARLReport(self, output_file)
+
+
+class OrderedMemory(Memory):
+    def __init__(self, configuration=None, identifier=None):
+        super().__init__(configuration, identifier)
+        self.__spo = OrderedDict()
+        self.__pos = OrderedDict()
+        self.__osp = OrderedDict()
+        self.__namespace = OrderedDict()
+        self.__prefix = OrderedDict()
+        self.__context_obj_map = OrderedDict()

--- a/test/utils/graph.py
+++ b/test/utils/graph.py
@@ -1,40 +1,74 @@
+import logging
+import traceback
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from rdflib.graph import Graph
 from rdflib.util import guess_format
+
+GraphSourceType = Union["GraphSource", Path]
 
 
 @dataclass(frozen=True)
 class GraphSource:
     path: Path
     format: str
+    public_id: Optional[str] = None
 
     @classmethod
-    def from_path(cls, path: Path) -> "GraphSource":
+    def from_path(cls, path: Path, public_id: Optional[str] = None) -> "GraphSource":
         format = guess_format(f"{path}")
         if format is None:
             raise ValueError(f"could not guess format for source {path}")
 
-        return cls(path, format)
+        return cls(path, format, public_id)
 
     @classmethod
-    def from_paths(cls, paths: Iterable[Path]) -> Tuple["GraphSource", ...]:
+    def from_paths(cls, *paths: Path) -> Tuple["GraphSource", ...]:
         result = []
         for path in paths:
             result.append(cls.from_path(path))
         return tuple(result)
 
+    @classmethod
+    def from_source(
+        cls, source: GraphSourceType, public_id: Optional[str] = None
+    ) -> "GraphSource":
+        logging.debug("stack = %s", "".join(traceback.format_stack(limit=8)))
+        logging.debug("source(%s) = %r", id(source), source)
+        if isinstance(source, Path):
+            source = GraphSource.from_path(source)
+        return source
+
+    def load(
+        self, graph: Optional[Graph] = None, public_id: Optional[str] = None
+    ) -> Graph:
+        if graph is None:
+            graph = Graph()
+        graph.parse(
+            source=self.path,
+            format=self.format,
+            publicID=self.public_id if public_id is None else public_id,
+        )
+        return graph
+
+
+def load_sources(
+    *sources: GraphSourceType,
+    graph: Optional[Graph] = None,
+    public_id: Optional[str] = None,
+) -> Graph:
+    if graph is None:
+        graph = Graph()
+    for source in sources:
+        GraphSource.from_source(source).load(graph, public_id)
+    return graph
+
 
 @lru_cache(maxsize=None)
 def cached_graph(
-    sources: Tuple[Union[GraphSource, Path], ...], format: Optional[str] = None
+    sources: Tuple[Union[GraphSource, Path], ...], public_id: Optional[str] = None
 ) -> Graph:
-    graph = Graph()
-    for source in sources:
-        if isinstance(source, Path):
-            source = GraphSource.from_path(source)
-        graph.parse(source=source.path, format=source.format)
-    return graph
+    return load_sources(*sources, public_id=public_id)

--- a/test/utils/iri.py
+++ b/test/utils/iri.py
@@ -1,0 +1,150 @@
+"""
+Various utilities for working with IRIs and URIs.
+"""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from test.utils import ensure_suffix
+from typing import Callable, Optional, Set, Tuple, Type, TypeVar, Union
+from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunsplit
+
+from nturl2path import url2pathname as nt_url2pathname
+
+PurePathT = TypeVar("PurePathT", bound=PurePath)
+
+
+def file_uri_to_path(
+    file_uri: str,
+    path_class: Type[PurePathT] = PurePath,  # type: ignore[assignment]
+    url2pathname: Optional[Callable[[str], str]] = None,
+) -> PurePathT:
+    """
+    This function returns a pathlib.PurePath object for the supplied file URI.
+
+    :param str file_uri: The file URI ...
+    :param class path_class: The type of path in the file_uri. By default it uses
+        the system specific path pathlib.PurePath, to force a specific type of path
+        pass pathlib.PureWindowsPath or pathlib.PurePosixPath
+    :returns: the pathlib.PurePath object
+    :rtype: pathlib.PurePath
+    """
+    is_windows_path = isinstance(path_class(), PureWindowsPath)
+    file_uri_parsed = urlparse(file_uri)
+    if url2pathname is None:
+        if is_windows_path:
+            # def _url2pathname(uri_path: str) -> str:
+            #     return nt_url2pathname(unquote(uri_path))
+            # url2pathname = _url2pathname
+            url2pathname = nt_url2pathname
+        else:
+            url2pathname = unquote
+    pathname = url2pathname(file_uri_parsed.path)
+    result = path_class(pathname)
+    return result
+
+
+def rebase_url(old_url: str, old_base: str, new_base: str) -> str:
+    logging.debug(
+        "old_url = %s, old_base = %s, new_base = %s", old_url, old_base, new_base
+    )
+    if not old_base.endswith("/"):
+        raise ValueError(
+            f"base URI should end with '/' but old_base {old_base!r} does not"
+        )
+    if not new_base.endswith("/"):
+        raise ValueError(
+            f"base URI should end with '/' but new_base {new_base!r} does not"
+        )
+    old_surl = urlsplit(old_url)
+    old_base_surl = urlsplit(old_base)
+    if (old_surl.scheme, old_surl.netloc) != (
+        old_base_surl.scheme,
+        old_base_surl.netloc,
+    ):
+        raise ValueError(
+            f"{old_url} does not have the same scheme or netlog as {old_base}"
+        )
+    old_path = PurePosixPath(unquote(old_surl.path))
+    old_base_path = PurePosixPath(unquote(old_base_surl.path))
+    rpath = old_path.relative_to(old_base_path)
+    logging.debug("rpath = %s", rpath)
+    joined = urljoin(new_base, quote(f"{rpath}"))
+    new_surl = urlsplit(joined)
+    new_url = urlunsplit(
+        (
+            new_surl.scheme,
+            new_surl.netloc,
+            new_surl.path,
+            old_surl.query,
+            old_surl.fragment,
+        )
+    )
+    if old_url.endswith("/"):
+        new_url = ensure_suffix(new_url, "/")
+    logging.debug("result = %s", new_url)
+    return new_url
+
+
+URIMappingTupleType = Tuple[str, str]
+
+
+@dataclass(frozen=True)
+class URIMapping:
+    remote: str
+    local: str
+
+    @classmethod
+    def from_tuple(cls, value: URIMappingTupleType) -> "URIMapping":
+        return cls(value[0], value[1])
+
+
+@dataclass
+class URIMapper:
+    mappings: Set[URIMapping]
+
+    def to_local_uri(self, remote: str) -> str:
+        return self._map(remote, to_local=True)
+
+    def to_local_path(self, remote: str) -> Path:
+        local_uri = self.to_local_uri(remote)
+        logging.debug("local_uri = %s", local_uri)
+        return file_uri_to_path(local_uri, Path)
+
+    def to_local(self, remote: str) -> Tuple[str, Path]:
+        local_uri = self.to_local_uri(remote)
+        local_path = file_uri_to_path(local_uri, Path)
+        return (local_uri, local_path)
+
+    def to_remote(self, local: Union[str, PurePath]) -> str:
+        return self._map(local, to_local=False)
+
+    def _map(self, value: Union[str, PurePath], to_local: bool = True) -> str:
+        error: Optional[ValueError] = None
+        mapping: URIMapping
+        uri = value.as_uri() if isinstance(value, PurePath) else value
+        for mapping in self.mappings:
+            try:
+                if to_local:
+                    return rebase_url(uri, mapping.remote, mapping.local)
+                else:
+                    return rebase_url(uri, mapping.local, mapping.remote)
+            except ValueError as e:
+                error = e
+                continue
+        error_msg = f"could not map {value} to remote"
+        if error is not None:
+            raise LookupError(error_msg) from error
+        else:
+            raise LookupError(error_msg)
+
+    @classmethod
+    def from_mappings(
+        cls, *values: Union["URIMapping", "URIMappingTupleType"]
+    ) -> "URIMapper":
+        result = set()
+        for value in values:
+            if isinstance(value, tuple):
+                value = URIMapping.from_tuple(value)
+            result.add(value)
+        return cls(result)

--- a/test/utils/test/test_iri.py
+++ b/test/utils/test/test_iri.py
@@ -1,0 +1,119 @@
+import logging
+from contextlib import ExitStack
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+from test.utils.iri import file_uri_to_path, rebase_url
+from typing import Optional, Type, Union
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ["file_uri", "path_class", "expected_result"],
+    [
+        (
+            "file:///example/some%20/thing/",
+            PurePosixPath,
+            PurePosixPath("/example/some /thing/"),
+        ),
+        (
+            "file:///c:/path/to%20/file",
+            PureWindowsPath,
+            PureWindowsPath("c:\\path\\to \\file"),
+        ),
+        (
+            "file:c:/path/to%24/file",
+            PureWindowsPath,
+            PureWindowsPath("c:\\path\\to$\\file"),
+        ),
+        (
+            "file:///C%3A/Users/iwana/d/github.com/iafork/rdflib/test/data/suites/w3c/dawg-data-r2/basic/manifest.ttl",
+            PureWindowsPath,
+            PureWindowsPath(
+                "\\C:\\Users\\iwana\\d\\github.com\\iafork\\rdflib\\test\\data\\suites\\w3c\\dawg-data-r2\\basic\\manifest.ttl"
+            ),
+        ),
+        (
+            "file:///C:/Users/iwana/d/github.com/iafork/rdflib/test/data/suites/w3c/dawg-data-r2/basic/manifest.ttl",
+            PureWindowsPath,
+            PureWindowsPath(
+                "C:/Users/iwana/d/github.com/iafork/rdflib/test/data/suites/w3c/dawg-data-r2/basic/manifest.ttl".replace(
+                    "/", "\\"
+                )
+            ),
+        ),
+    ],
+)
+def test_file_uri_to_path(
+    file_uri: str,
+    path_class: Type[PurePath],
+    expected_result: Union[PurePath, Type[Exception]],
+) -> None:
+    """
+    Tests that
+    """
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+
+    with ExitStack() as xstack:
+        if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+            catcher = xstack.enter_context(pytest.raises(expected_result))
+        result = file_uri_to_path(file_uri, path_class)
+        logging.debug("result = %s", result)
+    if catcher is not None:
+        assert catcher is not None
+        assert catcher.value is not None
+    else:
+        assert isinstance(expected_result, PurePath)
+        assert expected_result == result
+
+
+@pytest.mark.parametrize(
+    ["old_url", "old_base", "new_base", "expected_result"],
+    [
+        (
+            "https://example.com/2013/RDFXMLTests/a%20/b.xml?c=1#frag",
+            "https://example.com/2013/RDFXMLTests/",
+            "file:///example/local/path/",
+            "file:///example/local/path/a%20/b.xml?c=1#frag",
+        ),
+        (
+            "file:///example/local/path/a%20/b.xml?c=1#frag",
+            "file:///example/local/path/",
+            "https://example.com/2013/RDFXMLTests/",
+            "https://example.com/2013/RDFXMLTests/a%20/b.xml?c=1#frag",
+        ),
+        (
+            "https://example.com/2013/RDFXMLTests/a%20/b.xml?c=1#frag",
+            "https://example.com/2013/RDFXMLTests/",
+            "file:///c:/example/local/path/",
+            "file:///c:/example/local/path/a%20/b.xml?c=1#frag",
+        ),
+        (
+            "file:///c:/example/local/path/a%20/b.xml?c=1#frag",
+            "file:///c:/example/local/path/",
+            "https://example.com/2013/RDFXMLTests/",
+            "https://example.com/2013/RDFXMLTests/a%20/b.xml?c=1#frag",
+        ),
+    ],
+)
+def test_rebase_url(
+    old_url: str,
+    old_base: str,
+    new_base: str,
+    expected_result: Union[str, Type[Exception]],
+) -> None:
+    """
+    Tests that
+    """
+    catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+
+    with ExitStack() as xstack:
+        if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+            catcher = xstack.enter_context(pytest.raises(expected_result))
+        result = rebase_url(old_url, old_base, new_base)
+        logging.debug("result = %s", result)
+    if catcher is not None:
+        assert catcher is not None
+        assert catcher.value is not None
+    else:
+        assert isinstance(expected_result, str)
+        assert expected_result == result

--- a/test_reports/rdflib_w3c_nquads-HEAD.ttl
+++ b/test_reports/rdflib_w3c_nquads-HEAD.ttl
@@ -1,0 +1,689 @@
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<https://github.com/RDFLib/rdflib> a doap:Project ;
+    doap:description "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."@en ;
+    doap:homepage <https://github.com/RDFLib/rdflib> ;
+    doap:name "RDFLib" ;
+    doap:programming-language "Python" .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#comment_following_triple> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#langtagged_string> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#lantag_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_all_controls> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_2_dquotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_REVERSE_SOLIDUS2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_dquote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_numeric_escape4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_numeric_escape8> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#literal_with_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#minimal_whitespace> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bad-literal-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bad-literal-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bad-literal-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bad-quint-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bad-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-bnode-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nq-syntax-uri-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:untested ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-lang-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-num-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-num-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-num-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bad-uri-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bnode-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bnode-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-bnode-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-datatypes-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-datatypes-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-file-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-file-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-file-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-str-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-str-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-str-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-subm-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/NQuadsTests/#nt-syntax-uri-04> .
+

--- a/test_reports/rdflib_w3c_ntriples-HEAD.ttl
+++ b/test_reports/rdflib_w3c_ntriples-HEAD.ttl
@@ -1,0 +1,553 @@
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<https://github.com/RDFLib/rdflib> a doap:Project ;
+    doap:description "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."@en ;
+    doap:homepage <https://github.com/RDFLib/rdflib> ;
+    doap:name "RDFLib" ;
+    doap:programming-language "Python" .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#comment_following_triple> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#langtagged_string> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#lantag_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_all_controls> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_2_dquotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_REVERSE_SOLIDUS2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_dquote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_numeric_escape4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_numeric_escape8> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#literal_with_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#minimal_whitespace> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-lang-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-num-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-num-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-num-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bad-uri-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bnode-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bnode-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-bnode-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-datatypes-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-datatypes-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-file-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-file-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-file-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-str-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-str-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-str-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-subm-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/N-TriplesTests/#nt-syntax-uri-04> .
+

--- a/test_reports/rdflib_w3c_trig-HEAD.ttl
+++ b/test_reports/rdflib_w3c_trig-HEAD.ttl
@@ -1,0 +1,2689 @@
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<https://github.com/RDFLib/rdflib> a doap:Project ;
+    doap:description "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."@en ;
+    doap:homepage <https://github.com/RDFLib/rdflib> ;
+    doap:name "RDFLib" ;
+    doap:programming-language "Python" .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#HYPHEN_MINUS_in_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#IRIREF_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#IRI_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#IRI_with_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#IRI_with_eight_digit_numeric_escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#IRI_with_four_digit_numeric_escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL1_all_controls> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL1_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL1_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL1_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL2_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL2_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG1_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG1_with_1_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG1_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG1_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2_with_1_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#LITERAL_LONG2_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#SPARQL_style_base> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#SPARQL_style_prefix> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#alternating_bnode_graphs> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#alternating_iri_graphs> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#anonymous_blank_node_graph> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#anonymous_blank_node_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#anonymous_blank_node_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#bareword_a_predicate> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#bareword_decimal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#bareword_double> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#bareword_integer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#blankNodePropertyList_as_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#blankNodePropertyList_as_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#blankNodePropertyList_containing_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#blankNodePropertyList_with_multiple_triples> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#collection_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#collection_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#comment_following_PNAME_NS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#comment_following_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#default_namespace_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#double_lower_case_e> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#empty_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#first> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_graph> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_with_leading_digit> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_with_leading_underscore> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#labeled_blank_node_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#langtagged_LONG> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#langtagged_LONG_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#langtagged_non_LONG> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#lantag_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#last> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_false> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_true> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_escaped_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_escaped_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_escaped_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_escaped_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_escaped_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_numeric_escape4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#literal_with_numeric_escape8> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_leading_digit> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_leading_underscore> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_nfc_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localName_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#localname_with_COLON> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#negative_numeric> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#nested_blankNodePropertyLists> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#nested_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#number_sign_following_PNAME_NS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#number_sign_following_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#numeric_with_leading_0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#objectList_with_two_objects> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#old_style_base> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#old_style_prefix> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#percent_escaped_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#positive_numeric> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#predicateObjectList_with_two_objectLists> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefix_only_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefix_reassigned_and_used> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefix_with_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefix_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefixed_IRI_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefixed_IRI_predicate> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#prefixed_name_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#repeated_semis_at_end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#repeated_semis_not_at_end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#reserved_escaped_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#sole_blankNodePropertyList> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-bnodeplist-graph-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-collection-graph-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-collection-graph-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-bad-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-bad-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-bad-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-bad-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-eval-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-kw-graph-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-14> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-15> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-16> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-17> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-18> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-19> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-20> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-21> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-22> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-23> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-24> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-25> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-26> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-subm-27> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-LITERAL2_with_langtag_and_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-base-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-base-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-base-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-base-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-blank-label-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-esc-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-kw-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-kw-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-kw-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-kw-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-kw-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-lang-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-list-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-list-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-list-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-list-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-ln-dash-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-ln-escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-ln-escape-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-missing-ns-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-missing-ns-dot-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-n3-extras-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-ns-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-ns-dot-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-num-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-num-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-num-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-num-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-num-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-number-dot-in-anon> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-pname-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-pname-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-pname-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-prefix-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-14> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-15> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-16> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-struct-17> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bad-uri-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-base-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-base-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-base-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-blank-label> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-bnode-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-datatypes-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-datatypes-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-file-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-file-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-file-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-kw-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-kw-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-kw-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-lists-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-lists-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-lists-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-lists-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-lists-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-ln-colons> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-ln-dots> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-minimal-whitespace-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-ns-dots> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-number-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-pname-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-pname-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-pname-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-prefix-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-str-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-str-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-str-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-string-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-struct-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-syntax-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-bad-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#trig-turtle-bad-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#two_LITERAL_LONG2s> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TriGTests/#underscore_in_localName> .
+

--- a/test_reports/rdflib_w3c_turtle-HEAD.ttl
+++ b/test_reports/rdflib_w3c_turtle-HEAD.ttl
@@ -1,0 +1,2337 @@
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<https://github.com/RDFLib/rdflib> a doap:Project ;
+    doap:description "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."@en ;
+    doap:homepage <https://github.com/RDFLib/rdflib> ;
+    doap:name "RDFLib" ;
+    doap:programming-language "Python" .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#HYPHEN_MINUS_in_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#IRIREF_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#IRI_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#IRI_with_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#IRI_with_eight_digit_numeric_escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#IRI_with_four_digit_numeric_escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL1_all_controls> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL1_all_punctuation> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL1_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL1_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL2_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL2_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG1_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG1_with_1_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG1_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG1_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2_ascii_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2_with_1_squote> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2_with_2_squotes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#LITERAL_LONG2_with_UTF8_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#SPARQL_style_base> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#SPARQL_style_prefix> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#anonymous_blank_node_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#anonymous_blank_node_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#bareword_a_predicate> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#bareword_decimal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#bareword_double> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#bareword_integer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#blankNodePropertyList_as_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#blankNodePropertyList_as_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#blankNodePropertyList_containing_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#blankNodePropertyList_with_multiple_triples> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#collection_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#collection_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#comment_following_PNAME_NS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#comment_following_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#default_namespace_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#double_lower_case_e> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#empty_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#first> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_subject> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_with_leading_digit> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_with_leading_underscore> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#labeled_blank_node_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#langtagged_LONG> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#langtagged_LONG_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#langtagged_non_LONG> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#lantag_with_subtag> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#last> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_false> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_true> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_REVERSE_SOLIDUS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_escaped_BACKSPACE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_escaped_CARRIAGE_RETURN> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_escaped_CHARACTER_TABULATION> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_escaped_FORM_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_escaped_LINE_FEED> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_numeric_escape4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#literal_with_numeric_escape8> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_leading_digit> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_leading_underscore> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_nfc_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localName_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#localname_with_COLON> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#negative_numeric> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#nested_blankNodePropertyLists> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#nested_collection> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#number_sign_following_PNAME_NS> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#number_sign_following_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#numeric_with_leading_0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#objectList_with_two_objects> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#old_style_base> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#old_style_prefix> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#percent_escaped_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#positive_numeric> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#predicateObjectList_with_two_objectLists> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefix_only_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefix_reassigned_and_used> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefix_with_PN_CHARS_BASE_character_boundaries> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefix_with_non_leading_extras> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefixed_IRI_object> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefixed_IRI_predicate> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#prefixed_name_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#repeated_semis_at_end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#repeated_semis_not_at_end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#reserved_escaped_localName> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#sole_blankNodePropertyList> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-bad-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-bad-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-bad-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-bad-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-eval-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-14> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-15> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-16> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-17> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-18> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-19> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-20> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-21> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-22> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-23> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-24> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-25> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-26> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-subm-27> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-base-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-base-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-blank-label-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-esc-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-kw-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-kw-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-kw-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-kw-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-kw-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-lang-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-ln-dash-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-ln-escape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-ln-escape-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-missing-ns-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-missing-ns-dot-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-n3-extras-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-ns-dot-end> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-ns-dot-start> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-num-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-num-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-num-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-num-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-num-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-number-dot-in-anon> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-pname-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-pname-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-pname-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-prefix-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-prefix-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-prefix-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-prefix-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-12> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-13> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-14> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-15> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-16> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-struct-17> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:failed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bad-uri-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-base-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-base-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-base-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-base-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-blank-label> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-bnode-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-datatypes-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-datatypes-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-file-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-file-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-file-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-kw-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-kw-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-kw-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-lists-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-lists-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-lists-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-lists-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-lists-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-ln-colons> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-ln-dots> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-ns-dots> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-number-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-pname-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-pname-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-pname-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-prefix-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-str-esc-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-str-esc-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-str-esc-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-06> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-07> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-08> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-09> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-10> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-string-11> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-struct-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-struct-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-struct-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-struct-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-struct-05> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-uri-01> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-uri-02> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-uri-03> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#turtle-syntax-uri-04> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#two_LITERAL_LONG2s> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/RDFLib/rdflib> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/rdflib> ;
+    earl:test <http://www.w3.org/2013/TurtleTests/#underscore_in_localName> .
+


### PR DESCRIPTION
This patch reworks the turtle-like test suites (N-Quads, N-Triples,
Turtle, TriG). The changes includes:

- A new DAWG Manifest processor:
  - Incorporates pytest expected failure support in test parameter generation.
  - Supports URI mapping so that local filesystem URIs can be mapped to the
    correct remote base URIs and still work correctly with local files.
  - Supports custom entry types so that suite specific handling can be
    implemented separately from the core manifest processor. This will
    be used for SPARQL test suite and JSON test suite processing.
- Updated EARL reporter:
  - Support for the new DAWG Manifest processor.
  - Writing of EARL reports by default if a report prefix is
    specified in the DAWG Manifest processor.
  - Reports output is sorted so that it can be compared with text based
    diff tools.
  - Fixed reporting of xfail tests. These were reported as skipped before,
    now they are reported as failed. 

The testing is also more accurate, and now tests which were reported as
passing before are now correctly reported as failing. With one exception
all these failures are related to leniency in the parser, as our parser
accepts input that should raise an error when parsing.

Other changes:
- Moved IRI related test utilities to a separate module.
- Added generated reports for turtle-like formats to git with `-HEAD`
  suffix.

Subsequent changes will use this new processor for SPARQL and RDF/XML,
the draft for these can be seen in https://github.com/RDFLib/rdflib/pull/1969.


<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

