### PR TITLE
Fix passing ConjunctiveGraph as namespace_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and will be removed for release.
 
  - Fixes passing `NamespaceManager` in `ConjunctiveGraph`'s method `get_context()`. 
    The `get_context()` method will now pass the `NamespaceManager` of `ConjunctiveGraph` to the `namespace_manager` attribute of the newly created context graph, instead of the `ConjunctiveGraph` object itself. This cleans up an old FIXME commment.
-   [PR #2073](https://ichard26.github.io/next-pr-number/?owner=RDFLib&name=rdflib). 
+   [PR #2073](https://github.com/RDFLib/rdflib/pull/2073). 
 
 <!-- -->
 <!-- -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ CHANGE BARRIER is intended to reduce the potential for merge conflicts
 and will be removed for release.
 -->
 
+ <!-- --> 
+ <!-- --> 
+ <!-- CHANGE BARRIER: START --> 
+ <!-- --> 
+ <!-- --> 
+
+ - Fixes passing `NamespaceManager` in `ConjunctiveGraph`'s method `get_context()`. 
+   The `get_context()` method will now pass the `NamespaceManager` of `ConjunctiveGraph` to the `namespace_manager` attribute of the newly created context graph, instead of the `ConjunctiveGraph` object itself. This cleans up an old FIXME commment.
+   [PR #2073](https://ichard26.github.io/next-pr-number/?owner=RDFLib&name=rdflib). 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1918,9 +1918,8 @@ class ConjunctiveGraph(Graph):
 
         identifier must be a URIRef or BNode.
         """
-        # TODO: FIXME - why is ConjunctiveGraph passed as namespace_manager?
         return Graph(
-            store=self.store, identifier=identifier, namespace_manager=self, base=base  # type: ignore[arg-type]
+            store=self.store, identifier=identifier, namespace_manager=self.namespace_manager, base=base  # type: ignore[arg-type]
         )
 
     def remove_context(self, context):

--- a/test/test_conjunctivegraph/test_conjunctive_graph.py
+++ b/test/test_conjunctivegraph/test_conjunctive_graph.py
@@ -6,9 +6,9 @@ Tests for ConjunctiveGraph that do not depend on the underlying store
 import pytest
 
 from rdflib import ConjunctiveGraph, Graph
+from rdflib.namespace import NamespaceManager
 from rdflib.parser import StringInputSource
 from rdflib.term import BNode, Identifier, URIRef
-from rdflib.namespace import NamespaceManager
 
 DATA = """
 <http://example.org/record/1> a <http://xmlns.com/foaf/0.1/Document> .
@@ -47,15 +47,17 @@ def test_quad_contexts():
     for q in g.quads():
         assert isinstance(q[3], Graph)
 
+
 def test_context_namespaces():
     cg = ConjunctiveGraph()
     a = URIRef("urn:a")
-    ns = URIRef('http://example.org/')
+    ns = URIRef("http://example.org/")
     cg.bind("ex", ns)
     g = cg.get_context(a)
 
     assert type(g.namespace_manager) is NamespaceManager
-    assert ('ex', ns) in g.namespace_manager.namespaces()
+    assert ("ex", ns) in g.namespace_manager.namespaces()
+
 
 def get_graph_ids_tests():
     def check(kws):

--- a/test/test_conjunctivegraph/test_conjunctive_graph.py
+++ b/test/test_conjunctivegraph/test_conjunctive_graph.py
@@ -8,6 +8,7 @@ import pytest
 from rdflib import ConjunctiveGraph, Graph
 from rdflib.parser import StringInputSource
 from rdflib.term import BNode, Identifier, URIRef
+from rdflib.namespace import NamespaceManager
 
 DATA = """
 <http://example.org/record/1> a <http://xmlns.com/foaf/0.1/Document> .
@@ -46,6 +47,15 @@ def test_quad_contexts():
     for q in g.quads():
         assert isinstance(q[3], Graph)
 
+def test_context_namespaces():
+    cg = ConjunctiveGraph()
+    a = URIRef("urn:a")
+    ns = URIRef('http://example.org/')
+    cg.bind("ex", ns)
+    g = cg.get_context(a)
+
+    assert type(g.namespace_manager) is NamespaceManager
+    assert ('ex', ns) in g.namespace_manager.namespaces()
 
 def get_graph_ids_tests():
     def check(kws):


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

- passes the `NamespaceManager` of the `ConjunctiveGraph` as namespace_manager of the `Graph` created by the `get_context()` method instead of the `ConjunctiveGraph` object itself.

# Checklist


- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [x] Considered adding an example in `./examples` for new features.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

