### PR TITLE
Remove extra newline from N-Triples output

### DIFF
--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -39,7 +39,6 @@ class NTSerializer(Serializer):
 
         for triple in self.store:
             stream.write(_nt_row(triple).encode())
-        stream.write("\n".encode())
 
 
 class NT11Serializer(NTSerializer):

--- a/test/test_issues/test_issue1998.py
+++ b/test/test_issues/test_issue1998.py
@@ -10,6 +10,6 @@ def test_1998():
     g = rdflib.Graph()
     bob = rdflib.URIRef("http://example.org/people/Bob")
     g.add((bob, rdflib.RDF.type, rdflib.FOAF.Person))
-    for nt_format in ('nt', 'nt11'):
+    for nt_format in ("nt", "nt11"):
         output = g.serialize(format=nt_format)
-        assert not output.endswith('\n\n')
+        assert not output.endswith("\n\n")

--- a/test/test_issues/test_issue1998.py
+++ b/test/test_issues/test_issue1998.py
@@ -1,0 +1,15 @@
+"""Test that N-Triples formats do not have double newlines at the end
+of the output.
+
+https://github.com/RDFLib/rdflib/issues/1998
+"""
+import rdflib
+
+
+def test_1998():
+    g = rdflib.Graph()
+    bob = rdflib.URIRef("http://example.org/people/Bob")
+    g.add((bob, rdflib.RDF.type, rdflib.FOAF.Person))
+    for nt_format in ('nt', 'nt11'):
+        output = g.serialize(format=nt_format)
+        assert not output.endswith('\n\n')


### PR DESCRIPTION
Remove the extra newline generated by the N-Triples serializer and add
a unit test to verify that N-Triples output does not end in two
consecutive newlines.

Closes #1998 

<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

This pull request removes the extra newline that the N-Triples serializers add. This pull request also includes a unit test to verify that the output from the N-Triples serializers ("nt" and "nt11") does not end in two consecutive newlines.

See issue #1998 for additional details and a reproducible example. This reproducible example is used in the added unit test.

This fix does not change any APIs so it should be backward compatible.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ x] Checked that there aren't other open pull requests for
  the same change.
- [ x] Added tests for any changes that have a runtime impact.
- [ x] Checked that all tests and type checking passes.
- [ x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

