### PR TITLE
fix: handling of Literal datatype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ RDFLib.sublime-project
 /docs/_build/
 RDFLib.sublime-workspace
 coverage/
+cov.xml
 /.hgtags
 /.hgignore
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,25 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START PR #2076 -->
+<!-- -->
+<!-- -->
+
+- Fixed handling of `Literal` `datatype` to correctly differentiate between
+  blank string values and undefined values, also changed the datatype of
+  `rdflib.term.Literal.datatype` from `Optional[str]` to `Optional[URIRef]` now
+  that all non-`URIRef` `str` values will be converted to `URIRef`.
+  [PR #2076](https://github.com/RDFLib/rdflib/pull/2076).
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END PR #2076 -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -148,7 +148,7 @@ tasks:
   mypy:
     desc: Run mypy
     cmds:
-      - "{{._PYTHON | shellQuote}} -m mypy --show-error-context --show-error-codes"
+      - "{{._PYTHON | shellQuote}} -m mypy --show-error-context --show-error-codes {{.CLI_ARGS}}"
 
   lint:fix:
     desc: Fix auto-fixable linting errors

--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -217,14 +217,12 @@ class SimpleMemory(Store):
             self.__namespace[prefix] = namespace
         else:
             # type error: Invalid index type "Optional[URIRef]" for "Dict[URIRef, str]"; expected type "URIRef"
-            # type error: Incompatible types in assignment (expression has type "Optional[str]", target has type "str")
-            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index, assignment]
-                bound_prefix, prefix
+            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index]
+                bound_prefix, default=prefix
             )
             # type error: Invalid index type "Optional[str]" for "Dict[str, URIRef]"; expected type "str"
-            # type error: Incompatible types in assignment (expression has type "Optional[URIRef]", target has type "URIRef")
-            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index, assignment]
-                bound_namespace, namespace
+            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index]
+                bound_namespace, default=namespace
             )
 
     def namespace(self, prefix: str) -> Optional["URIRef"]:
@@ -538,14 +536,13 @@ class Memory(Store):
             self.__namespace[prefix] = namespace
         else:
             # type error: Invalid index type "Optional[URIRef]" for "Dict[URIRef, str]"; expected type "URIRef"
-            # type error: Incompatible types in assignment (expression has type "Optional[str]", target has type "str")
-            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index, assignment]
-                bound_prefix, prefix
+            self.__prefix[_coalesce(bound_namespace, namespace)] = _coalesce(  # type: ignore[index]
+                bound_prefix, default=prefix
             )
             # type error: Invalid index type "Optional[str]" for "Dict[str, URIRef]"; expected type "str"
             # type error: Incompatible types in assignment (expression has type "Optional[URIRef]", target has type "URIRef")
-            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index, assignment]
-                bound_namespace, namespace
+            self.__namespace[_coalesce(bound_prefix, prefix)] = _coalesce(  # type: ignore[index]
+                bound_namespace, default=namespace
             )
 
     def namespace(self, prefix: str) -> Optional["URIRef"]:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -662,7 +662,7 @@ class Literal(Identifier):
             value = lexical_or_value
             _value, _datatype = _castPythonToLiteral(lexical_or_value, datatype)
 
-            _datatype = rdflib.util._convert_optional(URIRef, _datatype)
+            _datatype = None if _datatype is None else URIRef(_datatype)
 
             datatype = rdflib.util._coalesce(datatype, _datatype)
             if _value is not None:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -69,6 +69,7 @@ from isodate import (
 )
 
 import rdflib
+import rdflib.util
 from rdflib.compat import long_type
 
 if TYPE_CHECKING:
@@ -598,7 +599,7 @@ class Literal(Identifier):
     _value: Any
     _language: Optional[str]
     # NOTE: _datatype should maybe be of type URIRef, and not optional.
-    _datatype: Optional[str]
+    _datatype: Optional[URIRef]
     _ill_typed: Optional[bool]
     __slots__ = ("_language", "_datatype", "_value", "_ill_typed")
 
@@ -624,7 +625,7 @@ class Literal(Identifier):
         if lang is not None and not _is_valid_langtag(lang):
             raise ValueError(f"'{str(lang)}' is not a valid language tag!")
 
-        if datatype:
+        if datatype is not None:
             datatype = URIRef(datatype)
 
         value = None
@@ -633,7 +634,7 @@ class Literal(Identifier):
             # create from another Literal instance
 
             lang = lang or lexical_or_value.language
-            if datatype:
+            if datatype is not None:
                 # override datatype
                 value = _castLexicalToPython(lexical_or_value, datatype)
             else:
@@ -644,7 +645,7 @@ class Literal(Identifier):
             # passed a string
             # try parsing lexical form of datatyped literal
             value = _castLexicalToPython(lexical_or_value, datatype)
-            if datatype and datatype in _toPythonMapping:
+            if datatype is not None and datatype in _toPythonMapping:
                 # datatype is a recognized datatype IRI:
                 # https://www.w3.org/TR/rdf11-concepts/#dfn-recognized-datatype-iris
                 dt_uri: URIRef = URIRef(datatype)
@@ -661,10 +662,12 @@ class Literal(Identifier):
             value = lexical_or_value
             _value, _datatype = _castPythonToLiteral(lexical_or_value, datatype)
 
-            datatype = datatype or _datatype
+            _datatype = rdflib.util._convert_optional(URIRef, _datatype)
+
+            datatype = rdflib.util._coalesce(datatype, _datatype)
             if _value is not None:
                 lexical_or_value = _value
-            if datatype:
+            if datatype is not None:
                 lang = None
 
         if isinstance(lexical_or_value, bytes):
@@ -729,7 +732,7 @@ class Literal(Identifier):
         return self._language
 
     @property
-    def datatype(self) -> Optional[str]:
+    def datatype(self) -> Optional[URIRef]:
         return self._datatype
 
     def __reduce__(
@@ -743,7 +746,7 @@ class Literal(Identifier):
     def __getstate__(self) -> Tuple[None, Dict[str, Union[str, None]]]:
         return (None, dict(language=self.language, datatype=self.datatype))
 
-    def __setstate__(self, arg: Tuple[Any, Dict[str, str]]) -> None:
+    def __setstate__(self, arg: Tuple[Any, Dict[str, Any]]) -> None:
         _, d = arg
         self._language = d["language"]
         self._datatype = d["datatype"]
@@ -1096,8 +1099,8 @@ class Literal(Identifier):
 
             # plain-literals and xsd:string literals
             # are "the same"
-            dtself = self.datatype or _XSD_STRING
-            dtother = other.datatype or _XSD_STRING
+            dtself = rdflib.util._coalesce(self.datatype, default=_XSD_STRING)
+            dtother = rdflib.util._coalesce(other.datatype, default=_XSD_STRING)
 
             if dtself != dtother:
                 if rdflib.DAWG_LITERAL_COLLATION:
@@ -1129,9 +1132,9 @@ class Literal(Identifier):
             # same language, same lexical form, check real dt
             # plain-literals come before xsd:string!
             if self.datatype != other.datatype:
-                if not self.datatype:
+                if self.datatype is None:
                     return False
-                elif not other.datatype:
+                elif other.datatype is None:
                     return True
                 else:
                     return self.datatype > other.datatype
@@ -1186,7 +1189,7 @@ class Literal(Identifier):
         rich-compare with this literal
         """
         if isinstance(other, Literal):
-            if self.datatype and other.datatype:
+            if self.datatype is not None and other.datatype is not None:
                 # two datatyped literals
                 if (
                     self.datatype not in XSDToPython
@@ -1247,7 +1250,7 @@ class Literal(Identifier):
         # Directly accessing the member is faster than the property.
         if self._language:
             res ^= hash(self._language.lower())
-        if self._datatype:
+        if self._datatype is not None:
             res ^= hash(self._datatype)
         return res
 
@@ -1342,8 +1345,8 @@ class Literal(Identifier):
             if (self.language or "").lower() != (other.language or "").lower():
                 return False
 
-            dtself = self.datatype or _XSD_STRING
-            dtother = other.datatype or _XSD_STRING
+            dtself = rdflib.util._coalesce(self.datatype, default=_XSD_STRING)
+            dtother = rdflib.util._coalesce(other.datatype, default=_XSD_STRING)
 
             if dtself == _XSD_STRING and dtother == _XSD_STRING:
                 # string/plain literals, compare on lexical form
@@ -1556,7 +1559,7 @@ class Literal(Identifier):
 
         datatype = self.datatype
         quoted_dt = None
-        if datatype:
+        if datatype is not None:
             if qname_callback:
                 quoted_dt = qname_callback(datatype)
             if not quoted_dt:
@@ -1906,16 +1909,18 @@ _STRING_LITERAL_TYPES: Tuple[URIRef, ...] = (
     URIRef(_XSD_PFX + "token"),
 )
 
+_StrT = TypeVar("_StrT", bound=str)
+
 
 def _py2literal(
     obj: Any,
     pType: Any,  # noqa: N803
     castFunc: Optional[Callable[[Any], Any]],
-    dType: Optional[str],
-) -> Tuple[Any, Optional[str]]:
-    if castFunc:
+    dType: Optional[_StrT],
+) -> Tuple[Any, Optional[_StrT]]:
+    if castFunc is not None:
         return castFunc(obj), dType
-    elif dType:
+    elif dType is not None:
         return obj, dType
     else:
         return obj, None
@@ -2062,7 +2067,7 @@ def _reset_bindings() -> None:
 
 
 def _castLexicalToPython(  # noqa: N802
-    lexical: Union[str, bytes], datatype: Optional[str]
+    lexical: Union[str, bytes], datatype: Optional[URIRef]
 ) -> Any:
     """
     Map a lexical form to the value-space for the given datatype

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Some utility functions.
 
@@ -35,13 +37,14 @@ from typing import (
     Set,
     Tuple,
     TypeVar,
+    overload,
 )
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import rdflib.graph  # avoid circular dependency
+import rdflib.namespace
+import rdflib.term
 from rdflib.compat import sign
-from rdflib.namespace import XSD, Namespace, NamespaceManager
-from rdflib.term import BNode, Literal, Node, URIRef
 
 if TYPE_CHECKING:
     from rdflib.graph import Graph
@@ -60,6 +63,7 @@ __all__ = [
     "get_tree",
     "_coalesce",
     "_iri2uri",
+    "_convert_optional",
 ]
 
 
@@ -117,11 +121,11 @@ def to_term(s, default=None):
     if not s:
         return default
     elif s.startswith("<") and s.endswith(">"):
-        return URIRef(s[1:-1])
+        return rdflib.term.URIRef(s[1:-1])
     elif s.startswith('"') and s.endswith('"'):
-        return Literal(s[1:-1])
+        return rdflib.term.Literal(s[1:-1])
     elif s.startswith("_"):
-        return BNode(s)
+        return rdflib.term.BNode(s)
     else:
         msg = "Unrecognised term syntax: '%s'" % s
         raise Exception(msg)
@@ -131,6 +135,8 @@ def from_n3(s: str, default=None, backend=None, nsm=None):
     r'''
     Creates the Identifier corresponding to the given n3 string.
 
+        >>> from rdflib.term import URIRef, Literal
+        >>> from rdflib.namespace import NamespaceManager
         >>> from_n3('<http://ex.com/foo>') == URIRef('http://ex.com/foo')
         True
         >>> from_n3('"foo"@de') == Literal('foo', lang='de')
@@ -159,7 +165,9 @@ def from_n3(s: str, default=None, backend=None, nsm=None):
     if s.startswith("<"):
         # Hack: this should correctly handle strings with either native unicode
         # characters, or \u1234 unicode escapes.
-        return URIRef(s[1:-1].encode("raw-unicode-escape").decode("unicode-escape"))
+        return rdflib.term.URIRef(
+            s[1:-1].encode("raw-unicode-escape").decode("unicode-escape")
+        )
     elif s.startswith('"'):
         if s.startswith('"""'):
             quotes = '"""'
@@ -189,9 +197,9 @@ def from_n3(s: str, default=None, backend=None, nsm=None):
         # Hack: this should correctly handle strings with either native unicode
         # characters, or \u1234 unicode escapes.
         value = value.encode("raw-unicode-escape").decode("unicode-escape")
-        return Literal(value, language, datatype)
+        return rdflib.term.Literal(value, language, datatype)
     elif s == "true" or s == "false":
-        return Literal(s == "true")
+        return rdflib.term.Literal(s == "true")
     elif (
         s.lower()
         .replace(".", "", 1)
@@ -200,10 +208,10 @@ def from_n3(s: str, default=None, backend=None, nsm=None):
         .isnumeric()
     ):
         if "e" in s.lower():
-            return Literal(s, datatype=XSD.double)
+            return rdflib.term.Literal(s, datatype=rdflib.namespace.XSD.double)
         if "." in s:
-            return Literal(float(s), datatype=XSD.decimal)
-        return Literal(int(s), datatype=XSD.integer)
+            return rdflib.term.Literal(float(s), datatype=rdflib.namespace.XSD.decimal)
+        return rdflib.term.Literal(int(s), datatype=rdflib.namespace.XSD.integer)
 
     elif s.startswith("{"):
         identifier = from_n3(s[1:-1])
@@ -212,16 +220,16 @@ def from_n3(s: str, default=None, backend=None, nsm=None):
         identifier = from_n3(s[1:-1])
         return rdflib.graph.Graph(backend, identifier)
     elif s.startswith("_:"):
-        return BNode(s[2:])
+        return rdflib.term.BNode(s[2:])
     elif ":" in s:
         if nsm is None:
             # instantiate default NamespaceManager and rely on its defaults
-            nsm = NamespaceManager(rdflib.graph.Graph())
+            nsm = rdflib.namespace.NamespaceManager(rdflib.graph.Graph())
         prefix, last_part = s.split(":", 1)
         ns = dict(nsm.namespaces())[prefix]
-        return Namespace(ns)[last_part]
+        return rdflib.namespace.Namespace(ns)[last_part]
     else:
-        return BNode(s)
+        return rdflib.term.BNode(s)
 
 
 def date_time(t=None, local_time_zone=False):
@@ -382,8 +390,10 @@ def _get_ext(fpath, lower=True):
 
 
 def find_roots(
-    graph: "Graph", prop: "URIRef", roots: Optional[Set["Node"]] = None
-) -> Set["Node"]:
+    graph: "Graph",
+    prop: "rdflib.term.URIRef",
+    roots: Optional[Set["rdflib.term.Node"]] = None,
+) -> Set["rdflib.term.Node"]:
     """
     Find the roots in some sort of transitive hierarchy.
 
@@ -395,7 +405,7 @@ def find_roots(
 
     """
 
-    non_roots: Set[Node] = set()
+    non_roots: Set[rdflib.term.Node] = set()
     if roots is None:
         roots = set()
     for x, y in graph.subject_objects(prop):
@@ -409,13 +419,13 @@ def find_roots(
 
 def get_tree(
     graph: "Graph",
-    root: "Node",
-    prop: "URIRef",
-    mapper: Callable[["Node"], "Node"] = lambda x: x,
+    root: "rdflib.term.Node",
+    prop: "rdflib.term.URIRef",
+    mapper: Callable[["rdflib.term.Node"], "rdflib.term.Node"] = lambda x: x,
     sortkey: Optional[Callable[[Any], Any]] = None,
-    done: Optional[Set["Node"]] = None,
+    done: Optional[Set["rdflib.term.Node"]] = None,
     dir: str = "down",
-) -> Optional[Tuple[Node, List[Any]]]:
+) -> Optional[Tuple["rdflib.term.Node", List[Any]]]:
     """
     Return a nested list/tuple structure representing the tree
     built by the transitive property given, starting from the root given
@@ -442,7 +452,7 @@ def get_tree(
     done.add(root)
     tree = []
 
-    branches: Iterator[Node]
+    branches: Iterator[rdflib.term.Node]
     if dir == "down":
         branches = graph.subjects(prop, root)
     else:
@@ -456,27 +466,68 @@ def get_tree(
     return (mapper(root), sorted(tree, key=sortkey))
 
 
+_InputT = TypeVar("_InputT")
+_OutputT = TypeVar("_OutputT")
+
+
+def _convert_optional(
+    converter: Callable[[_InputT], _OutputT],
+    input: Optional[_InputT],
+) -> Optional[_OutputT]:
+    """
+    Convert ``input`` to ``output`` using ``converter`` if ``input`` is not
+    `None`, otherwise return `None`.
+
+    :param converter: The callable to use to conver a non-None input value to an
+        output value.
+    :param input: The value to pass to the provided ``converter`` if it is not
+        None.
+    :return: The value of ``converter(input)`` if ``input`` is not `None`, else
+        `None`.
+    """
+    if input is None:
+        return None
+    return converter(input)
+
+
 _AnyT = TypeVar("_AnyT")
 
 
-def _coalesce(*args: Optional[_AnyT]) -> Optional[_AnyT]:
+@overload
+def _coalesce(*args: Optional[_AnyT], default: _AnyT) -> _AnyT:
+    ...
+
+
+@overload
+def _coalesce(
+    *args: Optional[_AnyT], default: Optional[_AnyT] = ...
+) -> Optional[_AnyT]:
+    ...
+
+
+def _coalesce(
+    *args: Optional[_AnyT], default: Optional[_AnyT] = None
+) -> Optional[_AnyT]:
     """
     This is a null coalescing function, it will return the first non-`None`
-    argument passed to it, otherwise it will return `None`.
+    argument passed to it, otherwise it will return ``default`` which is `None`
+    by default.
 
-    For more info regarding the rationale of this function see deferred `PEP
-    505 <https://peps.python.org/pep-0505/>`_.
+    For more info regarding the rationale of this function see deferred `PEP 505
+    <https://peps.python.org/pep-0505/>`_.
 
     :param args: Values to consider as candidates to return, the first arg that
         is not `None` will be returned. If no argument is passed this function
         will return None.
-    :return: The first ``arg`` that is not `None`, otherwise `None` if there
-        are no args or if all args are `None`.
+    :param default: The default value to return if none of the args are not
+        `None`.
+    :return: The first ``args`` that is not `None`, otherwise the value of
+        ``default`` if there are no ``args`` or if all ``args`` are `None`.
     """
     for arg in args:
         if arg is not None:
             return arg
-    return None
+    return default
 
 
 def _iri2uri(iri: str) -> str:

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -63,7 +63,6 @@ __all__ = [
     "get_tree",
     "_coalesce",
     "_iri2uri",
-    "_convert_optional",
 ]
 
 
@@ -464,30 +463,6 @@ def get_tree(
             tree.append(t)
 
     return (mapper(root), sorted(tree, key=sortkey))
-
-
-_InputT = TypeVar("_InputT")
-_OutputT = TypeVar("_OutputT")
-
-
-def _convert_optional(
-    converter: Callable[[_InputT], _OutputT],
-    input: Optional[_InputT],
-) -> Optional[_OutputT]:
-    """
-    Convert ``input`` to ``output`` using ``converter`` if ``input`` is not
-    `None`, otherwise return `None`.
-
-    :param converter: The callable to use to conver a non-None input value to an
-        output value.
-    :param input: The value to pass to the provided ``converter`` if it is not
-        None.
-    :return: The value of ``converter(input)`` if ``input`` is not `None`, else
-        `None`.
-    """
-    if input is None:
-        return None
-    return converter(input)
 
 
 _AnyT = TypeVar("_AnyT")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from test.data import TEST_DATA_DIR
 from test.utils.graph import cached_graph
 from test.utils.namespace import RDFT
-from typing import Any, Callable, Collection, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Collection, List, Optional, Set, Tuple, Type, Union
 
 import pytest
 
@@ -15,7 +15,7 @@ from rdflib import XSD, util
 from rdflib.graph import ConjunctiveGraph, Graph, QuotedGraph
 from rdflib.namespace import RDF, RDFS
 from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef
-from rdflib.util import _coalesce, _convert_optional, _iri2uri, find_roots, get_tree
+from rdflib.util import _coalesce, _iri2uri, find_roots, get_tree
 
 n3source = """\
 @prefix : <http://www.w3.org/2000/10/swap/Primer#>.
@@ -386,37 +386,6 @@ def test__coalesce_typing() -> None:
 
     str_value = _coalesce(None, "a", None, default="3")
     assert str_value == "a"
-
-
-@pytest.mark.parametrize(
-    ["converter", "input", "expected_result"],
-    [
-        (str, None, None),
-        (str, "5", "5"),
-        (str, 5, "5"),
-    ],
-)
-def test__convert_optional(
-    converter: Callable[[Any], Any], input: Any, expected_result: Any
-) -> None:
-    result = _convert_optional(converter, input)
-    assert expected_result == result
-
-
-def test__convert_optional_typing() -> None:
-    """
-    type checking for _convert_optional behaves as expected.
-    """
-    optional_str_value: Optional[str]
-
-    optional_str_value = _convert_optional(str, 1)
-    assert optional_str_value == "1"
-
-    optional_str_value = _convert_optional(str, "1")
-    assert optional_str_value == "1"
-
-    optional_str_value = _convert_optional(str, None)
-    assert optional_str_value is None
 
 
 @pytest.mark.parametrize(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from test.data import TEST_DATA_DIR
 from test.utils.graph import cached_graph
 from test.utils.namespace import RDFT
-from typing import Any, Collection, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Collection, List, Optional, Set, Tuple, Type, Union
 
 import pytest
 
@@ -15,7 +15,7 @@ from rdflib import XSD, util
 from rdflib.graph import ConjunctiveGraph, Graph, QuotedGraph
 from rdflib.namespace import RDF, RDFS
 from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef
-from rdflib.util import _coalesce, _iri2uri, find_roots, get_tree
+from rdflib.util import _coalesce, _convert_optional, _iri2uri, find_roots, get_tree
 
 n3source = """\
 @prefix : <http://www.w3.org/2000/10/swap/Primer#>.
@@ -347,19 +347,76 @@ class TestUtilTermConvert:
 
 
 @pytest.mark.parametrize(
-    ["params", "expected_result"],
+    ["params", "default", "expected_result"],
     [
-        ([], None),
-        (["something"], "something"),
-        ([False, "something"], False),
-        (["", "something"], ""),
-        ([0, "something"], 0),
-        ([None, "something", 1], "something"),
-        (["something", None, 1], "something"),
+        ([], ..., None),
+        (["something"], ..., "something"),
+        ([False, "something"], ..., False),
+        (["", "something"], ..., ""),
+        ([0, "something"], ..., 0),
+        ([None, "something", 1], ..., "something"),
+        (["something", None, 1], ..., "something"),
+        (["something", None, 1], 5, "something"),
+        ([], 5, 5),
+        ([None], 5, 5),
+        ([None, None], 5, 5),
+        ([None, None], 5, 5),
     ],
 )
-def test__coalesce(params: Collection[Any], expected_result: Any) -> None:
-    assert expected_result == _coalesce(*params)
+def test__coalesce(params: Collection[Any], default: Any, expected_result: Any) -> None:
+    if default == Ellipsis:
+        result = _coalesce(*params)
+    else:
+        result = _coalesce(*params, default)
+    assert expected_result == result
+
+
+def test__coalesce_typing() -> None:
+    """
+    type checking for _coalesce behaves as expected.
+    """
+    str_value: str
+    optional_str_value: Optional[str]
+
+    optional_str_value = _coalesce(None, "a", None)
+    assert optional_str_value == "a"
+
+    str_value = _coalesce(None, "a", None)  # type: ignore[assignment]
+    assert str_value == "a"
+
+    str_value = _coalesce(None, "a", None, default="3")
+    assert str_value == "a"
+
+
+@pytest.mark.parametrize(
+    ["converter", "input", "expected_result"],
+    [
+        (str, None, None),
+        (str, "5", "5"),
+        (str, 5, "5"),
+    ],
+)
+def test__convert_optional(
+    converter: Callable[[Any], Any], input: Any, expected_result: Any
+) -> None:
+    result = _convert_optional(converter, input)
+    assert expected_result == result
+
+
+def test__convert_optional_typing() -> None:
+    """
+    type checking for _convert_optional behaves as expected.
+    """
+    optional_str_value: Optional[str]
+
+    optional_str_value = _convert_optional(str, 1)
+    assert optional_str_value == "1"
+
+    optional_str_value = _convert_optional(str, "1")
+    assert optional_str_value == "1"
+
+    optional_str_value = _convert_optional(str, None)
+    assert optional_str_value is None
 
 
 @pytest.mark.parametrize(

--- a/test/utils/literal.py
+++ b/test/utils/literal.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import builtins
+from dataclasses import dataclass
+from typing import Any, Union
+
+from rdflib.term import Literal, URIRef
+
+
+@dataclass
+class LiteralChecker:
+    value: Union[builtins.ellipsis, Any] = ...
+    language: Union[builtins.ellipsis, str, None] = ...
+    datatype: Union[builtins.ellipsis, URIRef, None] = ...
+    ill_typed: Union[builtins.ellipsis, bool, None] = ...
+    lexical: Union[builtins.ellipsis, str] = ...
+
+    def check(self, actual: Literal) -> None:
+        if self.value is not Ellipsis:
+            assert self.value == actual.value
+        if self.lexical is not Ellipsis:
+            assert self.lexical == f"{actual}"
+        if self.ill_typed is not Ellipsis:
+            assert self.ill_typed == actual.ill_typed
+        if self.language is not Ellipsis:
+            assert self.language == actual.language
+        if self.datatype is not Ellipsis:
+            assert self.datatype == actual.datatype


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Check datatype against `None` instead of checking it's truthiness (i.e.
`if datatype is not None:` instead of `if datatype:`).

Checking truthiness instead of `is not None` causes a blank string to
be treated the same as None. The consequence of this was that
`Literal.datatype` could be a `str`, a `URIRef` or `None`, instead of
just a `URIRef` or `None` as was seemingly intended.

Other changes:
- Changed the type of `Literal.datatype` to be `Optional[URIRef]`
  instead of `Optional[str]` now that `str` will always be converted to
  `URIRef` even if it is a blank string.
- Changed `rdflib.util._coalesce` to make it easier and safer to use
  with a non-`None` default value.
- Added `rdflib.util._convert_optional` that makes it easy to convert
  optional values while retaining their optional nature.
- Changed `rdflib.util` to avoid issues with circular imports.


<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

