### PR TITLE
feat: add type hints for `rdflib.store` and `rdflib.plugins.stores`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,23 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START PR #2057 -->
+<!-- -->
+<!-- -->
+
+- Added type hints.
+  [PR #2057](https://github.com/RDFLib/rdflib/pull/2057).
+  - `rdflib.store` and builtin stores have mostly complete type hints.
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END PR #2057 -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/devtools/diffrtpy.py
+++ b/devtools/diffrtpy.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+"""
+This is a tool that can be used with git difftool to generate a diff that
+ignores type hints and comments.
+
+The name of this script, ``diffrtpy`` is short for "diff runtime python", as
+this will only compare the parts of the python code that has a runtime impact.
+
+This is to make it easier to review PRs that contain type hints.
+
+To use this script
+
+.. code-block:: bash
+    task run -- python -m pip install --upgrade strip-hints black python-minifier
+    PYLOGGING_LEVEL=INFO task run -- git difftool -y -x $(readlink -f devtools/diffrtpy.py) upstream/master | tee /var/tmp/compact.diff
+
+Then attach ``/var/tmp/compact.diff`` to the PR.
+"""
+
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from difflib import unified_diff
+from pathlib import Path
+from typing import List
+
+import black
+import python_minifier
+from strip_hints import strip_string_to_string
+
+
+def clean_python(code: str) -> str:
+    code = strip_string_to_string(code, to_empty=True, strip_nl=True)
+    code = python_minifier.minify(
+        code,
+        remove_annotations=True,
+        remove_pass=False,
+        remove_literal_statements=True,
+        combine_imports=False,
+        hoist_literals=False,
+        rename_locals=False,
+        rename_globals=False,
+        remove_object_base=False,
+        convert_posargs_to_args=False,
+        preserve_shebang=True,
+    )
+    code = black.format_str(code, mode=black.FileMode())
+    return code
+
+
+@dataclass
+class Application:
+    parser: argparse.ArgumentParser = field(
+        default_factory=lambda: argparse.ArgumentParser(add_help=True)
+    )
+
+    def __post_init__(self) -> None:
+        parser = self.parser
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            dest="verbosity",
+            help="increase verbosity level",
+        )
+        parser.add_argument("lhs_file", nargs=1, type=str)
+        parser.add_argument("rhs_file", nargs=1, type=str)
+        parser.set_defaults(handler=self.handle)
+
+    def run(self, args: List[str]) -> None:
+        parse_result = self.parser.parse_args(args)
+
+        verbosity = parse_result.verbosity
+        if verbosity is not None:
+            root_logger = logging.getLogger("")
+            root_logger.propagate = True
+            new_level = (
+                root_logger.getEffectiveLevel()
+                - (min(1, verbosity)) * 10
+                - min(max(0, verbosity - 1), 9) * 1
+            )
+            root_logger.setLevel(new_level)
+
+        logging.debug(
+            "sys.executable = %s, args = %s, parse_result = %s, logging.level = %s",
+            sys.executable,
+            args,
+            parse_result,
+            logging.getLogger("").getEffectiveLevel(),
+        )
+
+        parse_result.handler(parse_result)
+
+    def handle(self, parse_result: argparse.Namespace) -> None:
+        logging.debug("entry ...")
+
+        base = os.environ["BASE"]
+
+        lhs_file: Path = Path(parse_result.lhs_file[0])
+        rhs_file: Path = Path(parse_result.rhs_file[0])
+
+        logging.debug(
+            "base = %s, lhs_file = %s, rhs_file = %s", base, lhs_file, rhs_file
+        )
+
+        lhs_file_content = lhs_file.read_text()
+        rhs_file_content = rhs_file.read_text()
+
+        if lhs_file.name.endswith(".py") and rhs_file.name.endswith(".py"):
+            lhs_file_content = clean_python(lhs_file_content)
+            rhs_file_content = clean_python(rhs_file_content)
+
+        lhs_file_lines = lhs_file_content.splitlines(keepends=True)
+        rhs_file_lines = rhs_file_content.splitlines(keepends=True)
+
+        sys.stdout.writelines(
+            unified_diff(lhs_file_lines, rhs_file_lines, f"a/{base}", f"b/{base}", n=5)
+        )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("PYLOGGING_LEVEL", logging.INFO),
+        stream=sys.stderr,
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        format=(
+            "%(asctime)s.%(msecs)03d %(process)d %(thread)d %(levelno)03d:%(levelname)-8s "
+            "%(name)-12s %(module)s:%(lineno)s:%(funcName)s %(message)s"
+        ),
+    )
+
+    Application().run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,12 +267,16 @@ nitpick_ignore = [
     # sphinx-autodoc-typehints has some issues with TypeVars.
     # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/39
     ("py:class", "rdflib.plugin.PluginT"),
+    # sphinx-autodoc-typehints does not like generic parmaeters in inheritance it seems
+    ("py:class", "Identifier"),
     # These are related to pyparsing.
     ("py:class", "Diagnostics"),
     ("py:class", "ParseAction"),
     ("py:class", "ParseFailAction"),
     ("py:class", "pyparsing.core.TokenConverter"),
     ("py:class", "pyparsing.results.ParseResults"),
+    # These are related to BerkeleyDB
+    ("py:class", "db.DBEnv"),
 ]
 
 if sys.version_info < (3, 9):
@@ -283,6 +287,8 @@ if sys.version_info < (3, 9):
             ("py:class", "_ObjectType"),
             ("py:class", "_PredicateType"),
             ("py:class", "_SubjectType"),
+            ("py:class", "_ContextType"),
+            ("py:class", "_ContextIdentifierType"),
             ("py:class", "TextIO"),
         ]
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ pycodestyle = [
   # mirrored from setup.cfg
   "-E501",
   "-E203",
-  "-W503"
+  "-W503",
+  "-E231",
 ]
 pyflakes = [
   "+*",
@@ -63,6 +64,7 @@ exclude = '''
 addopts = [
    "--doctest-modules",
    "--ignore=admin",
+   "--ignore=devtools",
    "--ignore=rdflib/extras/external_graph_libs.py",
    "--ignore-glob=docs/*.py",
    "--doctest-glob=docs/*.rst",

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -42,14 +42,15 @@ from rdflib.term import BNode, Genid, IdentifiedNode, Literal, Node, RDFLibGenid
 _SubjectType = Node
 _PredicateType = Node
 _ObjectType = Node
+_ContextIdentifierType = Node
 
 _TripleType = Tuple["_SubjectType", "_PredicateType", "_ObjectType"]
-_QuadType = Tuple["_SubjectType", "_PredicateType", "_ObjectType", "Graph"]
+_QuadType = Tuple["_SubjectType", "_PredicateType", "_ObjectType", "_ContextType"]
 _OptionalQuadType = Tuple[
-    "_SubjectType", "_PredicateType", "_ObjectType", Optional["Graph"]
+    "_SubjectType", "_PredicateType", "_ObjectType", Optional["_ContextType"]
 ]
 _OptionalIdentifiedQuadType = Tuple[
-    "_SubjectType", "_PredicateType", "_ObjectType", Optional["Node"]
+    "_SubjectType", "_PredicateType", "_ObjectType", Optional["_ContextIdentifierType"]
 ]
 _TriplePatternType = Tuple[
     Optional["_SubjectType"], Optional["_PredicateType"], Optional["_ObjectType"]
@@ -393,7 +394,7 @@ class Graph(Node):
         return self.__store
 
     @property
-    def identifier(self) -> Node:
+    def identifier(self) -> "_ContextIdentifierType":
         return self.__identifier
 
     @property
@@ -534,9 +535,7 @@ class Graph(Node):
             for _s, _o in p.eval(self, s, o):
                 yield _s, p, _o
         else:
-            # type error: Argument 1 to "triples" of "Store" has incompatible type "Tuple[Optional[Node], Optional[Node], Optional[Node]]"; expected "Tuple[Optional[IdentifiedNode], Optional[IdentifiedNode], Optional[Node]]"
-            # NOTE on type error: This is because the store typing is too narrow, willbe fixed in subsequent PR.
-            for (_s, _p, _o), cg in self.__store.triples((s, p, o), context=self):  # type: ignore  [arg-type]
+            for (_s, _p, _o), cg in self.__store.triples((s, p, o), context=self):
                 yield _s, _p, _o
 
     def __getitem__(self, item):
@@ -1384,7 +1383,8 @@ class Graph(Node):
                     query_object,
                     initNs,
                     initBindings,
-                    self.default_union and "__UNION__" or self.identifier,
+                    # type error: Argument 4 to "query" of "Store" has incompatible type "Union[Literal['__UNION__'], Node]"; expected "Identifier"
+                    self.default_union and "__UNION__" or self.identifier,  # type: ignore[arg-type]
                     **kwargs,
                 )
             except NotImplementedError:
@@ -1661,6 +1661,9 @@ class Graph(Node):
         return subgraph
 
 
+_ContextType = Graph
+
+
 class ConjunctiveGraph(Graph):
     """A ConjunctiveGraph is an (unnamed) aggregation of all the named
     graphs in a store.
@@ -1868,12 +1871,9 @@ class ConjunctiveGraph(Graph):
 
         s, p, o, c = self._spoc(triple_or_quad)
 
-        # type error: Argument 1 to "triples" of "Store" has incompatible type "Tuple[Optional[Node], Optional[Node], Optional[Node]]"; expected "Tuple[Optional[IdentifiedNode], Optional[IdentifiedNode], Optional[Node]]"
-        # NOTE on type error: This is because the store typing is too narrow, willbe fixed in subsequent PR.
-        for (s, p, o), cg in self.store.triples((s, p, o), context=c):  # type: ignore[arg-type]
+        for (s, p, o), cg in self.store.triples((s, p, o), context=c):
             for ctx in cg:
-                # type error: Incompatible types in "yield" (actual type "Tuple[Optional[Node], Optional[Node], Optional[Node], Any]", expected type "Tuple[Node, Node, Node, Optional[Graph]]")
-                yield s, p, o, ctx  # type: ignore[misc]
+                yield s, p, o, ctx
 
     def triples_choices(self, triple, context=None):
         """Iterate over all the triples in the entire conjunctive graph"""
@@ -1905,7 +1905,8 @@ class ConjunctiveGraph(Graph):
                 # the weirdness - see #225
                 yield context
             else:
-                yield self.get_context(context)
+                # type error: Statement is unreachable
+                yield self.get_context(context)  # type: ignore[unreachable]
 
     def get_graph(self, identifier: Union[URIRef, BNode]) -> Union[Graph, None]:
         """Returns the graph identified by given identifier"""

--- a/rdflib/plugins/stores/auditable.py
+++ b/rdflib/plugins/stores/auditable.py
@@ -16,9 +16,24 @@ system fails): A and I out of ACID.
 """
 
 import threading
+from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, Tuple
 
-from rdflib import ConjunctiveGraph, Graph
+from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.store import Store
+
+if TYPE_CHECKING:
+    from rdflib.graph import (
+        _ContextIdentifierType,
+        _ContextType,
+        _ObjectType,
+        _PredicateType,
+        _SubjectType,
+        _TriplePatternType,
+        _TripleType,
+    )
+    from rdflib.query import Result
+    from rdflib.term import URIRef
+
 
 destructiveOpLocks = {  # noqa: N816
     "add": None,
@@ -27,35 +42,46 @@ destructiveOpLocks = {  # noqa: N816
 
 
 class AuditableStore(Store):
-    def __init__(self, store):
+    def __init__(self, store: "Store"):
         self.store = store
         self.context_aware = store.context_aware
         # NOTE: this store can't be formula_aware as it doesn't have enough
         # info to reverse the removal of a quoted statement
         self.formula_aware = False  # store.formula_aware
         self.transaction_aware = True  # This is only half true
-        self.reverseOps = []
+        self.reverseOps: List[
+            Tuple[
+                Optional["_SubjectType"],
+                Optional["_PredicateType"],
+                Optional["_ObjectType"],
+                Optional["_ContextIdentifierType"],
+                str,
+            ]
+        ] = []
         self.rollbackLock = threading.RLock()
 
-    def open(self, configuration, create=True):
+    def open(self, configuration: str, create: bool = True) -> Optional[int]:
         return self.store.open(configuration, create)
 
-    def close(self, commit_pending_transaction=False):
+    def close(self, commit_pending_transaction: bool = False) -> None:
         self.store.close()
 
-    def destroy(self, configuration):
+    def destroy(self, configuration: str) -> None:
         self.store.destroy(configuration)
 
-    def query(self, *args, **kw):
+    def query(self, *args: Any, **kw: Any) -> "Result":
         return self.store.query(*args, **kw)
 
-    def add(self, triple, context, quoted=False):
+    def add(
+        self, triple: "_TripleType", context: "_ContextType", quoted: bool = False
+    ) -> None:
         (s, p, o) = triple
         lock = destructiveOpLocks["add"]
         lock = lock if lock else threading.RLock()
         with lock:
+            # type error: Argument 2 to "Graph" has incompatible type "Node"; expected "Union[IdentifiedNode, str, None]"
             context = (
-                context.__class__(self.store, context.identifier)
+                context.__class__(self.store, context.identifier)  # type: ignore[arg-type]
                 if context is not None
                 else None
             )
@@ -69,22 +95,26 @@ class AuditableStore(Store):
                 pass
             self.store.add((s, p, o), context, quoted)
 
-    def remove(self, spo, context=None):
+    def remove(
+        self, spo: "_TriplePatternType", context: Optional["_ContextType"] = None
+    ) -> None:
         subject, predicate, object_ = spo
         lock = destructiveOpLocks["remove"]
         lock = lock if lock else threading.RLock()
         with lock:
             # Need to determine which quads will be removed if any term is a
             # wildcard
+            # type error: error: Argument 2 to "Graph" has incompatible type "Node"; expected "Union[IdentifiedNode, str, None]"
             context = (
-                context.__class__(self.store, context.identifier)
+                context.__class__(self.store, context.identifier)  # type: ignore[arg-type]
                 if context is not None
                 else None
             )
             ctxId = context.identifier if context is not None else None  # noqa: N806
             if None in [subject, predicate, object_, context]:
                 if ctxId:
-                    for s, p, o in context.triples((subject, predicate, object_)):
+                    # type error: Item "None" of "Optional[Graph]" has no attribute "triples"
+                    for s, p, o in context.triples((subject, predicate, object_)):  # type: ignore[union-attr]
                         try:
                             self.reverseOps.remove((s, p, o, ctxId, "remove"))
                         except ValueError:
@@ -94,9 +124,11 @@ class AuditableStore(Store):
                         (subject, predicate, object_)
                     ):
                         try:
-                            self.reverseOps.remove((s, p, o, ctx.identifier, "remove"))
+                            # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+                            self.reverseOps.remove((s, p, o, ctx.identifier, "remove"))  # type: ignore[union-attr]
                         except ValueError:
-                            self.reverseOps.append((s, p, o, ctx.identifier, "add"))
+                            # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+                            self.reverseOps.append((s, p, o, ctx.identifier, "add"))  # type: ignore[union-attr]
             else:
                 if not list(self.triples((subject, predicate, object_), context)):
                     return  # triple not present in store, do nothing
@@ -108,55 +140,63 @@ class AuditableStore(Store):
                     self.reverseOps.append((subject, predicate, object_, ctxId, "add"))
             self.store.remove((subject, predicate, object_), context)
 
-    def triples(self, triple, context=None):
+    def triples(
+        self, triple: "_TriplePatternType", context: Optional["_ContextType"] = None
+    ) -> Iterator[Tuple["_TripleType", Iterator[Optional["_ContextType"]]]]:
         (su, pr, ob) = triple
+        # type error: Argument 2 to "Graph" has incompatible type "Node"; expected "Union[IdentifiedNode, str, None]"
         context = (
-            context.__class__(self.store, context.identifier)
+            context.__class__(self.store, context.identifier)  # type: ignore[arg-type]
             if context is not None
             else None
         )
         for (s, p, o), cg in self.store.triples((su, pr, ob), context):
             yield (s, p, o), cg
 
-    def __len__(self, context=None):
+    def __len__(self, context: Optional["_ContextType"] = None):
+        # type error: Argument 2 to "Graph" has incompatible type "Node"; expected "Union[IdentifiedNode, str, None]"
         context = (
-            context.__class__(self.store, context.identifier)
+            context.__class__(self.store, context.identifier)  # type: ignore[arg-type]
             if context is not None
             else None
         )
         return self.store.__len__(context)
 
-    def contexts(self, triple=None):
+    def contexts(
+        self, triple: Optional["_TripleType"] = None
+    ) -> Generator["_ContextType", None, None]:
         for ctx in self.store.contexts(triple):
             yield ctx
 
-    def bind(self, prefix, namespace, override=True):
+    def bind(self, prefix: str, namespace: "URIRef", override: bool = True) -> None:
         self.store.bind(prefix, namespace, override=override)
 
-    def prefix(self, namespace):
+    def prefix(self, namespace: "URIRef") -> Optional[str]:
         return self.store.prefix(namespace)
 
-    def namespace(self, prefix):
+    def namespace(self, prefix: str) -> Optional["URIRef"]:
         return self.store.namespace(prefix)
 
-    def namespaces(self):
+    def namespaces(self) -> Iterator[Tuple[str, "URIRef"]]:
         return self.store.namespaces()
 
-    def commit(self):
+    def commit(self) -> None:
         self.reverseOps = []
 
-    def rollback(self):
+    def rollback(self) -> None:
         # Acquire Rollback lock and apply reverse operations in the forward
         # order
         with self.rollbackLock:
             for subject, predicate, obj, context, op in self.reverseOps:
                 if op == "add":
+                    # type error: Argument 2 to "Graph" has incompatible type "Optional[Node]"; expected "Union[IdentifiedNode, str, None]"
                     self.store.add(
-                        (subject, predicate, obj), Graph(self.store, context)
+                        (subject, predicate, obj), Graph(self.store, context)  # type: ignore[arg-type]
                     )
                 else:
+                    # type error: Argument 2 to "Graph" has incompatible type "Optional[Node]"; expected "Union[IdentifiedNode, str, None]"
                     self.store.remove(
-                        (subject, predicate, obj), Graph(self.store, context)
+                        (subject, predicate, obj), Graph(self.store, context)  # type: ignore[arg-type]
                     )
 
             self.reverseOps = []

--- a/rdflib/plugins/stores/berkeleydb.py
+++ b/rdflib/plugins/stores/berkeleydb.py
@@ -2,13 +2,17 @@ import logging
 from os import mkdir
 from os.path import abspath, exists
 from threading import Thread
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple
 from urllib.request import pathname2url
 
 from rdflib.store import NO_STORE, VALID_STORE, Store
-from rdflib.term import URIRef
+from rdflib.term import Identifier, Node, URIRef
+
+if TYPE_CHECKING:
+    from rdflib.graph import Graph, _ContextType, _TriplePatternType, _TripleType
 
 
-def bb(u):
+def bb(u: str) -> bytes:
     return u.encode("utf-8")
 
 
@@ -34,7 +38,24 @@ if has_bsddb:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["BerkeleyDB"]
+__all__ = [
+    "BerkeleyDB",
+    "_ToKeyFunc",
+    "_FromKeyFunc",
+    "_GetPrefixFunc",
+    "_ResultsFromKeyFunc",
+]
+
+
+_ToKeyFunc = Callable[[Tuple[bytes, bytes, bytes], bytes], bytes]
+_FromKeyFunc = Callable[[bytes], Tuple[bytes, bytes, bytes, bytes]]
+_GetPrefixFunc = Callable[
+    [Tuple[str, str, str], Optional[str]], Generator[str, None, None]
+]
+_ResultsFromKeyFunc = Callable[
+    [bytes, Optional[Node], Optional[Node], Optional[Node], bytes],
+    Tuple[Tuple[Node, Node, Node], Generator[Node, None, None]],
+]
 
 
 class BerkeleyDB(Store):
@@ -63,9 +84,13 @@ class BerkeleyDB(Store):
     formula_aware = True
     transaction_aware = False
     graph_aware = True
-    db_env = None
+    db_env: "db.DBEnv" = None
 
-    def __init__(self, configuration=None, identifier=None):
+    def __init__(
+        self,
+        configuration: Optional[str] = None,
+        identifier: Optional["Identifier"] = None,
+    ):
         if not has_bsddb:
             raise ImportError("Unable to import berkeleydb, store is unusable.")
         self.__open = False
@@ -73,13 +98,16 @@ class BerkeleyDB(Store):
         super(BerkeleyDB, self).__init__(configuration)
         self._loads = self.node_pickler.loads
         self._dumps = self.node_pickler.dumps
+        self.__indicies_info: List[Tuple[Any, _ToKeyFunc, _FromKeyFunc]]
 
-    def __get_identifier(self):
+    def __get_identifier(self) -> Optional["Identifier"]:
         return self.__identifier
 
     identifier = property(__get_identifier)
 
-    def _init_db_environment(self, homeDir, create=True):  # noqa: N803
+    def _init_db_environment(
+        self, homeDir: str, create: bool = True  # noqa: N803
+    ) -> "db.DBEnv":  # noqa: N803
         if not exists(homeDir):
             if create is True:
                 mkdir(homeDir)
@@ -94,10 +122,10 @@ class BerkeleyDB(Store):
         db_env.open(homeDir, ENVFLAGS | db.DB_CREATE)
         return db_env
 
-    def is_open(self):
+    def is_open(self) -> bool:
         return self.__open
 
-    def open(self, path, create=True):
+    def open(self, path: str, create: bool = True) -> Optional[int]:
         if not has_bsddb:
             return NO_STORE
         homeDir = path  # noqa: N806
@@ -127,11 +155,14 @@ class BerkeleyDB(Store):
         dbsetflags = 0
 
         # create and open the DBs
-        self.__indicies = [
+        self.__indicies: List["db.DB"] = [
             None,
         ] * 3
+        # NOTE on type ingore: this is because type checker does not like this
+        # way of initializing, using a temporary variable will solve it.
+        # type error: error: List item 0 has incompatible type "None"; expected "Tuple[Any, Callable[[Tuple[bytes, bytes, bytes], bytes], bytes], Callable[[bytes], Tuple[bytes, bytes, bytes, bytes]]]"
         self.__indicies_info = [
-            None,
+            None,  # type: ignore[list-item]
         ] * 3
         for i in range(0, 3):
             index_name = to_key_func(i)(
@@ -144,9 +175,11 @@ class BerkeleyDB(Store):
             self.__indicies[i] = index
             self.__indicies_info[i] = (index, to_key_func(i), from_key_func(i))
 
-        lookup = {}
+        lookup: Dict[
+            int, Tuple["db.DB", _GetPrefixFunc, _FromKeyFunc, _ResultsFromKeyFunc]
+        ] = {}
         for i in range(0, 8):
-            results = []
+            results: List[Tuple[Tuple[int, int], int, int]] = []
             for start in range(0, 3):
                 score = 1
                 len = 0
@@ -160,10 +193,15 @@ class BerkeleyDB(Store):
                 results.append(((score, tie_break), start, len))
 
             results.sort()
-            score, start, len = results[-1]
+            # NOTE on type error: this is because the variable `score` is
+            # reused with different type
+            # type error: Incompatible types in assignment (expression has type "Tuple[int, int]", variable has type "int")
+            score, start, len = results[-1]  # type: ignore[assignment]
 
-            def get_prefix_func(start, end):
-                def get_prefix(triple, context):
+            def get_prefix_func(start: int, end: int) -> _GetPrefixFunc:
+                def get_prefix(
+                    triple: Tuple[str, str, str], context: Optional[str]
+                ) -> Generator[str, None, None]:
                     if context is None:
                         yield ""
                     else:
@@ -212,7 +250,7 @@ class BerkeleyDB(Store):
         self.__sync_thread = t
         return VALID_STORE
 
-    def __sync_run(self):
+    def __sync_run(self) -> None:
         from time import sleep, time
 
         try:
@@ -236,7 +274,7 @@ class BerkeleyDB(Store):
         except Exception as e:
             logger.exception(e)
 
-    def sync(self):
+    def sync(self) -> None:
         if self.__open:
             for i in self.__indicies:
                 i.sync()
@@ -246,7 +284,7 @@ class BerkeleyDB(Store):
             self.__i2k.sync()
             self.__k2i.sync()
 
-    def close(self, commit_pending_transaction=False):
+    def close(self, commit_pending_transaction: bool = False) -> None:
         self.__open = False
         self.__sync_thread.join()
         for i in self.__indicies:
@@ -258,7 +296,13 @@ class BerkeleyDB(Store):
         self.__k2i.close()
         self.db_env.close()
 
-    def add(self, triple, context, quoted=False, txn=None):
+    def add(
+        self,
+        triple: "_TripleType",
+        context: "_ContextType",
+        quoted: bool = False,
+        txn: Optional[Any] = None,
+    ) -> None:
         """\
         Add a triple to the store of triples.
         """
@@ -298,7 +342,13 @@ class BerkeleyDB(Store):
 
             self.__needs_sync = True
 
-    def __remove(self, spo, c, quoted=False, txn=None):
+    def __remove(
+        self,
+        spo: Tuple[bytes, bytes, bytes],
+        c: bytes,
+        quoted: bool = False,
+        txn: Optional[Any] = None,
+    ) -> None:
         s, p, o = spo
         cspo, cpos, cosp = self.__indicies
         contexts_value = cspo.get(
@@ -327,7 +377,13 @@ class BerkeleyDB(Store):
                     except db.DBNotFoundError:
                         pass  # TODO: is it okay to ignore these?
 
-    def remove(self, spo, context, txn=None):
+    # type error: Signature of "remove" incompatible with supertype "Store"
+    def remove(  # type: ignore[override]
+        self,
+        spo: "_TriplePatternType",
+        context: Optional["_ContextType"],
+        txn: Optional[Any] = None,
+    ) -> None:
         subject, predicate, object = spo
         assert self.__open, "The Store must be open."
         Store.remove(self, (subject, predicate, object), context)
@@ -376,7 +432,10 @@ class BerkeleyDB(Store):
                     current = None
                 cursor.close()
                 if key.startswith(prefix):
-                    c, s, p, o = from_key(key)
+                    # NOTE on type error: variables are being reused with a
+                    # different type
+                    # type error: Incompatible types in assignment (expression has type "bytes", variable has type "str")
+                    c, s, p, o = from_key(key)  # type: ignore[assignment]
                     if context is None:
                         contexts_value = index.get(key, txn=txn) or "".encode("latin-1")
                         # remove triple from all non quoted contexts
@@ -385,9 +444,15 @@ class BerkeleyDB(Store):
                         contexts.add("".encode("latin-1"))
                         for c in contexts:
                             for i, _to_key, _ in self.__indicies_info:
-                                i.delete(_to_key((s, p, o), c), txn=txn)
+                                # NOTE on type error: variables are being
+                                # reused with a different type
+                                # type error: Argument 1 has incompatible type "Tuple[str, str, str]"; expected "Tuple[bytes, bytes, bytes]"
+                                # type error: Argument 2 has incompatible type "str"; expected "bytes"
+                                i.delete(_to_key((s, p, o), c), txn=txn)  # type: ignore[arg-type]
                     else:
-                        self.__remove((s, p, o), c, txn=txn)
+                        # type error: Argument 1 to "__remove" of "BerkeleyDB" has incompatible type "Tuple[str, str, str]"; expected "Tuple[bytes, bytes, bytes]"
+                        # type error: Argument 2 to "__remove" of "BerkeleyDB" has incompatible type "str"; expected "bytes"
+                        self.__remove((s, p, o), c, txn=txn)  # type: ignore[arg-type]
                 else:
                     break
 
@@ -404,7 +469,16 @@ class BerkeleyDB(Store):
 
             self.__needs_sync = needs_sync
 
-    def triples(self, spo, context=None, txn=None):
+    def triples(
+        self,
+        spo: "_TriplePatternType",
+        context: Optional["_ContextType"] = None,
+        txn: Optional[Any] = None,
+    ) -> Generator[
+        Tuple["_TripleType", Generator[Optional["_ContextType"], None, None]],
+        None,
+        None,
+    ]:
         """A generator over all the triples matching"""
         assert self.__open, "The Store must be open."
 
@@ -437,11 +511,14 @@ class BerkeleyDB(Store):
             cursor.close()
             if key and key.startswith(prefix):
                 contexts_value = index.get(key, txn=txn)
-                yield results_from_key(key, subject, predicate, object, contexts_value)
+                # type error: Incompatible types in "yield" (actual type "Tuple[Tuple[Node, Node, Node], Generator[Node, None, None]]", expected type "Tuple[Tuple[IdentifiedNode, URIRef, Identifier], Iterator[Optional[Graph]]]")
+                # NOTE on type ignore: this is needed because some context is
+                # lost in the process of extracting triples from the database.
+                yield results_from_key(key, subject, predicate, object, contexts_value)  # type: ignore[misc]
             else:
                 break
 
-    def __len__(self, context=None):
+    def __len__(self, context: Optional["_ContextType"] = None) -> int:
         assert self.__open, "The Store must be open."
         if context is not None:
             if context == self:
@@ -467,9 +544,13 @@ class BerkeleyDB(Store):
         cursor.close()
         return count
 
-    def bind(self, prefix, namespace, override=True):
-        prefix = prefix.encode("utf-8")
-        namespace = namespace.encode("utf-8")
+    def bind(self, prefix: str, namespace: "URIRef", override: bool = True) -> None:
+        # NOTE on type error: this is because the variables are reused with
+        # another type.
+        # type error: Incompatible types in assignment (expression has type "bytes", variable has type "str")
+        prefix = prefix.encode("utf-8")  # type: ignore[assignment]
+        # type error: Incompatible types in assignment (expression has type "bytes", variable has type "URIRef")
+        namespace = namespace.encode("utf-8")  # type: ignore[assignment]
         bound_prefix = self.__prefix.get(namespace)
         bound_namespace = self.__namespace.get(prefix)
         if override:
@@ -483,21 +564,27 @@ class BerkeleyDB(Store):
             self.__prefix[bound_namespace or namespace] = bound_prefix or prefix
             self.__namespace[bound_prefix or prefix] = bound_namespace or namespace
 
-    def namespace(self, prefix):
-        prefix = prefix.encode("utf-8")
+    def namespace(self, prefix: str) -> Optional["URIRef"]:
+        # NOTE on type error: this is because the variable is reused with
+        # another type.
+        # type error: Incompatible types in assignment (expression has type "bytes", variable has type "str")
+        prefix = prefix.encode("utf-8")  # type: ignore[assignment]
         ns = self.__namespace.get(prefix, None)
         if ns is not None:
             return URIRef(ns.decode("utf-8"))
         return None
 
-    def prefix(self, namespace):
-        namespace = namespace.encode("utf-8")
+    def prefix(self, namespace: "URIRef") -> Optional[str]:
+        # NOTE on type error: this is because the variable is reused with
+        # another type.
+        # type error: Incompatible types in assignment (expression has type "bytes", variable has type "URIRef")
+        namespace = namespace.encode("utf-8")  # type: ignore[assignment]
         prefix = self.__prefix.get(namespace, None)
         if prefix is not None:
             return prefix.decode("utf-8")
         return None
 
-    def namespaces(self):
+    def namespaces(self) -> Generator[Tuple[str, "URIRef"], None, None]:
         cursor = self.__namespace.cursor()
         results = []
         current = cursor.first()
@@ -510,20 +597,31 @@ class BerkeleyDB(Store):
         for prefix, namespace in results:
             yield prefix, URIRef(namespace)
 
-    def contexts(self, triple=None):
+    def contexts(
+        self, triple: Optional["_TripleType"] = None
+    ) -> Generator["_ContextType", None, None]:
         _from_string = self._from_string
         _to_string = self._to_string
-
+        # NOTE on type errors: context is lost because of how data is loaded
+        # from the DB.
         if triple:
-            s, p, o = triple
-            s = _to_string(s)
-            p = _to_string(p)
-            o = _to_string(o)
+            s: str
+            p: str
+            o: str
+            # type error: Incompatible types in assignment (expression has type "Node", variable has type "str")
+            s, p, o = triple  # type: ignore[assignment]
+            # type error: Argument 1 has incompatible type "str"; expected "Node"
+            s = _to_string(s)  # type: ignore[arg-type]
+            # type error: Argument 1 has incompatible type "str"; expected "Node"
+            p = _to_string(p)  # type: ignore[arg-type]
+            # type error: Argument 1 has incompatible type "str"; expected "Node"
+            o = _to_string(o)  # type: ignore[arg-type]
             contexts = self.__indicies[0].get(bb("%s^%s^%s^%s^" % ("", s, p, o)))
             if contexts:
                 for c in contexts.split("^".encode("latin-1")):
                     if c:
-                        yield _from_string(c)
+                        # type error: Incompatible types in "yield" (actual type "Node", expected type "Graph")
+                        yield _from_string(c)  # type: ignore[misc]
         else:
             index = self.__contexts
             cursor = index.cursor()
@@ -532,7 +630,8 @@ class BerkeleyDB(Store):
             while current:
                 key, value = current
                 context = _from_string(key)
-                yield context
+                # type error: Incompatible types in "yield" (actual type "Node", expected type "Graph")
+                yield context  # type: ignore[misc]
                 cursor = index.cursor()
                 try:
                     cursor.set_range(key)
@@ -542,17 +641,17 @@ class BerkeleyDB(Store):
                     current = None
                 cursor.close()
 
-    def add_graph(self, graph):
+    def add_graph(self, graph: "Graph") -> None:
         self.__contexts.put(bb(self._to_string(graph)), b"")
 
-    def remove_graph(self, graph):
+    def remove_graph(self, graph: "Graph"):
         self.remove((None, None, None), graph)
 
-    def _from_string(self, i):
+    def _from_string(self, i: bytes) -> Node:
         k = self.__i2k.get(int(i))
         return self._loads(k)
 
-    def _to_string(self, term, txn=None):
+    def _to_string(self, term: Node, txn: Optional[Any] = None) -> str:
         k = self._dumps(term)
         i = self.__k2i.get(k, txn=txn)
         if i is None:
@@ -568,30 +667,42 @@ class BerkeleyDB(Store):
             i = i.decode()
         return i
 
-    def __lookup(self, spo, context, txn=None):
+    def __lookup(
+        self,
+        spo: "_TriplePatternType",
+        context: Optional["_ContextType"],
+        txn: Optional[Any] = None,
+    ) -> Tuple["db.DB", bytes, _FromKeyFunc, _ResultsFromKeyFunc]:
         subject, predicate, object = spo
         _to_string = self._to_string
+        # NOTE on type errors: this is because the same variable is used with different types.
         if context is not None:
-            context = _to_string(context, txn=txn)
+            # type error: Incompatible types in assignment (expression has type "str", variable has type "Optional[Graph]")
+            context = _to_string(context, txn=txn)  # type: ignore[assignment]
         i = 0
         if subject is not None:
             i += 1
-            subject = _to_string(subject, txn=txn)
+            # type error: Incompatible types in assignment (expression has type "str", variable has type "Node")
+            subject = _to_string(subject, txn=txn)  # type: ignore[assignment]
         if predicate is not None:
             i += 2
-            predicate = _to_string(predicate, txn=txn)
+            # type error: Incompatible types in assignment (expression has type "str", variable has type "Node")
+            predicate = _to_string(predicate, txn=txn)  # type: ignore[assignment]
         if object is not None:
             i += 4
-            object = _to_string(object, txn=txn)
+            # type error: Incompatible types in assignment (expression has type "str", variable has type "Node")
+            object = _to_string(object, txn=txn)  # type: ignore[assignment]
         index, prefix_func, from_key, results_from_key = self.__lookup_dict[i]
         # print (subject, predicate, object), context, prefix_func, index
         # #DEBUG
-        prefix = bb("^".join(prefix_func((subject, predicate, object), context)))
+        # type error: Argument 1 has incompatible type "Tuple[Node, Node, Node]"; expected "Tuple[str, str, str]"
+        # type error: Argument 2 has incompatible type "Optional[Graph]"; expected "Optional[str]"
+        prefix = bb("^".join(prefix_func((subject, predicate, object), context)))  # type: ignore[arg-type]
         return index, prefix, from_key, results_from_key
 
 
-def to_key_func(i):
-    def to_key(triple, context):
+def to_key_func(i: int) -> _ToKeyFunc:
+    def to_key(triple: Tuple[bytes, bytes, bytes], context: bytes) -> bytes:
         "Takes a string; returns key"
         return "^".encode("latin-1").join(
             (
@@ -606,8 +717,8 @@ def to_key_func(i):
     return to_key
 
 
-def from_key_func(i):
-    def from_key(key):
+def from_key_func(i: int) -> _FromKeyFunc:
+    def from_key(key: bytes) -> Tuple[bytes, bytes, bytes, bytes]:
         "Takes a key; returns string"
         parts = key.split("^".encode("latin-1"))
         return (
@@ -620,8 +731,16 @@ def from_key_func(i):
     return from_key
 
 
-def results_from_key_func(i, from_string):
-    def from_key(key, subject, predicate, object, contexts_value):
+def results_from_key_func(
+    i: int, from_string: Callable[[bytes], Node]
+) -> _ResultsFromKeyFunc:
+    def from_key(
+        key: bytes,
+        subject: Optional[Node],
+        predicate: Optional[Node],
+        object: Optional[Node],
+        contexts_value: bytes,
+    ) -> Tuple[Tuple[Node, Node, Node], Generator[Node, None, None]]:
         "Takes a key and subject, predicate, object; returns tuple for yield"
         parts = key.split("^".encode("latin-1"))
         if subject is None:
@@ -646,8 +765,10 @@ def results_from_key_func(i, from_string):
     return from_key
 
 
-def readable_index(i):
-    s, p, o = "?" * 3
+# TODO: Remove unused
+def readable_index(i: int) -> str:
+    # type error: Unpacking a string is disallowed
+    s, p, o = "?" * 3  # type: ignore[misc]
     if i & 1:
         s = "s"
     if i & 2:

--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -1,7 +1,35 @@
 #
 #
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Generator,
+    Iterator,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    overload,
+)
+
 from rdflib.store import Store
 from rdflib.util import _coalesce
+
+if TYPE_CHECKING:
+    from rdflib.graph import (
+        Graph,
+        _ContextType,
+        _ObjectType,
+        _PredicateType,
+        _SubjectType,
+        _TriplePatternType,
+        _TripleType,
+    )
+    from rdflib.plugins.sparql.sparql import Query, Update
+    from rdflib.query import Result
+    from rdflib.term import Identifier, URIRef, Variable
 
 __all__ = ["SimpleMemory", "Memory"]
 
@@ -19,23 +47,38 @@ class SimpleMemory(Store):
     Authors: Michel Pelletier, Daniel Krech, Stefan Niederhauser
     """
 
-    def __init__(self, configuration=None, identifier=None):
+    def __init__(
+        self,
+        configuration: Optional[str] = None,
+        identifier: Optional["Identifier"] = None,
+    ):
         super(SimpleMemory, self).__init__(configuration)
         self.identifier = identifier
 
         # indexed by [subject][predicate][object]
-        self.__spo = {}
+        self.__spo: Dict[
+            "_SubjectType", Dict["_PredicateType", Dict["_ObjectType", int]]
+        ] = {}
 
         # indexed by [predicate][object][subject]
-        self.__pos = {}
+        self.__pos: Dict[
+            "_PredicateType", Dict["_ObjectType", Dict["_SubjectType", int]]
+        ] = {}
 
         # indexed by [predicate][object][subject]
-        self.__osp = {}
+        self.__osp: Dict[
+            "_ObjectType", Dict["_SubjectType", Dict["_PredicateType", int]]
+        ] = {}
 
-        self.__namespace = {}
-        self.__prefix = {}
+        self.__namespace: Dict[str, "URIRef"] = {}
+        self.__prefix: Dict["URIRef", str] = {}
 
-    def add(self, triple, context, quoted=False):
+    def add(
+        self,
+        triple: "_TripleType",
+        context: "_ContextType",
+        quoted: bool = False,
+    ) -> None:
         """\
         Add a triple to the store of triples.
         """
@@ -76,13 +119,21 @@ class SimpleMemory(Store):
             p = sp[subject] = {}
         p[predicate] = 1
 
-    def remove(self, triple_pattern, context=None):
+    def remove(
+        self,
+        triple_pattern: "_TriplePatternType",
+        context: Optional["_ContextType"] = None,
+    ) -> None:
         for (subject, predicate, object), c in list(self.triples(triple_pattern)):
             del self.__spo[subject][predicate][object]
             del self.__pos[predicate][object][subject]
             del self.__osp[object][subject][predicate]
 
-    def triples(self, triple_pattern, context=None):
+    def triples(
+        self,
+        triple_pattern: "_TriplePatternType",
+        context: Optional["_ContextType"] = None,
+    ) -> Iterator[Tuple["_TripleType", Iterator[Optional["_ContextType"]]]]:
         """A generator over all the triples matching"""
         subject, predicate, object = triple_pattern
         if subject != ANY:  # subject is given
@@ -142,19 +193,20 @@ class SimpleMemory(Store):
                     for o in subjectDictionary[p].keys():
                         yield (s, p, o), self.__contexts()
 
-    def __len__(self, context=None):
+    def __len__(self, context: Optional["_ContextType"] = None) -> int:
         # @@ optimize
         i = 0
         for triple in self.triples((None, None, None)):
             i += 1
         return i
 
-    def bind(self, prefix, namespace, override=True):
+    def bind(self, prefix: str, namespace: "URIRef", override: bool = True) -> None:
         # should be identical to `Memory.bind`
         bound_namespace = self.__namespace.get(prefix)
         bound_prefix = _coalesce(
             self.__prefix.get(namespace),
-            self.__prefix.get(bound_namespace),
+            # type error: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[URIRef]"; expected "URIRef"
+            self.__prefix.get(bound_namespace),  # type: ignore[arg-type]
         )
         if override:
             if bound_prefix is not None:
@@ -164,32 +216,53 @@ class SimpleMemory(Store):
             self.__prefix[namespace] = prefix
             self.__namespace[prefix] = namespace
         else:
-            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(
+            # type error: Invalid index type "Optional[URIRef]" for "Dict[URIRef, str]"; expected type "URIRef"
+            # type error: Incompatible types in assignment (expression has type "Optional[str]", target has type "str")
+            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index, assignment]
                 bound_prefix, prefix
             )
-            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(
+            # type error: Invalid index type "Optional[str]" for "Dict[str, URIRef]"; expected type "str"
+            # type error: Incompatible types in assignment (expression has type "Optional[URIRef]", target has type "URIRef")
+            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index, assignment]
                 bound_namespace, namespace
             )
 
-    def namespace(self, prefix):
+    def namespace(self, prefix: str) -> Optional["URIRef"]:
         return self.__namespace.get(prefix, None)
 
-    def prefix(self, namespace):
+    def prefix(self, namespace: "URIRef") -> Optional[str]:
         return self.__prefix.get(namespace, None)
 
-    def namespaces(self):
+    def namespaces(self) -> Iterator[Tuple[str, "URIRef"]]:
         for prefix, namespace in self.__namespace.items():
             yield prefix, namespace
 
-    def __contexts(self):
-        return (c for c in [])  # TODO: best way to return empty generator
+    def __contexts(self) -> Generator["_ContextType", None, None]:
+        # TODO: best way to return empty generator
+        # type error: Need type annotation for "c"
+        return (c for c in [])  # type: ignore[var-annotated]
 
-    def query(self, query, initNs, initBindings, queryGraph, **kwargs):  # noqa: N803
+    # type error: Missing return statement
+    def query(  # type: ignore[return]
+        self,
+        query: Union["Query", str],
+        initNs: Dict[str, str],  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"],  # noqa: N803
+        queryGraph: "Identifier",  # noqa: N803
+        **kwargs: Any,
+    ) -> "Result":
         super(SimpleMemory, self).query(
             query, initNs, initBindings, queryGraph, **kwargs
         )
 
-    def update(self, update, initNs, initBindings, queryGraph, **kwargs):  # noqa: N803
+    def update(
+        self,
+        update: Union["Update", str],
+        initNs: Dict[str, str],  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"],  # noqa: N803
+        queryGraph: "Identifier",  # noqa: N803
+        **kwargs: Any,
+    ) -> None:
         super(SimpleMemory, self).update(
             update, initNs, initBindings, queryGraph, **kwargs
         )
@@ -207,30 +280,45 @@ class Memory(Store):
     formula_aware = True
     graph_aware = True
 
-    def __init__(self, configuration=None, identifier=None):
+    def __init__(
+        self,
+        configuration: Optional[str] = None,
+        identifier: Optional["Identifier"] = None,
+    ):
         super(Memory, self).__init__(configuration)
         self.identifier = identifier
 
         # indexed by [subject][predicate][object]
-        self.__spo = {}
+        self.__spo: Dict[
+            "_SubjectType", Dict["_PredicateType", Dict["_ObjectType", int]]
+        ] = {}
 
         # indexed by [predicate][object][subject]
-        self.__pos = {}
+        self.__pos: Dict[
+            "_PredicateType", Dict["_ObjectType", Dict["_SubjectType", int]]
+        ] = {}
 
         # indexed by [predicate][object][subject]
-        self.__osp = {}
+        self.__osp: Dict[
+            "_ObjectType", Dict["_SubjectType", Dict["_PredicateType", int]]
+        ] = {}
 
-        self.__namespace = {}
-        self.__prefix = {}
-        self.__context_obj_map = {}
-        self.__tripleContexts = {}
-        self.__contextTriples = {None: set()}
+        self.__namespace: Dict[str, "URIRef"] = {}
+        self.__prefix: Dict["URIRef", str] = {}
+        self.__context_obj_map: Dict[str, "Graph"] = {}
+        self.__tripleContexts: Dict["_TripleType", Dict[Optional[str], bool]] = {}
+        self.__contextTriples: Dict[Optional[str], Set["_TripleType"]] = {None: set()}
         # all contexts used in store (unencoded)
-        self.__all_contexts = set()
+        self.__all_contexts: Set["Graph"] = set()
         # default context information for triples
-        self.__defaultContexts = None
+        self.__defaultContexts: Optional[Dict[Optional[str], bool]] = None
 
-    def add(self, triple, context, quoted=False):
+    def add(
+        self,
+        triple: "_TripleType",
+        context: "_ContextType",
+        quoted: bool = False,
+    ) -> None:
         """\
         Add a triple to the store of triples.
         """
@@ -287,7 +375,11 @@ class Memory(Store):
             p = sp[subject] = {}
         p[predicate] = 1
 
-    def remove(self, triple_pattern, context=None):
+    def remove(
+        self,
+        triple_pattern: "_TriplePatternType",
+        context: Optional["_ContextType"] = None,
+    ) -> None:
         req_ctx = self.__ctx_to_str(context)
         for triple, c in self.triples(triple_pattern, context=context):
             subject, predicate, object_ = triple
@@ -321,7 +413,15 @@ class Memory(Store):
             # remove the whole context
             self.__all_contexts.remove(context)
 
-    def triples(self, triple_pattern, context=None):
+    def triples(
+        self,
+        triple_pattern: "_TriplePatternType",
+        context: Optional["_ContextType"] = None,
+    ) -> Generator[
+        Tuple["_TripleType", Generator[Optional["_ContextType"], None, None]],
+        None,
+        None,
+    ]:
         """A generator over all the triples matching"""
         req_ctx = self.__ctx_to_str(context)
         subject, predicate, object_ = triple_pattern
@@ -336,7 +436,10 @@ class Memory(Store):
 
         # optimize "triple in graph" case (all parts given)
         elif subject is not None and predicate is not None and object_ is not None:
-            triple = triple_pattern
+            # type error: Incompatible types in assignment (expression has type "Tuple[Optional[IdentifiedNode], Optional[IdentifiedNode], Optional[Identifier]]", variable has type "Tuple[IdentifiedNode, IdentifiedNode, Identifier]")
+            # NOTE on type error: at this point, all elements of triple_pattern
+            # is not None, so it has the same type as triple
+            triple = triple_pattern  # type: ignore[assignment]
             try:
                 _ = self.__spo[subject][predicate][object_]
                 if self.__triple_has_context(triple, req_ctx):
@@ -418,12 +521,13 @@ class Memory(Store):
                         if self.__triple_has_context(triple, req_ctx):
                             yield triple, self.__contexts(triple)
 
-    def bind(self, prefix, namespace, override=True):
+    def bind(self, prefix: str, namespace: "URIRef", override: bool = True) -> None:
         # should be identical to `SimpleMemory.bind`
         bound_namespace = self.__namespace.get(prefix)
         bound_prefix = _coalesce(
             self.__prefix.get(namespace),
-            self.__prefix.get(bound_namespace),
+            # type error: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[URIRef]"; expected "URIRef"
+            self.__prefix.get(bound_namespace),  # type: ignore[arg-type]
         )
         if override:
             if bound_prefix is not None:
@@ -433,24 +537,30 @@ class Memory(Store):
             self.__prefix[namespace] = prefix
             self.__namespace[prefix] = namespace
         else:
-            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(
+            # type error: Invalid index type "Optional[URIRef]" for "Dict[URIRef, str]"; expected type "URIRef"
+            # type error: Incompatible types in assignment (expression has type "Optional[str]", target has type "str")
+            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index, assignment]
                 bound_prefix, prefix
             )
-            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(
+            # type error: Invalid index type "Optional[str]" for "Dict[str, URIRef]"; expected type "str"
+            # type error: Incompatible types in assignment (expression has type "Optional[URIRef]", target has type "URIRef")
+            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index, assignment]
                 bound_namespace, namespace
             )
 
-    def namespace(self, prefix):
+    def namespace(self, prefix: str) -> Optional["URIRef"]:
         return self.__namespace.get(prefix, None)
 
-    def prefix(self, namespace):
+    def prefix(self, namespace: "URIRef") -> Optional[str]:
         return self.__prefix.get(namespace, None)
 
-    def namespaces(self):
+    def namespaces(self) -> Iterator[Tuple[str, "URIRef"]]:
         for prefix, namespace in self.__namespace.items():
             yield prefix, namespace
 
-    def contexts(self, triple=None):
+    def contexts(
+        self, triple: Optional["_TripleType"] = None
+    ) -> Generator["_ContextType", None, None]:
         if triple is None or triple == (None, None, None):
             return (context for context in self.__all_contexts)
 
@@ -461,19 +571,19 @@ class Memory(Store):
         except KeyError:
             return (_ for _ in [])
 
-    def __len__(self, context=None):
+    def __len__(self, context: Optional["_ContextType"] = None) -> int:
         ctx = self.__ctx_to_str(context)
         if ctx not in self.__contextTriples:
             return 0
         return len(self.__contextTriples[ctx])
 
-    def add_graph(self, graph):
+    def add_graph(self, graph: "Graph") -> None:
         if not self.graph_aware:
             Store.add_graph(self, graph)
         else:
             self.__all_contexts.add(graph)
 
-    def remove_graph(self, graph):
+    def remove_graph(self, graph: "Graph") -> None:
         if not self.graph_aware:
             Store.remove_graph(self, graph)
         else:
@@ -484,7 +594,13 @@ class Memory(Store):
                 pass  # we didn't know this graph, no problem
 
     # internal utility methods below
-    def __add_triple_context(self, triple, triple_exists, context, quoted):
+    def __add_triple_context(
+        self,
+        triple: "_TripleType",
+        triple_exists: bool,
+        context: Optional["_ContextType"],
+        quoted: bool,
+    ) -> None:
         """add the given context to the set of contexts for the triple"""
         ctx = self.__ctx_to_str(context)
         quoted = bool(quoted)
@@ -495,9 +611,10 @@ class Memory(Store):
             except KeyError:
                 # triple exists with default ctx info
                 # start with a copy of the default ctx info
+                # type error: Item "None" of "Optional[Dict[Optional[str], bool]]" has no attribute "copy"
                 triple_context = self.__tripleContexts[
                     triple
-                ] = self.__defaultContexts.copy()
+                ] = self.__defaultContexts.copy()  # type: ignore[union-attr]
 
             triple_context[ctx] = quoted
 
@@ -530,24 +647,30 @@ class Memory(Store):
         if triple_context == self.__defaultContexts:
             del self.__tripleContexts[triple]
 
-    def __get_context_for_triple(self, triple, skipQuoted=False):  # noqa: N803
+    def __get_context_for_triple(
+        self, triple: "_TripleType", skipQuoted: bool = False  # noqa: N803
+    ) -> Collection[Optional[str]]:
         """return a list of contexts (str) for the triple, skipping
         quoted contexts if skipQuoted==True"""
 
         ctxs = self.__tripleContexts.get(triple, self.__defaultContexts)
 
         if not skipQuoted:
-            return ctxs.keys()
+            # type error: Item "None" of "Optional[Dict[Optional[str], bool]]" has no attribute "keys"
+            return ctxs.keys()  # type: ignore[union-attr]
 
-        return [ctx for ctx, quoted in ctxs.items() if not quoted]
+        # type error: Item "None" of "Optional[Dict[Optional[str], bool]]" has no attribute "items"
+        return [ctx for ctx, quoted in ctxs.items() if not quoted]  # type: ignore[union-attr]
 
-    def __triple_has_context(self, triple, ctx):
+    def __triple_has_context(self, triple: "_TripleType", ctx: Optional[str]) -> bool:
         """return True if the triple exists in the given context"""
-        return ctx in self.__tripleContexts.get(triple, self.__defaultContexts)
+        # type error: Unsupported right operand type for in ("Optional[Dict[Optional[str], bool]]")
+        return ctx in self.__tripleContexts.get(triple, self.__defaultContexts)  # type: ignore[operator]
 
-    def __remove_triple_context(self, triple, ctx):
+    def __remove_triple_context(self, triple: "_TripleType", ctx):
         """remove the context from the triple"""
-        ctxs = self.__tripleContexts.get(triple, self.__defaultContexts).copy()
+        # type error: Item "None" of "Optional[Dict[Optional[str], bool]]" has no attribute "copy"
+        ctxs = self.__tripleContexts.get(triple, self.__defaultContexts).copy()  # type: ignore[union-attr]
         del ctxs[ctx]
         if ctxs == self.__defaultContexts:
             del self.__tripleContexts[triple]
@@ -555,7 +678,15 @@ class Memory(Store):
             self.__tripleContexts[triple] = ctxs
         self.__contextTriples[ctx].remove(triple)
 
-    def __ctx_to_str(self, ctx):
+    @overload
+    def __ctx_to_str(self, ctx: "_ContextType") -> str:
+        ...
+
+    @overload
+    def __ctx_to_str(self, ctx: None) -> None:
+        ...
+
+    def __ctx_to_str(self, ctx: Optional["_ContextType"]) -> Optional[str]:
         if ctx is None:
             return None
         try:
@@ -565,25 +696,46 @@ class Memory(Store):
             return ctx_str
         except AttributeError:
             # otherwise, ctx should be a URIRef or BNode or str
-            if isinstance(ctx, str):
-                ctx_str = "{}:{}".format(ctx.__class__.__name__, ctx)
+            # NOTE on type errors: This is actually never called with ctx value as str in all unit tests, so this seems like it should just not be here.
+            # type error: Subclass of "Graph" and "str" cannot exist: would have incompatible method signatures
+            if isinstance(ctx, str):  # type: ignore[unreachable]
+                # type error: Statement is unreachable
+                ctx_str = "{}:{}".format(ctx.__class__.__name__, ctx)  # type: ignore[unreachable]
                 if ctx_str in self.__context_obj_map:
                     return ctx_str
                 self.__context_obj_map[ctx_str] = ctx
                 return ctx_str
             raise RuntimeError("Cannot use that type of object as a Graph context")
 
-    def __contexts(self, triple):
+    def __contexts(
+        self, triple: "_TripleType"
+    ) -> Generator["_ContextType", None, None]:
         """return a generator for all the non-quoted contexts
         (dereferenced) the encoded triple appears in"""
+        # type error: Argument 2 to "get" of "Mapping" has incompatible type "str"; expected "Optional[Graph]"
         return (
-            self.__context_obj_map.get(ctx_str, ctx_str)
+            self.__context_obj_map.get(ctx_str, ctx_str)  # type: ignore[arg-type]
             for ctx_str in self.__get_context_for_triple(triple, skipQuoted=True)
             if ctx_str is not None
         )
 
-    def query(self, query, initNs, initBindings, queryGraph, **kwargs):  # noqa: N803
+    # type error: Missing return statement
+    def query(  # type: ignore[return]
+        self,
+        query: Union["Query", str],
+        initNs: Dict[str, str],  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"],  # noqa: N803
+        queryGraph: "Identifier",
+        **kwargs,
+    ) -> "Result":
         super(Memory, self).query(query, initNs, initBindings, queryGraph, **kwargs)
 
-    def update(self, update, initNs, initBindings, queryGraph, **kwargs):  # noqa: N803
+    def update(
+        self,
+        update: Union["Update", str],
+        initNs: Dict[str, str],  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"],  # noqa: N803
+        queryGraph: "Identifier",
+        **kwargs,
+    ) -> None:
         super(Memory, self).update(update, initNs, initBindings, queryGraph, **kwargs)

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -6,8 +6,8 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from rdflib import BNode
 from rdflib.query import Result
+from rdflib.term import BNode
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class SPARQLConnector(object):
 
         Any additional keyword arguments will be passed to to the request, and can be used to setup timesouts etc.
         """
-
+        self._method: str
         self.returnFormat = returnFormat
         self.query_endpoint = query_endpoint
         self.update_endpoint = update_endpoint
@@ -66,11 +66,11 @@ class SPARQLConnector(object):
             )
 
     @property
-    def method(self):
+    def method(self) -> str:
         return self._method
 
     @method.setter
-    def method(self, method):
+    def method(self, method: str) -> None:
         if method not in ("GET", "POST", "POST_FORM"):
             raise SPARQLConnectorException(
                 'Method must be "GET", "POST", or "POST_FORM"'
@@ -78,7 +78,12 @@ class SPARQLConnector(object):
 
         self._method = method
 
-    def query(self, query, default_graph: str = None, named_graph: str = None):
+    def query(
+        self,
+        query: str,
+        default_graph: Optional[str] = None,
+        named_graph: Optional[str] = None,
+    ) -> "Result":
         if not self.query_endpoint:
             raise SPARQLConnectorException("Query endpoint not set!")
 
@@ -121,7 +126,8 @@ class SPARQLConnector(object):
                     )
                 )
             except HTTPError as e:
-                return e.code, str(e), None
+                # type error: Incompatible return value type (got "Tuple[int, str, None]", expected "Result")
+                return e.code, str(e), None  # type: ignore[return-value]
         elif self.method == "POST_FORM":
             params["query"] = query
             args["params"].update(params)
@@ -134,7 +140,8 @@ class SPARQLConnector(object):
                     )
                 )
             except HTTPError as e:
-                return e.code, str(e), None
+                # type error: Incompatible return value type (got "Tuple[int, str, None]", expected "Result")
+                return e.code, str(e), None  # type: ignore[return-value]
         else:
             raise SPARQLConnectorException("Unknown method %s" % self.method)
         return Result.parse(
@@ -143,10 +150,10 @@ class SPARQLConnector(object):
 
     def update(
         self,
-        query,
+        query: str,
         default_graph: Optional[str] = None,
         named_graph: Optional[str] = None,
-    ):
+    ) -> None:
         if not self.update_endpoint:
             raise SPARQLConnectorException("Query endpoint not set!")
 

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -7,13 +7,40 @@ This was first done in layer-cake, and then ported to RDFLib
 """
 import collections
 import re
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
-from rdflib import BNode, Variable
-from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Graph
 from rdflib.plugins.stores.regexmatching import NATIVE_REGEX
 from rdflib.store import Store
-from rdflib.term import Node
+from rdflib.term import BNode, Identifier, Node, URIRef, Variable
+
+if TYPE_CHECKING:
+    import typing_extensions as te
+    from rdflib.graph import (
+        _TripleType,
+        _ContextType,
+        _QuadType,
+        _TriplePatternType,
+        _SubjectType,
+        _PredicateType,
+        _ObjectType,
+        _ContextIdentifierType,
+    )
+    from rdflib.plugins.sparql.sparql import Query, Update
+    from rdflib.query import Result, ResultRow
 
 from .sparqlconnector import SPARQLConnector
 
@@ -24,16 +51,17 @@ ORDERBY = "ORDER BY"
 
 BNODE_IDENT_PATTERN = re.compile(r"(?P<label>_\:[^\s]+)")
 
-NodeToSparql = Callable[..., str]
+_NodeToSparql = Callable[["Node"], str]
 
 
-def _node_to_sparql(node) -> str:
+def _node_to_sparql(node: "Node") -> str:
     if isinstance(node, BNode):
         raise Exception(
             "SPARQLStore does not support BNodes! "
             "See http://www.w3.org/TR/sparql11-query/#BGPsparqlBNodes"
         )
-    return node.n3()
+    # type error: "Node" has no attribute "n3"
+    return node.n3()  # type: ignore[attr-defined]
 
 
 class SPARQLStore(SPARQLConnector, Store):
@@ -95,10 +123,10 @@ class SPARQLStore(SPARQLConnector, Store):
 
     def __init__(
         self,
-        query_endpoint: str = None,
+        query_endpoint: Optional[str] = None,
         sparql11: bool = True,
         context_aware: bool = True,
-        node_to_sparql: NodeToSparql = _node_to_sparql,
+        node_to_sparql: _NodeToSparql = _node_to_sparql,
         returnFormat: str = "xml",  # noqa: N803
         auth: Optional[Tuple[str, str]] = None,
         **sparqlconnector_kwargs,
@@ -117,7 +145,8 @@ class SPARQLStore(SPARQLConnector, Store):
         self.graph_aware = context_aware
         self._queries = 0
 
-    def open(self, configuration: str, create=False):
+    # type error: Missing return statement
+    def open(self, configuration: str, create: bool = False) -> Optional[int]:  # type: ignore[return]
         """This method is included so that calls to this Store via Graph, e.g. Graph("SPARQLStore"),
         can set the required parameters
         """
@@ -129,46 +158,52 @@ class SPARQLStore(SPARQLConnector, Store):
             )
 
     # Database Management Methods
-    def create(self, configuration):
+    def create(self, configuration: str) -> None:
         raise TypeError(
             "The SPARQL Store is read only. Try SPARQLUpdateStore for read/write."
         )
 
-    def destroy(self, configuration):
+    def destroy(self, configuration: str) -> None:
         raise TypeError("The SPARQL store is read only")
 
     # Transactional interfaces
-    def commit(self):
+    def commit(self) -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def rollback(self):
+    def rollback(self) -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def add(self, _, context=None, quoted=False):
+    def add(
+        self, _: "_TripleType", context: "_ContextType" = None, quoted: bool = False
+    ) -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def addN(self, quads):  # noqa: N802
+    def addN(self, quads: Iterable["_QuadType"]) -> None:  # noqa: N802
         raise TypeError("The SPARQL store is read only")
 
-    def remove(self, _, context):
+    # type error: Signature of "remove" incompatible with supertype "Store"
+    def remove(  # type: ignore[override]
+        self, _: "_TriplePatternType", context: Optional["_ContextType"]
+    ) -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def update(
+    # type error: Signature of "update" incompatible with supertype "SPARQLConnector"
+    def update(  # type: ignore[override]
         self,
-        query,
-        initNs={},  # noqa: N803
-        initBindings={},
-        queryGraph=None,
-        DEBUG=False,
-    ):
+        query: Union["Update", str],
+        initNs: Dict[str, str] = {},  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"] = {},
+        queryGraph: "Identifier" = None,
+        DEBUG: bool = False,
+    ) -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def _query(self, *args, **kwargs):
+    def _query(self, *args: Any, **kwargs: Any) -> "Result":
         self._queries += 1
 
         return super(SPARQLStore, self).query(*args, **kwargs)
 
-    def _inject_prefixes(self, query, extra_bindings):
+    def _inject_prefixes(self, query: str, extra_bindings: Dict[str, str]) -> str:
         bindings = set(list(self.nsBindings.items()) + list(extra_bindings.items()))
         if not bindings:
             return query
@@ -180,14 +215,16 @@ class SPARQLStore(SPARQLConnector, Store):
             ]
         )
 
-    def query(
+    # type error: Signature of "query" incompatible with supertype "SPARQLConnector"
+    # type error: Signature of "query" incompatible with supertype "Store"
+    def query(  # type: ignore[override]
         self,
-        query,
-        initNs=None,  # noqa: N803
-        initBindings=None,
-        queryGraph=None,
-        DEBUG=False,
-    ):
+        query: Union["Query", str],
+        initNs: Optional[Dict[str, str]] = None,  # noqa: N803
+        initBindings: Optional[Dict["Variable", "Identifier"]] = None,
+        queryGraph: Optional["Identifier"] = None,
+        DEBUG: bool = False,
+    ) -> "Result":
         self.debug = DEBUG
         assert isinstance(query, str)
 
@@ -209,7 +246,10 @@ class SPARQLStore(SPARQLConnector, Store):
             query, default_graph=queryGraph if self._is_contextual(queryGraph) else None
         )
 
-    def triples(self, spo, context=None):
+    # type error: Return type "Iterator[Tuple[Tuple[Node, Node, Node], None]]" of "triples" incompatible with return type "Iterator[Tuple[Tuple[Node, Node, Node], Iterator[Optional[Graph]]]]"
+    def triples(  # type: ignore[override]
+        self, spo: "_TriplePatternType", context: Optional["_ContextType"] = None
+    ) -> Iterator[Tuple["_TripleType", None]]:
         """
         - tuple **(s, o, p)**
           the triple used as filter for the SPARQL select.
@@ -285,7 +325,8 @@ class SPARQLStore(SPARQLConnector, Store):
                 getattr(context, ORDERBY), Variable
             ):
                 var = getattr(context, ORDERBY)
-            query = query + " %s %s" % (ORDERBY, var.n3())
+            # type error: Item "None" of "Optional[Variable]" has no attribute "n3"
+            query = query + " %s %s" % (ORDERBY, var.n3())  # type: ignore[union-attr]
 
         try:
             query = query + " LIMIT %s" % int(getattr(context, LIMIT))
@@ -298,7 +339,8 @@ class SPARQLStore(SPARQLConnector, Store):
 
         result = self._query(
             query,
-            default_graph=context.identifier if self._is_contextual(context) else None,
+            # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+            default_graph=context.identifier if self._is_contextual(context) else None,  # type: ignore[union-attr]
         )
 
         if vars:
@@ -308,6 +350,10 @@ class SPARQLStore(SPARQLConnector, Store):
                         "It looks like you need to authenticate with this SPARQL Store. HTTP unauthorized"
                     )
             for row in result:
+                if TYPE_CHECKING:
+                    # This will be a ResultRow because if vars is truthish then
+                    # the query will be a SELECT query.
+                    assert isinstance(row, ResultRow)
                 yield (
                     row.get(s, s),
                     row.get(p, p),
@@ -317,7 +363,22 @@ class SPARQLStore(SPARQLConnector, Store):
             if result.askAnswer:
                 yield (s, p, o), None
 
-    def triples_choices(self, _, context=None):
+    def triples_choices(
+        self,
+        _: Tuple[
+            Union["_SubjectType", List["_SubjectType"]],
+            Union["_PredicateType", List["_PredicateType"]],
+            Union["_ObjectType", List["_ObjectType"]],
+        ],
+        context: Optional["_ContextType"] = None,
+    ) -> Generator[
+        Tuple[
+            Tuple["_SubjectType", "_PredicateType", "_ObjectType"],
+            Iterator[Optional["_ContextType"]],
+        ],
+        None,
+        None,
+    ]:
         """
         A variant of triples that can take a list of terms instead of a
         single term in any slot.  Stores can implement this to optimize
@@ -327,7 +388,7 @@ class SPARQLStore(SPARQLConnector, Store):
         """
         raise NotImplementedError("Triples choices currently not supported")
 
-    def __len__(self, context=None):
+    def __len__(self, context: Optional["_ContextType"] = None) -> int:
         if not self.sparql11:
             raise NotImplementedError(
                 "For performance reasons, this is not"
@@ -338,14 +399,17 @@ class SPARQLStore(SPARQLConnector, Store):
 
             result = self._query(
                 q,
-                default_graph=context.identifier
+                # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+                default_graph=context.identifier  # type: ignore[union-attr]
                 if self._is_contextual(context)
                 else None,
             )
-
             return int(next(iter(result)).c)
 
-    def contexts(self, triple=None):
+    # type error: Return type "Generator[Identifier, None, None]" of "contexts" incompatible with return type "Generator[Graph, None, None]" in supertype "Store"
+    def contexts(  # type: ignore[override]
+        self, triple: Optional["_TripleType"] = None
+    ) -> Generator["_ContextIdentifierType", None, None]:
         """
         Iterates over results to "SELECT ?NAME { GRAPH ?NAME { ?s ?p ?o } }"
         or "SELECT ?NAME { GRAPH ?NAME {} }" if triple is `None`.
@@ -373,34 +437,41 @@ class SPARQLStore(SPARQLConnector, Store):
             q = "SELECT ?name WHERE { GRAPH ?name {} }"
 
         result = self._query(q)
-
         return (row.name for row in result)
 
     # Namespace persistence interface implementation
-    def bind(self, prefix, namespace, override=True):
+    def bind(self, prefix: str, namespace: "URIRef", override: bool = True) -> None:
         bound_prefix = self.prefix(namespace)
         if override and bound_prefix:
             del self.nsBindings[bound_prefix]
         self.nsBindings[prefix] = namespace
 
-    def prefix(self, namespace):
+    def prefix(self, namespace: "URIRef") -> Optional["str"]:
         """ """
         return dict([(v, k) for k, v in self.nsBindings.items()]).get(namespace)
 
-    def namespace(self, prefix):
+    def namespace(self, prefix: str) -> Optional["URIRef"]:
         return self.nsBindings.get(prefix)
 
-    def namespaces(self):
+    def namespaces(self) -> Iterator[Tuple[str, "URIRef"]]:
         for prefix, ns in self.nsBindings.items():
             yield prefix, ns
 
-    def add_graph(self, graph):
+    def add_graph(self, graph: "Graph") -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def remove_graph(self, graph):
+    def remove_graph(self, graph: "Graph") -> None:
         raise TypeError("The SPARQL store is read only")
 
-    def _is_contextual(self, graph):
+    @overload
+    def _is_contextual(self, graph: None) -> "te.Literal[False]":
+        ...
+
+    @overload
+    def _is_contextual(self, graph: Optional[Union["Graph", "str"]]) -> bool:
+        ...
+
+    def _is_contextual(self, graph: Optional[Union["Graph", "str"]]) -> bool:
         """Returns `True` if the "GRAPH" keyword must appear
         in the final SPARQL query sent to the endpoint.
         """
@@ -411,32 +482,50 @@ class SPARQLStore(SPARQLConnector, Store):
         else:
             return graph.identifier != DATASET_DEFAULT_GRAPH_ID
 
-    def subjects(self, predicate=None, object=None):
+    def subjects(
+        self,
+        predicate: Optional["_PredicateType"] = None,
+        object: Optional["_ObjectType"] = None,
+    ) -> Generator["_SubjectType", None, None]:
         """A generator of subjects with the given predicate and object"""
         for t, c in self.triples((None, predicate, object)):
             yield t[0]
 
-    def predicates(self, subject=None, object=None):
+    def predicates(
+        self,
+        subject: Optional["_SubjectType"] = None,
+        object: Optional["_ObjectType"] = None,
+    ) -> Generator["_PredicateType", None, None]:
         """A generator of predicates with the given subject and object"""
         for t, c in self.triples((subject, None, object)):
             yield t[1]
 
-    def objects(self, subject=None, predicate=None):
+    def objects(
+        self,
+        subject: Optional["_SubjectType"] = None,
+        predicate: Optional["_PredicateType"] = None,
+    ) -> Generator["_ObjectType", None, None]:
         """A generator of objects with the given subject and predicate"""
         for t, c in self.triples((subject, predicate, None)):
             yield t[2]
 
-    def subject_predicates(self, object=None):
+    def subject_predicates(
+        self, object: Optional["_ObjectType"] = None
+    ) -> Generator[Tuple["_SubjectType", "_PredicateType"], None, None]:
         """A generator of (subject, predicate) tuples for the given object"""
         for t, c in self.triples((None, None, object)):
             yield t[0], t[1]
 
-    def subject_objects(self, predicate=None):
+    def subject_objects(
+        self, predicate: Optional["_PredicateType"] = None
+    ) -> Generator[Tuple["_SubjectType", "_ObjectType"], None, None]:
         """A generator of (subject, object) tuples for the given predicate"""
         for t, c in self.triples((None, predicate, None)):
             yield t[0], t[2]
 
-    def predicate_objects(self, subject=None):
+    def predicate_objects(
+        self, subject: Optional["_SubjectType"] = None
+    ) -> Generator[Tuple["_PredicateType", "_ObjectType"], None, None]:
         """A generator of (predicate, object) tuples for the given subject"""
         for t, c in self.triples((subject, None, None)):
             yield t[1], t[2]
@@ -548,10 +637,12 @@ class SPARQLUpdateStore(SPARQLStore):
         self.postAsEncoded = postAsEncoded
         self.autocommit = autocommit
         self.dirty_reads = dirty_reads
-        self._edits = None
+        self._edits: Optional[List[str]] = None
         self._updates = 0
 
-    def open(self, configuration: Union[str, Tuple[str, str]], create=False):
+    def open(
+        self, configuration: Union[str, Tuple[str, str]], create: bool = False
+    ) -> None:
         """
         This method is included so that calls to this Store via Graph, e.g.
         Graph("SPARQLStore"), can set the required parameters
@@ -567,28 +658,34 @@ class SPARQLUpdateStore(SPARQLStore):
                 "or a tuple (a query/update endpoint URI pair)"
             )
 
-    def query(self, *args, **kwargs):
+    def query(self, *args: Any, **kwargs: Any) -> "Result":
         if not self.autocommit and not self.dirty_reads:
             self.commit()
         return SPARQLStore.query(self, *args, **kwargs)
 
-    def triples(self, *args, **kwargs):
+    # type error: Signature of "triples" incompatible with supertype "Store"
+    def triples(  # type: ignore[override]
+        self, *args: Any, **kwargs: Any
+    ) -> Iterator[Tuple["_TripleType", None]]:
         if not self.autocommit and not self.dirty_reads:
             self.commit()
         return SPARQLStore.triples(self, *args, **kwargs)
 
-    def contexts(self, *args, **kwargs):
+    # type error: Signature of "contexts" incompatible with supertype "Store"
+    def contexts(  # type: ignore[override]
+        self, *args: Any, **kwargs: Any
+    ) -> Generator["_ContextIdentifierType", None, None]:
         if not self.autocommit and not self.dirty_reads:
             self.commit()
         return SPARQLStore.contexts(self, *args, **kwargs)
 
-    def __len__(self, *args, **kwargs):
+    def __len__(self, *args: Any, **kwargs: Any) -> int:
         if not self.autocommit and not self.dirty_reads:
             self.commit()
         return SPARQLStore.__len__(self, *args, **kwargs)
 
     # TODO: FIXME: open is defined twice
-    def open(self, configuration, create=False):  # type: ignore[no-redef]  # noqa: F811
+    def open(self, configuration: Union[str, Tuple[str, str]], create: bool = False) -> None:  # type: ignore[no-redef]  # noqa: F811
         """
         sets the endpoint URLs for this SPARQLStore
 
@@ -608,13 +705,13 @@ class SPARQLUpdateStore(SPARQLStore):
             self.query_endpoint = configuration
             self.update_endpoint = configuration
 
-    def _transaction(self):
+    def _transaction(self) -> List[str]:
         if self._edits is None:
             self._edits = []
         return self._edits
 
     # Transactional interfaces
-    def commit(self):
+    def commit(self) -> None:
         """add(), addN(), and remove() are transactional to reduce overhead of many small edits.
         Read and update() calls will automatically commit any outstanding edits.
         This should behave as expected most of the time, except that alternating writes
@@ -624,10 +721,15 @@ class SPARQLUpdateStore(SPARQLStore):
             self._update("\n;\n".join(self._edits))
             self._edits = None
 
-    def rollback(self):
+    def rollback(self) -> None:
         self._edits = None
 
-    def add(self, spo, context=None, quoted=False):
+    def add(
+        self,
+        spo: "_TripleType",
+        context: Optional["_ContextType"] = None,
+        quoted: bool = False,
+    ) -> None:
         """Add a triple to the store of triples."""
 
         if not self.update_endpoint:
@@ -639,6 +741,9 @@ class SPARQLUpdateStore(SPARQLStore):
         nts = self.node_to_sparql
         triple = "%s %s %s ." % (nts(subject), nts(predicate), nts(obj))
         if self._is_contextual(context):
+            if TYPE_CHECKING:
+                # _is_contextual will never return true if context is None
+                assert context is not None
             q = "INSERT DATA { GRAPH %s { %s } }" % (nts(context.identifier), triple)
         else:
             q = "INSERT DATA { %s }" % triple
@@ -646,7 +751,7 @@ class SPARQLUpdateStore(SPARQLStore):
         if self.autocommit:
             self.commit()
 
-    def addN(self, quads):  # noqa: N802
+    def addN(self, quads: Iterable["_QuadType"]) -> None:  # noqa: N802
         """Add a list of quads to the store."""
         if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
@@ -654,7 +759,7 @@ class SPARQLUpdateStore(SPARQLStore):
         contexts = collections.defaultdict(list)
         for subject, predicate, obj, context in quads:
             contexts[context].append((subject, predicate, obj))
-        data = []
+        data: List[str] = []
         nts = self.node_to_sparql
         for context in contexts:
             triples = [
@@ -669,7 +774,10 @@ class SPARQLUpdateStore(SPARQLStore):
         if self.autocommit:
             self.commit()
 
-    def remove(self, spo, context):
+    # type error: Signature of "remove" incompatible with supertype "Store"
+    def remove(  # type: ignore[override]
+        self, spo: "_TriplePatternType", context: Optional["_ContextType"]
+    ) -> None:
         """Remove a triple from the store"""
         if not self.update_endpoint:
             raise Exception("UpdateEndpoint is not set - call 'open'")
@@ -685,6 +793,9 @@ class SPARQLUpdateStore(SPARQLStore):
         nts = self.node_to_sparql
         triple = "%s %s %s ." % (nts(subject), nts(predicate), nts(obj))
         if self._is_contextual(context):
+            if TYPE_CHECKING:
+                # _is_contextual will never return true if context is None
+                assert context is not None
             cid = nts(context.identifier)
             q = "WITH %(graph)s DELETE { %(triple)s } WHERE { %(triple)s }" % {
                 "graph": cid,
@@ -696,7 +807,7 @@ class SPARQLUpdateStore(SPARQLStore):
         if self.autocommit:
             self.commit()
 
-    def setTimeout(self, timeout):  # noqa: N802
+    def setTimeout(self, timeout) -> None:  # noqa: N802
         self._timeout = int(timeout)
 
     def _update(self, update):
@@ -705,13 +816,15 @@ class SPARQLUpdateStore(SPARQLStore):
 
         SPARQLConnector.update(self, update)
 
-    def update(
+    # type error: Signature of "update" incompatible with supertype "SPARQLConnector"
+    # type error: Signature of "update" incompatible with supertype "Store"
+    def update(  # type: ignore[override]
         self,
-        query,
-        initNs={},  # noqa: N803
-        initBindings={},
-        queryGraph=None,
-        DEBUG=False,
+        query: Union["Update", str],
+        initNs: Dict[str, str] = {},  # noqa: N803
+        initBindings: Dict["Variable", "Identifier"] = {},
+        queryGraph: Optional["Identifier"] = None,
+        DEBUG: bool = False,
     ):
         """
         Perform a SPARQL Update Query against the endpoint,
@@ -753,6 +866,9 @@ class SPARQLUpdateStore(SPARQLStore):
         query = self._inject_prefixes(query, initNs)
 
         if self._is_contextual(queryGraph):
+            if TYPE_CHECKING:
+                # _is_contextual will never return true if context is None
+                assert queryGraph is not None
             query = self._insert_named_graph(query, queryGraph)
 
         if initBindings:
@@ -773,7 +889,7 @@ class SPARQLUpdateStore(SPARQLStore):
         if self.autocommit:
             self.commit()
 
-    def _insert_named_graph(self, query, query_graph):
+    def _insert_named_graph(self, query: str, query_graph: str) -> str:
         """
         Inserts GRAPH <query_graph> {} into blocks of SPARQL Update operations
 
@@ -830,13 +946,13 @@ class SPARQLUpdateStore(SPARQLStore):
 
         return "".join(modified_query)
 
-    def add_graph(self, graph):
+    def add_graph(self, graph: "Graph") -> None:
         if not self.graph_aware:
             Store.add_graph(self, graph)
         elif graph.identifier != DATASET_DEFAULT_GRAPH_ID:
             self.update("CREATE GRAPH %s" % self.node_to_sparql(graph.identifier))
 
-    def remove_graph(self, graph):
+    def remove_graph(self, graph: "Graph") -> None:
         if not self.graph_aware:
             Store.remove_graph(self, graph)
         elif graph.identifier == DATASET_DEFAULT_GRAPH_ID:
@@ -844,32 +960,50 @@ class SPARQLUpdateStore(SPARQLStore):
         else:
             self.update("DROP GRAPH %s" % self.node_to_sparql(graph.identifier))
 
-    def subjects(self, predicate=None, object=None):
+    def subjects(
+        self,
+        predicate: Optional["_PredicateType"] = None,
+        object: Optional["_ObjectType"] = None,
+    ) -> Generator["_SubjectType", None, None]:
         """A generator of subjects with the given predicate and object"""
         for t, c in self.triples((None, predicate, object)):
             yield t[0]
 
-    def predicates(self, subject=None, object=None):
+    def predicates(
+        self,
+        subject: Optional["_SubjectType"] = None,
+        object: Optional["_ObjectType"] = None,
+    ) -> Generator["_PredicateType", None, None]:
         """A generator of predicates with the given subject and object"""
         for t, c in self.triples((subject, None, object)):
             yield t[1]
 
-    def objects(self, subject=None, predicate=None):
+    def objects(
+        self,
+        subject: Optional["_SubjectType"] = None,
+        predicate: Optional["_PredicateType"] = None,
+    ) -> Generator["_ObjectType", None, None]:
         """A generator of objects with the given subject and predicate"""
         for t, c in self.triples((subject, predicate, None)):
             yield t[2]
 
-    def subject_predicates(self, object=None):
+    def subject_predicates(
+        self, object: Optional["_ObjectType"] = None
+    ) -> Generator[Tuple["_SubjectType", "_PredicateType"], None, None]:
         """A generator of (subject, predicate) tuples for the given object"""
         for t, c in self.triples((None, None, object)):
             yield t[0], t[1]
 
-    def subject_objects(self, predicate=None):
+    def subject_objects(
+        self, predicate: Optional["_PredicateType"] = None
+    ) -> Generator[Tuple["_SubjectType", "_ObjectType"], None, None]:
         """A generator of (subject, object) tuples for the given predicate"""
         for t, c in self.triples((None, predicate, None)):
             yield t[0], t[2]
 
-    def predicate_objects(self, subject=None):
+    def predicate_objects(
+        self, subject: Optional["_SubjectType"] = None
+    ) -> Generator[Tuple["_PredicateType", "_ObjectType"], None, None]:
         """A generator of (predicate, object) tuples for the given subject"""
         for t, c in self.triples((subject, None, None)):
             yield t[1], t[2]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ extend-ignore =
     # https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated
     E203, # Whitespace before ':'
     W503, # Line break occurred before a binary operator
+    # Disabled because this bumps heads with black
+    E231, # missing whitespace after ','
 
 [coverage:run]
 branch = True
@@ -48,7 +50,7 @@ exclude_lines =
     if __name__==.__main__.:
 
 [mypy]
-files = rdflib,test
+files = rdflib,test,devtools
 python_version = 3.7
 warn_unused_configs = True
 ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 deps =
     lxml: lxml
     lxml: lxml-stubs
+    extensive: berkeleydb-stubs
 setenv =
     extensive: BERKELEYDB_DIR = /usr
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage.{envname}}


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Add type hints and aliases for `rdflib.store` and
`rdflib.plugins.stores` and also add a couple of more type hints and
aliases to `rdflib.graph`.

This PR contains no runtime changes.

Other changes:
- Changed some imports to be more specific (e.g. `import from
  rdflib.graph` instead of `import from rdflib`). This is to reduce
  the probability of circular imports.
- Ignore `E231` (missing whitespace after ',') in flake8 as black is
  managing the whitespaces and seems to be bumping heads with flake8
  with spaces after `,` sometimes.
- Install `berkeleydb-stubs` when doing extensive testing with tox.
- Added `devtools/diffrtpy.py` which is a script that can be used with
  `git difftool` to generate compact diffs for python code. This should
  make it a lot easier to review PRs that change type hints to verify
  that they don't have a runtime impact.

Compact diff: https://gist.github.com/aucampia/3f380070fbd8f0e8a99aea2df6cc1f06

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

