### PR TITLE
Fix for #1873 avoid AttributeError raised ...

### DIFF
--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -298,10 +298,10 @@ def Builtin_CONCAT(expr, ctx):
 
     # dt/lang passed on only if they all match
 
-    dt = set(x.datatype for x in expr.arg)
+    dt = set(x.datatype for x in expr.arg if isinstance(x, Literal))
     dt = dt.pop() if len(dt) == 1 else None
 
-    lang = set(x.language for x in expr.arg)
+    lang = set(x.language for x in expr.arg if isinstance(x, Literal))
     lang = lang.pop() if len(lang) == 1 else None
 
     return Literal("".join(string(x) for x in expr.arg), datatype=dt, lang=lang)

--- a/test/test_issues/test_issue1873.py
+++ b/test/test_issues/test_issue1873.py
@@ -1,0 +1,9 @@
+from rdflib import Graph
+
+
+def test_sparql_error_implicit_bind():
+    [r for r in Graph().query('SELECT (concat("", sha1(?x)) AS ?y) WHERE {}')]
+
+
+def test_sparql_error_explicit_bind():
+    [r for r in Graph().query("SELECT ?v ?p ?m WHERE {?v ?p ?m BIND (sha1(?x) AS ?m)}")]


### PR DESCRIPTION
from attempting to access language and datatype attributes of non-Literal objects

Fix for #1873 ... 
> “Using the SPARQL query engine of rdflib 6.1.1, when an assignment's operand is an error (e.g., running a function on an unbound variable), an error is thrown, for example: # AttributeError: 'NotBoundError' object has no attribute 'datatype'. However, the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#assignment) expects that the assigned variable would remain unbound in such case:”

# Summary of changes

Added `isinstance` check to avoid AttributeErrors being raised by attempting to access `language` and `datatype`attribs of non-Literal objects being passed back up the call stack resulting from SPARQL BIND failures/errors.

# Checklist
- [x] Checked that there aren't other open pull requests for the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

