### PR TITLE
fix: issues with string destination handling in `{Graph,Result}.serialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,28 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START #2068 -->
+<!-- -->
+<!-- -->
+
+- Improve file-URI and path handling in `Graph.serialize` and `Result.serialize` to
+  address problems with windows path handling in `Result.serialize` and to make
+  the behavior between `Graph.serialize` and `Result.serialie` more consistent.
+  Closed [issue #2067](https://github.com/RDFLib/rdflib/issues/2067).
+  [PR #2068](https://github.com/RDFLib/rdflib/pull/2068).
+  - String values for the `destination` argument will now only be treated as
+    file URIs if `urllib.parse.urlparse` returns their schema as `file`.
+  - Simplified file writing to avoid a temporary file.
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END #2068 -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/test/utils/destination.py
+++ b/test/utils/destination.py
@@ -1,0 +1,54 @@
+import enum
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePath
+from typing import IO, Callable, Generator, Optional, TextIO, Union
+
+DestParmType = Union[Path, PurePath, str, IO[bytes], TextIO]
+
+
+@dataclass(frozen=True)
+class DestRef:
+    param: DestParmType
+    path: Path
+
+
+class DestinationType(str, enum.Enum):
+    RETURN = enum.auto()
+    PATH = enum.auto()
+    PURE_PATH = enum.auto()
+    STR_PATH = enum.auto()
+    FILE_URI = enum.auto()
+    BINARY_IO = enum.auto()
+    TEXT_IO = enum.auto()
+
+    @contextmanager
+    def make_ref(
+        self,
+        tmp_path: Path,
+        encoding: Optional[str] = None,
+        path_factory: Callable[[Path, "DestinationType", Optional[str]], Path] = (
+            lambda tmp_path, type, encoding: tmp_path / f"file-{type.name}-{encoding}"
+        ),
+    ) -> Generator[Optional[DestRef], None, None]:
+        path = path_factory(tmp_path, self, encoding)
+        # path = tmp_path / f"file-{self.name}"
+        if self is DestinationType.RETURN:
+            yield None
+        elif self is DestinationType.PATH:
+            yield DestRef(path, path)
+        elif self is DestinationType.PURE_PATH:
+            yield DestRef(PurePath(path), path)
+        elif self is DestinationType.STR_PATH:
+            yield DestRef(f"{path}", path)
+        elif self is DestinationType.FILE_URI:
+            yield DestRef(path.as_uri(), path)
+        elif self is DestinationType.BINARY_IO:
+            with path.open("wb") as bfh:
+                yield DestRef(bfh, path)
+        elif self is DestinationType.TEXT_IO:
+            assert encoding is not None
+            with path.open("w", encoding=encoding) as fh:
+                yield DestRef(fh, path)
+        else:
+            raise ValueError(f"unsupported type {type!r}")

--- a/test/utils/result.py
+++ b/test/utils/result.py
@@ -145,3 +145,108 @@ def assert_bindings_sequences_equal(
         assert lhs_only == []
         assert rhs_only == []
         assert (len(common) == len(lhs)) and (len(common) == len(rhs))
+
+
+ResultFormatInfoDict = Dict["ResultFormat", "ResultFormatInfo"]
+
+
+class ResultFormatTrait(enum.Enum):
+    HAS_SERIALIZER = enum.auto()
+    HAS_PARSER = enum.auto()
+
+
+class ResultFormat(str, enum.Enum):
+    CSV = "csv"
+    TXT = "txt"
+    JSON = "json"
+    XML = "xml"
+    TSV = "tsv"
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def info_dict(cls) -> "ResultFormatInfoDict":
+        return ResultFormatInfo.make_dict(
+            ResultFormatInfo(
+                ResultFormat.CSV,
+                frozenset({ResultType.SELECT}),
+                frozenset(
+                    {
+                        ResultFormatTrait.HAS_PARSER,
+                        ResultFormatTrait.HAS_SERIALIZER,
+                    }
+                ),
+                frozenset({"utf-8", "utf-16"}),
+            ),
+            ResultFormatInfo(
+                ResultFormat.TXT,
+                frozenset({ResultType.SELECT}),
+                frozenset(
+                    {
+                        ResultFormatTrait.HAS_SERIALIZER,
+                    }
+                ),
+                frozenset({"utf-8"}),
+            ),
+            ResultFormatInfo(
+                ResultFormat.JSON,
+                frozenset({ResultType.SELECT}),
+                frozenset(
+                    {
+                        ResultFormatTrait.HAS_PARSER,
+                        ResultFormatTrait.HAS_SERIALIZER,
+                    }
+                ),
+                frozenset({"utf-8", "utf-16"}),
+            ),
+            ResultFormatInfo(
+                ResultFormat.XML,
+                frozenset({ResultType.SELECT}),
+                frozenset(
+                    {
+                        ResultFormatTrait.HAS_PARSER,
+                        ResultFormatTrait.HAS_SERIALIZER,
+                    }
+                ),
+                frozenset({"utf-8", "utf-16"}),
+            ),
+            ResultFormatInfo(
+                ResultFormat.TSV,
+                frozenset({ResultType.SELECT}),
+                frozenset(
+                    {
+                        ResultFormatTrait.HAS_PARSER,
+                    }
+                ),
+                frozenset({"utf-8", "utf-16"}),
+            ),
+        )
+
+    @property
+    def info(self) -> "ResultFormatInfo":
+        return self.info_dict()[self]
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def set(cls) -> Set["ResultFormat"]:
+        return set(cls)
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def info_set(cls) -> Set["ResultFormatInfo"]:
+        return {format.info for format in cls.set()}
+
+
+@dataclass(frozen=True)
+class ResultFormatInfo:
+    format: ResultFormat
+    supported_types: FrozenSet[ResultType]
+    traits: FrozenSet[ResultFormatTrait]
+    encodings: FrozenSet[str]
+
+    @classmethod
+    def make_dict(cls, *items: "ResultFormatInfo") -> ResultFormatInfoDict:
+        return dict((info.format, info) for info in items)
+
+    @property
+    def name(self) -> "str":
+        return f"{self.format.value}"

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ extras =
 commands =
     {env:TOX_EXTRA_COMMAND:}
     {env:TOX_MYPY_COMMAND:{envpython} -m mypy --show-error-context --show-error-codes}
-    {posargs:{envpython} -m pytest {env:TOX_PYTEST_ARGS:--cov --cov-report=}}
+    {posargs:{envpython} -m pytest -ra --tb=native {env:TOX_PYTEST_ARGS:--cov --cov-report=}}
     docs: sphinx-build -n -T -W -b html -d {envdir}/doctree docs docs/_build/html
 
 [testenv:covreport]


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Change `{Graph,Result}.serialize` to only handle string destinations as URIs if
the schema is `file` and to treat it as operating system paths in all
other cases.

This is for the following reasons:
- `Result.serialize` was treating URI paths as OS paths which only works
  for some cases, for special charachters and percentage encoding it
  does not work.
- Many valid Unix and Windows paths parse using `urlparse` and have no netloc, e.g. `C:\some\path`
  and `some:/path`, however they should be treated as paths and not as URIs.
- `Graph` and `Result` should behave consistently.

Some caveats in this change:
- non-file URIs will now be treated as OS paths which may result in
  slightly confusing error messages, such as
  `FileNotFoundError: [Errno 2] No such file or directory: 'http://example.com/'`
  if http://example.com/ is passed.
- some valid file URIs (e.g. `file:/path/to/file` from https://datatracker.ietf.org/doc/html/rfc8089)
  are also valid Posix paths but will be treated as file-URIs instead of
  Posix paths. For `Graph.serialize` this ambiguity can be avoided by
  using `pathlib.Path`, but for `Result.serialize` there is currently no
  way to avoid it, though I will work on https://github.com/RDFLib/rdflib/issues/1834
  soon and in that provide a way to avoid the ambiguity there also.

<!-- -->

- Fixes https://github.com/RDFLib/rdflib/issues/2067

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

