### PR TITLE
Add fragment property to URIRef

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -313,6 +313,18 @@ class URIRef(IdentifiedNode):
             return URIRef(url)
         else:
             return self
+    
+    @property
+    def fragment(self) -> str:
+        """
+        Return the URL Fragment
+        
+        >>> URIRef("http://example.com/some/path/#some-fragment").fragment
+        'some-fragment'
+        >>> URIRef("http://example.com/some/path/").fragment
+        ''
+        """
+        return urlparse(self).fragment
 
     def __reduce__(self) -> Tuple[Type["URIRef"], Tuple[str]]:
         return (URIRef, (str(self),))

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -313,12 +313,12 @@ class URIRef(IdentifiedNode):
             return URIRef(url)
         else:
             return self
-    
+
     @property
     def fragment(self) -> str:
         """
         Return the URL Fragment
-        
+
         >>> URIRef("http://example.com/some/path/#some-fragment").fragment
         'some-fragment'
         >>> URIRef("http://example.com/some/path/").fragment


### PR DESCRIPTION
# Summary of changes

Added a property `fragment` to `URIRef` so it is easy to access the URI's fragment:

```python
>>> URIRef("http://example.com/some/path/#some-fragment").fragment
'some-fragment'
>>> URIRef("http://example.com/some/path/").fragment
''
```

## Why is this useful?

The non-fragment part of the URI often just serves a namespace purpose, e.g. `https://brickschema.org/schema/Brick#`.

Actual "things" use that namespace, and have the "thing" name as the fragment, e.g. `https://brickschema.org/schema/Brick#Valve_Position_Sensor`

For display purposes, it's nice to get to the "thing" name, i.e. the fragment easily.

TODO: update docs and tests. I'll do that if you deem this PR is useful.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] Added tests for any changes that have a runtime impact.
- [ ] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

