### PR TITLE
Fix for Issue #948, reworked PR #1087 escaping turtle prefix names

### DIFF
--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -284,6 +284,26 @@ class TurtleSerializer(RecursiveSerializer):
 
             if pfx is not None:
                 parts = (pfx, uri, "")
+
+            # Does the uri contain chars that need to be escaped?
+            elif len(self.namespaces) > 0:
+                for prefix, local in [
+                    (_prefix, uri.split(_namespace)[1])
+                    for _prefix, _namespace in self.namespaces.items()
+                    if uri.startswith(_namespace)
+                ]:
+                    return "{prefix}:{escaped_local}".format(
+                        prefix=prefix,
+                        escaped_local="".join(
+                            [
+                                f"\\{char}" if char in "_~.-!$&'()*+,;=/?#@%" else char
+                                for char in local
+                            ]
+                        ),
+                    )
+                # Was worth a try
+                return None
+
             else:
                 # nothing worked
                 return None

--- a/test/test_serializers/test_serializer_turtle.py
+++ b/test/test_serializers/test_serializer_turtle.py
@@ -113,3 +113,24 @@ def test_turtle_namespace():
     assert "GENO:0000385" in output
     assert "SERIAL:0167-6423" in output
     assert r"EX:name_with_\(parenthesis\)" in output
+
+
+def test_issue948_escapeturtleprefixname():
+    foo = Namespace("http://www.example.com/foo/")
+    g = Graph()
+    g.bind("foo", foo)
+    g.add((foo["subj"], foo["pred"], foo["obj"]))
+    g.add((foo["subj"], foo["pred"], foo["obj/bar"]))
+    g.add((foo["subj"], foo["pred"], foo["obj#boo"]))
+    g1 = Graph()
+    g1.bind("foo", foo)
+    g1.parse(data=g.serialize(format="turtle"), format="turtle")
+    expected = r"""@prefix foo: <http://www.example.com/foo/> .
+
+foo:subj foo:pred foo:obj,
+        foo:obj\#boo,
+        foo:obj\/bar .
+
+"""
+    assert g.serialize(format="turtle") == expected
+    assert g1.serialize(format="turtle") == expected


### PR DESCRIPTION
# Summary of changes

Refined the candidate solution down to an additional on-exception fallback recovery attempt in the turtle serializer. If there's an existing namespace that starts the uri, use that to split it and escape the local part.

# Checklist

- [x] Checked that there aren't other open pull requests for the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
