### PR TITLE
Toplevel n80x

### DIFF
--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -11,13 +11,13 @@ class Collection(object):
 
     >>> from rdflib.graph import Graph
     >>> from pprint import pprint
-    >>> listName = BNode()
+    >>> listname = BNode()
     >>> g = Graph('Memory')
     >>> listItem1 = BNode()
     >>> listItem2 = BNode()
-    >>> g.add((listName, RDF.first, Literal(1))) # doctest: +ELLIPSIS
+    >>> g.add((listname, RDF.first, Literal(1))) # doctest: +ELLIPSIS
     <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
-    >>> g.add((listName, RDF.rest, listItem1)) # doctest: +ELLIPSIS
+    >>> g.add((listname, RDF.rest, listItem1)) # doctest: +ELLIPSIS
     <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g.add((listItem1, RDF.first, Literal(2))) # doctest: +ELLIPSIS
     <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
@@ -27,7 +27,7 @@ class Collection(object):
     <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
     >>> g.add((listItem2, RDF.first, Literal(3))) # doctest: +ELLIPSIS
     <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
-    >>> c = Collection(g,listName)
+    >>> c = Collection(g,listname)
     >>> pprint([term.n3() for term in c])
     [u'"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
      u'"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
@@ -51,13 +51,13 @@ class Collection(object):
     def n3(self):
         """
         >>> from rdflib.graph import Graph
-        >>> listName = BNode()
+        >>> listname = BNode()
         >>> g = Graph('Memory')
         >>> listItem1 = BNode()
         >>> listItem2 = BNode()
-        >>> g.add((listName, RDF.first, Literal(1))) # doctest: +ELLIPSIS
+        >>> g.add((listname, RDF.first, Literal(1))) # doctest: +ELLIPSIS
         <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
-        >>> g.add((listName, RDF.rest, listItem1)) # doctest: +ELLIPSIS
+        >>> g.add((listname, RDF.rest, listItem1)) # doctest: +ELLIPSIS
         <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
         >>> g.add((listItem1, RDF.first, Literal(2))) # doctest: +ELLIPSIS
         <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
@@ -67,7 +67,7 @@ class Collection(object):
         <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
         >>> g.add((listItem2, RDF.first, Literal(3))) # doctest: +ELLIPSIS
         <Graph identifier=... (<class 'rdflib.graph.Graph'>)>
-        >>> c = Collection(g, listName)
+        >>> c = Collection(g, listname)
         >>> print(c.n3()) #doctest: +NORMALIZE_WHITESPACE
         ( "1"^^<http://www.w3.org/2001/XMLSchema#integer>
           "2"^^<http://www.w3.org/2001/XMLSchema#integer>
@@ -96,21 +96,21 @@ class Collection(object):
         """
         Returns the 0-based numerical index of the item in the list
         """
-        listName = self.uri
+        listname = self.uri
         index = 0
         while True:
-            if (listName, RDF.first, item) in self.graph:
+            if (listname, RDF.first, item) in self.graph:
                 return index
             else:
-                newLink = list(self.graph.objects(listName, RDF.rest))
+                newlink = list(self.graph.objects(listname, RDF.rest))
                 index += 1
-                if newLink == [RDF.nil]:
+                if newlink == [RDF.nil]:
                     raise ValueError("%s is not in %s" % (item, self.uri))
-                elif not newLink:
+                elif not newlink:
                     raise Exception("Malformed RDF Collection: %s" % self.uri)
                 else:
-                    assert len(newLink) == 1, "Malformed RDF Collection: %s" % self.uri
-                    listName = newLink[0]
+                    assert len(newlink) == 1, "Malformed RDF Collection: %s" % self.uri
+                    listname = newlink[0]
 
     def __getitem__(self, key):
         """TODO"""
@@ -183,8 +183,8 @@ class Collection(object):
             pass
         elif key == len(self) - 1:
             # the tail
-            priorLink = self._get_container(key - 1)
-            self.graph.set((priorLink, RDF.rest, RDF.nil))
+            priorlink = self._get_container(key - 1)
+            self.graph.set((priorlink, RDF.rest, RDF.nil))
             graph.remove((current, None, None))
         else:
             next = self._get_container(key + 1)
@@ -210,9 +210,9 @@ class Collection(object):
     def append(self, item):
         """
         >>> from rdflib.graph import Graph
-        >>> listName = BNode()
+        >>> listname = BNode()
         >>> g = Graph()
-        >>> c = Collection(g,listName,[Literal(1),Literal(2)])
+        >>> c = Collection(g,listname,[Literal(1),Literal(2)])
         >>> links = [
         ...     list(g.subjects(object=i, predicate=RDF.first))[0] for i in c]
         >>> len([i for i in links if (i, RDF.rest, RDF.nil) in g])

--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -118,7 +118,7 @@ def _total_seconds(td):
     return result
 
 
-class _runtime(object):
+class _runtime(object):  # noqa: N801
     def __init__(self, label):
         self.label = label
 
@@ -137,7 +137,7 @@ class _runtime(object):
         return wrapped_f
 
 
-class _call_count(object):
+class _call_count(object):  # noqa: N801
     def __init__(self, label):
         self.label = label
 

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     import xml.etree.ElementTree as etree
 else:
     try:
-        from lxml import etree  # n0qa: N813
+        from lxml import etree  # noqa: N813
     except ImportError:
         import xml.etree.ElementTree as etree  # noqa: N813 F401
 

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     import xml.etree.ElementTree as etree
 else:
     try:
-        from lxml import etree  # nqqa: N813
+        from lxml import etree  # n0qa: N813
     except ImportError:
-        import xml.etree.ElementTree as etree  # noqa: N813 F401
+        import xml.etree.ElementTree as etree  # noqa: N813
 
 
 def cast_bytes(s, enc="utf-8"):

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     import xml.etree.ElementTree as etree
 else:
     try:
-        from lxml import etree
+        from lxml import etree  # nqqa: N813
     except ImportError:
-        import xml.etree.ElementTree as etree
+        import xml.etree.ElementTree as etree  # noqa: N813
 
 
 def cast_bytes(s, enc="utf-8"):

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -14,7 +14,7 @@ else:
     try:
         from lxml import etree  # n0qa: N813
     except ImportError:
-        import xml.etree.ElementTree as etree  # noqa: N813
+        import xml.etree.ElementTree as etree  # noqa: N813 F401
 
 
 def cast_bytes(s, enc="utf-8"):

--- a/rdflib/compat.py
+++ b/rdflib/compat.py
@@ -14,7 +14,7 @@ else:
     try:
         from lxml import etree  # nqqa: N813
     except ImportError:
-        import xml.etree.ElementTree as etree  # noqa: N813
+        import xml.etree.ElementTree as etree  # noqa: N813 F401
 
 
 def cast_bytes(s, enc="utf-8"):

--- a/rdflib/container.py
+++ b/rdflib/container.py
@@ -92,11 +92,11 @@ class Container(object):
         pred = self.graph.predicates(self.uri, item)
         if not pred:
             raise ValueError("%s is not in %s" % (item, "container"))
-        LI_INDEX = URIRef(str(RDF) + "_")
+        li_index = URIRef(str(RDF) + "_")
 
         i = None
         for p in pred:
-            i = int(p.replace(LI_INDEX, ""))
+            i = int(p.replace(li_index, ""))
         return i
 
     def __getitem__(self, key):

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -469,10 +469,10 @@ def evalPath(graph, t):
             "recommendations and will be replaced by evalpath() in rdflib 7.0.0."
         )
     )
-    return evalpath(graph, t)
+    return eval_path(graph, t)
 
 
-def evalpath(graph, t):
+def eval_path(graph, t):
     return ((s, o) for s, p, o in graph.triples(t))
 
 

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -464,7 +464,7 @@ def path_sequence(self, other):
 def evalPath(graph, t):
     warnings.warn(
         DeprecationWarning(
-            "rdflib.path.evalPath() is deprecated, use the (all-lowercase) eval_path(). "
+            "rdflib.path.evalPath() is deprecated, use the (snake-cased) eval_path(). "
             "The mixed-case evalPath() function name is incompatible with PEP8 "
             "recommendations and will be replaced by eval_path() in rdflib 7.0.0."
         )

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -103,74 +103,74 @@ Graph generator functions, triples, subjects, objects, etc. :
 
 A more complete set of tests:
 
->>> list(evalPath(g, (None, e.p1/e.p2, None)))==[(e.a, e.e)]
+>>> list(evalpath(g, (None, e.p1/e.p2, None)))==[(e.a, e.e)]
 True
->>> list(evalPath(g, (e.a, e.p1|e.p2, None)))==[(e.a,e.c), (e.a,e.f)]
+>>> list(evalpath(g, (e.a, e.p1|e.p2, None)))==[(e.a,e.c), (e.a,e.f)]
 True
->>> list(evalPath(g, (e.c, ~e.p1, None))) == [ (e.c, e.a) ]
+>>> list(evalpath(g, (e.c, ~e.p1, None))) == [ (e.c, e.a) ]
 True
->>> list(evalPath(g, (e.a, e.p1*ZeroOrOne, None))) == [(e.a, e.a), (e.a, e.c)]
+>>> list(evalpath(g, (e.a, e.p1*ZeroOrOne, None))) == [(e.a, e.a), (e.a, e.c)]
 True
->>> list(evalPath(g, (e.c, e.p3*OneOrMore, None))) == [
+>>> list(evalpath(g, (e.c, e.p3*OneOrMore, None))) == [
 ...     (e.c, e.g), (e.c, e.h), (e.c, e.a)]
 True
->>> list(evalPath(g, (e.c, e.p3*ZeroOrMore, None))) == [(e.c, e.c),
+>>> list(evalpath(g, (e.c, e.p3*ZeroOrMore, None))) == [(e.c, e.c),
 ...     (e.c, e.g), (e.c, e.h), (e.c, e.a)]
 True
->>> list(evalPath(g, (e.a, -e.p1, None))) == [(e.a, e.f)]
+>>> list(evalpath(g, (e.a, -e.p1, None))) == [(e.a, e.f)]
 True
->>> list(evalPath(g, (e.a, -(e.p1|e.p2), None))) == []
+>>> list(evalpath(g, (e.a, -(e.p1|e.p2), None))) == []
 True
->>> list(evalPath(g, (e.g, -~e.p2, None))) == [(e.g, e.j)]
+>>> list(evalpath(g, (e.g, -~e.p2, None))) == [(e.g, e.j)]
 True
->>> list(evalPath(g, (e.e, ~(e.p1/e.p2), None))) == [(e.e, e.a)]
+>>> list(evalpath(g, (e.e, ~(e.p1/e.p2), None))) == [(e.e, e.a)]
 True
->>> list(evalPath(g, (e.a, e.p1/e.p3/e.p3, None))) == [(e.a, e.h)]
+>>> list(evalpath(g, (e.a, e.p1/e.p3/e.p3, None))) == [(e.a, e.h)]
 True
 
->>> list(evalPath(g, (e.q, e.px*OneOrMore, None)))
+>>> list(evalpath(g, (e.q, e.px*OneOrMore, None)))
 [(rdflib.term.URIRef('ex:q'), rdflib.term.URIRef('ex:q'))]
 
->>> list(evalPath(g, (None, e.p1|e.p2, e.c)))
+>>> list(evalpath(g, (None, e.p1|e.p2, e.c)))
 [(rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:c'))]
 
->>> list(evalPath(g, (None, ~e.p1, e.a))) == [ (e.c, e.a) ]
+>>> list(evalpath(g, (None, ~e.p1, e.a))) == [ (e.c, e.a) ]
 True
->>> list(evalPath(g, (None, e.p1*ZeroOrOne, e.c))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(evalpath(g, (None, e.p1*ZeroOrOne, e.c))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:c')),
  (rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:c'))]
 
->>> list(evalPath(g, (None, e.p3*OneOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(evalpath(g, (None, e.p3*OneOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:h'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:g'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a'))]
 
->>> list(evalPath(g, (None, e.p3*ZeroOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(evalpath(g, (None, e.p3*ZeroOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:h'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:g'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a'))]
 
->>> list(evalPath(g, (None, -e.p1, e.f))) == [(e.a, e.f)]
+>>> list(evalpath(g, (None, -e.p1, e.f))) == [(e.a, e.f)]
 True
->>> list(evalPath(g, (None, -(e.p1|e.p2), e.c))) == []
+>>> list(evalpath(g, (None, -(e.p1|e.p2), e.c))) == []
 True
->>> list(evalPath(g, (None, -~e.p2, e.j))) == [(e.g, e.j)]
+>>> list(evalpath(g, (None, -~e.p2, e.j))) == [(e.g, e.j)]
 True
->>> list(evalPath(g, (None, ~(e.p1/e.p2), e.a))) == [(e.e, e.a)]
+>>> list(evalpath(g, (None, ~(e.p1/e.p2), e.a))) == [(e.e, e.a)]
 True
->>> list(evalPath(g, (None, e.p1/e.p3/e.p3, e.h))) == [(e.a, e.h)]
+>>> list(evalpath(g, (None, e.p1/e.p3/e.p3, e.h))) == [(e.a, e.h)]
 True
 
->>> list(evalPath(g, (e.q, e.px*OneOrMore, None)))
+>>> list(evalpath(g, (e.q, e.px*OneOrMore, None)))
 [(rdflib.term.URIRef('ex:q'), rdflib.term.URIRef('ex:q'))]
 
->>> list(evalPath(g, (e.c, (e.p2|e.p3)*ZeroOrMore, e.j)))
+>>> list(evalpath(g, (e.c, (e.p2|e.p3)*ZeroOrMore, e.j)))
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:j'))]
 
 No vars specified:
 
->>> sorted(list(evalPath(g, (None, e.p3*OneOrMore, None)))) #doctest: +NORMALIZE_WHITESPACE
+>>> sorted(list(evalpath(g, (None, e.p3*OneOrMore, None)))) #doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:g')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:h')),
@@ -180,7 +180,7 @@ No vars specified:
 
 """
 
-
+import warnings
 from functools import total_ordering
 from typing import TYPE_CHECKING, Callable, Iterator, Optional, Tuple, Union
 
@@ -462,6 +462,17 @@ def path_sequence(self, other):
 
 
 def evalPath(graph, t):
+    warnings.warn(
+        DeprecationWarning(
+            "rdflib.path.evalPath() is deprecated, use the (all-lowercase) evalpath(). "
+            "The mixed-case evalPath() function name is incompatible with PEP8 "
+            "recommendations and will be replaced by evalpath() in rdflib 7.0.0."
+        )
+    )
+    return evalpath(graph, t)
+
+
+def evalpath(graph, t):
     return ((s, o) for s, p, o in graph.triples(t))
 
 

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -103,74 +103,74 @@ Graph generator functions, triples, subjects, objects, etc. :
 
 A more complete set of tests:
 
->>> list(evalpath(g, (None, e.p1/e.p2, None)))==[(e.a, e.e)]
+>>> list(eval_path(g, (None, e.p1/e.p2, None)))==[(e.a, e.e)]
 True
->>> list(evalpath(g, (e.a, e.p1|e.p2, None)))==[(e.a,e.c), (e.a,e.f)]
+>>> list(eval_path(g, (e.a, e.p1|e.p2, None)))==[(e.a,e.c), (e.a,e.f)]
 True
->>> list(evalpath(g, (e.c, ~e.p1, None))) == [ (e.c, e.a) ]
+>>> list(eval_path(g, (e.c, ~e.p1, None))) == [ (e.c, e.a) ]
 True
->>> list(evalpath(g, (e.a, e.p1*ZeroOrOne, None))) == [(e.a, e.a), (e.a, e.c)]
+>>> list(eval_path(g, (e.a, e.p1*ZeroOrOne, None))) == [(e.a, e.a), (e.a, e.c)]
 True
->>> list(evalpath(g, (e.c, e.p3*OneOrMore, None))) == [
+>>> list(eval_path(g, (e.c, e.p3*OneOrMore, None))) == [
 ...     (e.c, e.g), (e.c, e.h), (e.c, e.a)]
 True
->>> list(evalpath(g, (e.c, e.p3*ZeroOrMore, None))) == [(e.c, e.c),
+>>> list(eval_path(g, (e.c, e.p3*ZeroOrMore, None))) == [(e.c, e.c),
 ...     (e.c, e.g), (e.c, e.h), (e.c, e.a)]
 True
->>> list(evalpath(g, (e.a, -e.p1, None))) == [(e.a, e.f)]
+>>> list(eval_path(g, (e.a, -e.p1, None))) == [(e.a, e.f)]
 True
->>> list(evalpath(g, (e.a, -(e.p1|e.p2), None))) == []
+>>> list(eval_path(g, (e.a, -(e.p1|e.p2), None))) == []
 True
->>> list(evalpath(g, (e.g, -~e.p2, None))) == [(e.g, e.j)]
+>>> list(eval_path(g, (e.g, -~e.p2, None))) == [(e.g, e.j)]
 True
->>> list(evalpath(g, (e.e, ~(e.p1/e.p2), None))) == [(e.e, e.a)]
+>>> list(eval_path(g, (e.e, ~(e.p1/e.p2), None))) == [(e.e, e.a)]
 True
->>> list(evalpath(g, (e.a, e.p1/e.p3/e.p3, None))) == [(e.a, e.h)]
+>>> list(eval_path(g, (e.a, e.p1/e.p3/e.p3, None))) == [(e.a, e.h)]
 True
 
->>> list(evalpath(g, (e.q, e.px*OneOrMore, None)))
+>>> list(eval_path(g, (e.q, e.px*OneOrMore, None)))
 [(rdflib.term.URIRef('ex:q'), rdflib.term.URIRef('ex:q'))]
 
->>> list(evalpath(g, (None, e.p1|e.p2, e.c)))
+>>> list(eval_path(g, (None, e.p1|e.p2, e.c)))
 [(rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:c'))]
 
->>> list(evalpath(g, (None, ~e.p1, e.a))) == [ (e.c, e.a) ]
+>>> list(eval_path(g, (None, ~e.p1, e.a))) == [ (e.c, e.a) ]
 True
->>> list(evalpath(g, (None, e.p1*ZeroOrOne, e.c))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(eval_path(g, (None, e.p1*ZeroOrOne, e.c))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:c')),
  (rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:c'))]
 
->>> list(evalpath(g, (None, e.p3*OneOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(eval_path(g, (None, e.p3*OneOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:h'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:g'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a'))]
 
->>> list(evalpath(g, (None, e.p3*ZeroOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
+>>> list(eval_path(g, (None, e.p3*ZeroOrMore, e.a))) # doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:a'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:h'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:g'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a'))]
 
->>> list(evalpath(g, (None, -e.p1, e.f))) == [(e.a, e.f)]
+>>> list(eval_path(g, (None, -e.p1, e.f))) == [(e.a, e.f)]
 True
->>> list(evalpath(g, (None, -(e.p1|e.p2), e.c))) == []
+>>> list(eval_path(g, (None, -(e.p1|e.p2), e.c))) == []
 True
->>> list(evalpath(g, (None, -~e.p2, e.j))) == [(e.g, e.j)]
+>>> list(eval_path(g, (None, -~e.p2, e.j))) == [(e.g, e.j)]
 True
->>> list(evalpath(g, (None, ~(e.p1/e.p2), e.a))) == [(e.e, e.a)]
+>>> list(eval_path(g, (None, ~(e.p1/e.p2), e.a))) == [(e.e, e.a)]
 True
->>> list(evalpath(g, (None, e.p1/e.p3/e.p3, e.h))) == [(e.a, e.h)]
+>>> list(eval_path(g, (None, e.p1/e.p3/e.p3, e.h))) == [(e.a, e.h)]
 True
 
->>> list(evalpath(g, (e.q, e.px*OneOrMore, None)))
+>>> list(eval_path(g, (e.q, e.px*OneOrMore, None)))
 [(rdflib.term.URIRef('ex:q'), rdflib.term.URIRef('ex:q'))]
 
->>> list(evalpath(g, (e.c, (e.p2|e.p3)*ZeroOrMore, e.j)))
+>>> list(eval_path(g, (e.c, (e.p2|e.p3)*ZeroOrMore, e.j)))
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:j'))]
 
 No vars specified:
 
->>> sorted(list(evalpath(g, (None, e.p3*OneOrMore, None)))) #doctest: +NORMALIZE_WHITESPACE
+>>> sorted(list(eval_path(g, (None, e.p3*OneOrMore, None)))) #doctest: +NORMALIZE_WHITESPACE
 [(rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:a')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:g')),
  (rdflib.term.URIRef('ex:c'), rdflib.term.URIRef('ex:h')),
@@ -464,9 +464,9 @@ def path_sequence(self, other):
 def evalPath(graph, t):
     warnings.warn(
         DeprecationWarning(
-            "rdflib.path.evalPath() is deprecated, use the (all-lowercase) evalpath(). "
+            "rdflib.path.evalPath() is deprecated, use the (all-lowercase) eval_path(). "
             "The mixed-case evalPath() function name is incompatible with PEP8 "
-            "recommendations and will be replaced by evalpath() in rdflib 7.0.0."
+            "recommendations and will be replaced by eval_path() in rdflib 7.0.0."
         )
     )
     return eval_path(graph, t)

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -98,7 +98,7 @@ class Plugin(Generic[PluginT]):
         self.class_name = class_name
         self._class: Optional[Type[PluginT]] = None
 
-    def getClass(self) -> Type[PluginT]:
+    def getClass(self) -> Type[PluginT]:  # noqa: N802
         if self._class is None:
             module = __import__(self.module_path, globals(), locals(), [""])
             self._class = getattr(module, self.class_name)
@@ -112,7 +112,7 @@ class PKGPlugin(Plugin[PluginT]):
         self.ep = ep
         self._class: Optional[Type[PluginT]] = None
 
-    def getClass(self) -> Type[PluginT]:
+    def getClass(self) -> Type[PluginT]:  # noqa: N802
         if self._class is None:
             self._class = self.ep.load()
         return self._class

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -37,7 +37,9 @@ class Processor(object):
     def __init__(self, graph):
         pass
 
-    def query(self, str_or_query, initBindings={}, initNs={}, DEBUG=False):  # noqa: N803
+    def query(
+        self, str_or_query, initBindings={}, initNs={}, DEBUG=False
+    ):  # noqa: N803
         pass
 
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -37,7 +37,7 @@ class Processor(object):
     def __init__(self, graph):
         pass
 
-    def query(self, strOrQuery, initBindings={}, initNs={}, DEBUG=False):
+    def query(self, str_or_query, initBindings={}, initNs={}, DEBUG=False):
         pass
 
 
@@ -57,7 +57,7 @@ class UpdateProcessor(object):
     def __init__(self, graph):
         pass
 
-    def update(self, strOrQuery, initBindings={}, initNs={}):
+    def update(self, str_or_query, initBindings={}, initNs={}):
         pass
 
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -37,9 +37,7 @@ class Processor(object):
     def __init__(self, graph):
         pass
 
-    def query(
-        self, str_or_query, initBindings={}, initNs={}, DEBUG=False  # noqa: N803
-    ):
+    def query(self, strOrQuery, initBindings={}, initNs={}, DEBUG=False):  # noqa: N803
         pass
 
 
@@ -59,7 +57,7 @@ class UpdateProcessor(object):
     def __init__(self, graph):
         pass
 
-    def update(self, str_or_query, initBindings={}, initNs={}):  # noqa: N803
+    def update(self, strOrQuery, initBindings={}, initNs={}):  # noqa: N803
         pass
 
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -37,7 +37,7 @@ class Processor(object):
     def __init__(self, graph):
         pass
 
-    def query(self, str_or_query, initBindings={}, initNs={}, DEBUG=False):
+    def query(self, str_or_query, initBindings={}, initNs={}, DEBUG=False):  # noqa: N803
         pass
 
 
@@ -57,7 +57,7 @@ class UpdateProcessor(object):
     def __init__(self, graph):
         pass
 
-    def update(self, str_or_query, initBindings={}, initNs={}):
+    def update(self, str_or_query, initBindings={}, initNs={})::  # noqa: N803
         pass
 
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -38,8 +38,8 @@ class Processor(object):
         pass
 
     def query(
-        self, str_or_query, initBindings={}, initNs={}, DEBUG=False
-    ):  # noqa: N803
+        self, str_or_query, initBindings={}, initNs={}, DEBUG=False  # noqa: N803
+    ):
         pass
 
 

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -57,7 +57,7 @@ class UpdateProcessor(object):
     def __init__(self, graph):
         pass
 
-    def update(self, str_or_query, initBindings={}, initNs={})::  # noqa: N803
+    def update(self, str_or_query, initBindings={}, initNs={}):  # noqa: N803
         pass
 
 


### PR DESCRIPTION
Handful of fixes for PEP8 naming convention violations.

# Summary of changes

Changes to argument names not impacting the API, `noqa` pragmas added for convention violations that appear in the published API. Added deprecation to `paths.evalPath()`

# Checklist
- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

