### PR TITLE
fix: always parse HexTuple files as utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,22 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START PR #2070 -->
+<!-- -->
+<!-- -->
+
+- Always parse HexTuple files as utf-8. 
+  [PR #2070](https://github.com/RDFLib/rdflib/pull/2070).
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END PR #2070 -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -87,7 +87,7 @@ class HextuplesParser(Parser):
 
         # handle different source types - only file and string (data) for now
         if hasattr(source, "file"):
-            with open(source.file.name) as fp:
+            with open(source.file.name, encoding="utf-8") as fp:
                 for l in fp:
                     self._parse_hextuple(cg, self._load_json_line(l))
         elif hasattr(source, "_InputSource__bytefile"):

--- a/test/test_graph/test_variants.py
+++ b/test/test_graph/test_variants.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 from test.data import TEST_DATA_DIR
@@ -191,16 +190,6 @@ EXPECTED_FAILURES = {
         raises=AssertionError,
     ),
 }
-
-if sys.platform == "win32":
-    EXPECTED_FAILURES["variants/diverse_triples"] = pytest.mark.xfail(
-        reason="""
-    Some encoding issue when parsing hext on windows:
-        >       return codecs.charmap_decode(input,self.errors,decoding_table)[0]
-        E       UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 356: character maps to <undefined>
-        """,
-        raises=UnicodeDecodeError,
-    )
 
 
 def tests_found() -> None:


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Always parse HexTuple files as utf-8 as was the intent anyway as
evidenced by the code that will raise a warning if the encoding provided
for a HexTuple file is something other than utf-8 or None.

https://github.com/RDFLib/rdflib/blob/cfa418074b27b12aac905ba266b002a237c5ff4c/rdflib/plugins/parsers/hext.py#L73-L79

Not adding any tests as this code is already tested and an XFAIL is
removed in this patch.


<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

