### PR TITLE
fix: issue with trig reference counting across graphs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,8 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
+indent_size = 4
+indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,27 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START PR #2085 -->
+<!-- -->
+<!-- -->
+
+- Fixed serialization of BNodes in TriG.
+  The TriG serializer was only considering BNode references inside a single
+  graph and not counting the BNodes subjects as references when considering if a
+  BNode should be serialized as unlabeled blank nodes (i.e. `[ ]`), and as a
+  result it was serializing BNodes as unlabeled if they were in fact referencing
+  BNodes in other graphs.
+  [PR #2085](https://github.com/RDFLib/rdflib/pull/2085).
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END PR #2085 -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -282,6 +282,11 @@ tasks:
       - task: install:flake8
       - task: flake8
 
+  cmd:rdfpipe:
+    desc: Run rdfpipe
+    cmds:
+      - cmd: "{{._PYTHON | shellQuote}} -m rdflib.tools.rdfpipe {{.CLI_ARGS}}"
+
   _rimraf:
     # This task is a utility task for recursively removing directories, it is
     # similar to rm -rf but not identical and it should work wherever there is

--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -3,7 +3,6 @@ Trig RDF graph serializer for RDFLib.
 See <http://www.w3.org/TR/trig/> for syntax specification.
 """
 
-from collections import defaultdict
 from typing import IO, TYPE_CHECKING, Optional, Union
 
 from rdflib.graph import ConjunctiveGraph, Graph
@@ -37,17 +36,15 @@ class TrigSerializer(TurtleSerializer):
         for context in self.contexts:
             self.store = context
             self.getQName(context.identifier)
-            self._references = defaultdict(int)
             self._subjects = {}
 
             for triple in context:
                 self.preprocessTriple(triple)
 
-            self._contexts[context] = (
-                self.orderSubjects(),
-                self._subjects,
-                self._references,
-            )
+            for subject in self._subjects.keys():
+                self._references[subject] += 1
+
+            self._contexts[context] = (self.orderSubjects(), self._subjects)
 
     def reset(self):
         super(TrigSerializer, self).reset()
@@ -77,11 +74,10 @@ class TrigSerializer(TurtleSerializer):
         self.startDocument()
 
         firstTime = True
-        for store, (ordered_subjects, subjects, ref) in self._contexts.items():
+        for store, (ordered_subjects, subjects) in self._contexts.items():
             if not ordered_subjects:
                 continue
 
-            self._references = ref
             self._serialized = {}
             self.store = store
             self._subjects = subjects

--- a/test/data/roundtrip/bnode_refs.trig
+++ b/test/data/roundtrip/bnode_refs.trig
@@ -1,0 +1,71 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix egdo: <http://example.org/> .
+
+{
+    egdo:bob dc:publisher "Bob" .
+    egdo:alice dc:publisher "Alice" .
+}
+
+
+egdo:alice {
+    _:alice foaf:name "Alice";
+        foaf:mbox <mailto:alice@work.example.org> .
+}
+
+egdo:bob {
+    _:bob foaf:name "Bob";
+        foaf:mbox <mailto:bob@oldcorp.example.org>;
+        foaf:knows _:alice .
+}
+
+
+egdo:blake {
+    [] foaf:name "Blake" ;
+        foaf:mbox <mailto:blake@oldcorp.example.org>;
+        foaf:knows [
+            foaf:name "Taylor";
+            foaf:mbox <mailto:taylor@work.example.org>
+        ] .
+}
+
+egdo:austin {
+    _:austin foaf:name "Austin" ;
+        foaf:mbox <mailto:austin@oldcorp.example.org>;
+        foaf:knows _:carson.
+
+
+    _:carson foaf:name "Carson" ;
+        foaf:mbox <mailto:carson@oldcorp.example.org>;
+        foaf:knows _:austin.
+}
+
+egdo:charlie {
+    _:charlie foaf:name "Charlie" ;
+        foaf:mbox <mailto:charlie@oldcorp.example.org>;
+        foaf:knows _:dylan;
+        foaf:knows _:greer.
+
+    _:dylan foaf:name "Dylan" ;
+        foaf:mbox <mailto:dylan@oldcorp.example.org>;
+        foaf:knows _:charlie;
+        foaf:knows _:greer.
+
+    _:greer foaf:name "Greer" ;
+        foaf:mbox <mailto:greer@oldcorp.example.org>;
+        foaf:knows _:charlie;
+        foaf:knows _:dylan.
+}
+
+egdo:jaime {
+    _:jaime foaf:name "Jaime";
+        foaf:mbox <mailto:jaime@work.example.org>;
+        foaf:knows _:keaton.
+}
+
+egdo:kennedy {
+    _:kennedy foaf:name "Kennedy";
+        foaf:mbox <mailto:kennedy@oldcorp.example.org>;
+        foaf:knows _:keaton .
+}

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -144,28 +144,6 @@ XFAILS = {
         reason="results in invalid xml element name: <ns1:name(s)/>",
         raises=SAXParseException,
     ),
-    ("trig", "rdf11trig_eg2.trig"): pytest.mark.xfail(
-        reason="""
-    Something is going wrong here with blank node serialization. In the second
-    graph below bob knows someone who does not exist, while in first he knows
-    someone that does exist and has the name Alice.
-
-    AssertionError: in both:
-        (rdflib.term.BNode('cbb5eb12b5dcf688537b0298cce144c6dd68cf047530d0b4a455a8f31f314244fd'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('mailto:alice@work.example.org'))
-        (rdflib.term.BNode('cbb5eb12b5dcf688537b0298cce144c6dd68cf047530d0b4a455a8f31f314244fd'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'), rdflib.term.Literal('Alice'))
-        (rdflib.term.URIRef('http://example.org/alice'), rdflib.term.URIRef('http://purl.org/dc/terms/publisher'), rdflib.term.Literal('Alice'))
-        (rdflib.term.URIRef('http://example.org/bob'), rdflib.term.URIRef('http://purl.org/dc/terms/publisher'), rdflib.term.Literal('Bob'))
-    only in first:
-        (rdflib.term.BNode('cb0'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'), rdflib.term.BNode('cbb5eb12b5dcf688537b0298cce144c6dd68cf047530d0b4a455a8f31f314244fd'))
-        (rdflib.term.BNode('cb0'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('mailto:bob@oldcorp.example.org'))
-        (rdflib.term.BNode('cb0'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'), rdflib.term.Literal('Bob'))
-    only in second:
-        (rdflib.term.BNode('cb7be1d0397a49ddd4ae8aa96acc7b6135903c5f3fa5e47bf619c0e4b438aafcc1'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'), rdflib.term.BNode('cb0'))
-        (rdflib.term.BNode('cb7be1d0397a49ddd4ae8aa96acc7b6135903c5f3fa5e47bf619c0e4b438aafcc1'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('mailto:bob@oldcorp.example.org'))
-        (rdflib.term.BNode('cb7be1d0397a49ddd4ae8aa96acc7b6135903c5f3fa5e47bf619c0e4b438aafcc1'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'), rdflib.term.Literal('Bob'))
-        """,
-        raises=AssertionError,
-    ),
     ("json-ld", "diverse_quads.trig"): pytest.mark.xfail(
         reason="""
     jsonld serializer is dropping datatype:
@@ -204,6 +182,10 @@ XFAILS = {
         "n3",
         "data/suites/w3c/n3/N3Tests/cwm_syntax/neg-single-quote.n3",
     ): pytest.mark.xfail(raises=BadSyntax, reason="no support for single quotes"),
+    ("json-ld", "bnode_refs.trig"): pytest.mark.xfail(
+        reason="a whole bunch of triples with bnode as subject is not in the reconstituted graph",
+        raises=AssertionError,
+    ),
 }
 
 # This is for files which can only be represented properly in one format
@@ -253,7 +235,13 @@ def roundtrip(
     s = g1.serialize(format=testfmt)
 
     if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("source = %s, serailized = \n%s", source, s)
+        logger.debug(
+            "infmt = %s, testfmt = %s, source = %s, serailized = \n%s",
+            infmt,
+            testfmt,
+            source,
+            s,
+        )
 
     g2 = graph_type()
     if same_public_id:
@@ -525,6 +513,7 @@ EXTRA_FILES = [
     (TEST_DATA_DIR / "variants" / "diverse_triples.nt", "ntriples"),
     (TEST_DATA_DIR / "variants" / "diverse_quads.nq", "nquads"),
     (TEST_DATA_DIR / "variants" / "diverse_quads.trig", "trig"),
+    (TEST_DATA_DIR / "roundtrip" / "bnode_refs.trig", "trig"),
     (TEST_DATA_DIR / "example-lots_of_graphs.n3", "n3"),
     (TEST_DATA_DIR / "issue156.n3", "n3"),
 ]


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

The TriG serializer was only considering BNode references inside a single
graph and not counting the BNodes subjects as references when considering if a
BNode should be serialized as unlabeled blank nodes (i.e. `[ ]`), and as a
result it was serializing BNodes as unlabeled if they were in fact referencing
BNodes in other graphs.

One caveat of this change is that some RDF Datasets may be serialized
less sussinctly in that it would not use unlabeled blank nodes where it is
technically possible. This can be trivially fixed, but a trivial fix
increases the compuational complexity of serialization significantly.

Other changes:
- Removed the roundtrip xfail that this change fixed.
- Added another roundtrip test which has various combinations of BNode
  references across graphs in a dataset, this test fails for JSON-LD
  however, so while this change removes one xfail it also now adds
  another.
- Set the default indent_size and style in .editorconfig as to avoid
  relying on undefined system defaults.

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

