### PR TITLE
fix: Don't register berkelydb as a store if it is not available on the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,24 @@ and will be removed for release.
 <!-- -->
 <!-- -->
 
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: START -->
+<!-- -->
+<!-- -->
+
+- Only register the `rdflib.plugins.stores.berkeleydb.BerkeleyDB` as a store
+  plugin if the `berkeleydb` module is present.
+  Closed [issue #1816](https://github.com/RDFLib/rdflib/issues/1816).
+  [PR #2096](https://github.com/RDFLib/rdflib/pull/2096).
+
+<!-- -->
+<!-- -->
+<!-- CHANGE BARRIER: END -->
+<!-- -->
+<!-- -->
+
 <!-- -->
 <!-- -->
 <!-- CHANGE BARRIER: START -->

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -618,5 +618,3 @@ register(
     "rdflib.plugins.sparql.results.tsvresults",
     "TSVResultParser",
 )
-
-# if plugins whatever doesn't have bddb, unregister it

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -180,6 +180,15 @@ def plugins(
 
 
 # Register Stores
+
+if rdflib.plugins.stores.berkeleydb.has_bsddb:
+    # Checks for BerkeleyDB before registering it
+    register(
+        "BerkeleyDB",
+        Store,
+        "rdflib.plugins.stores.berkeleydb",
+        "BerkeleyDB",
+    )
 register(
     "default",
     Store,
@@ -210,13 +219,7 @@ register(
     "rdflib.plugins.stores.concurrent",
     "ConcurrentStore",
 )
-if rdflib.plugins.stores.berkeleydb.has_bsddb == True:
-    register(
-        "BerkeleyDB",
-        Store,
-        "rdflib.plugins.stores.berkeleydb",
-        "BerkeleyDB",
-    )
+
 register(
     "SPARQLStore",
     Store,

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -39,6 +39,7 @@ from typing import (
     overload,
 )
 
+import rdflib.plugins.stores.berkeleydb
 from rdflib.exceptions import Error
 from rdflib.parser import Parser
 from rdflib.query import (
@@ -209,12 +210,13 @@ register(
     "rdflib.plugins.stores.concurrent",
     "ConcurrentStore",
 )
-register(
-    "BerkeleyDB",
-    Store,
-    "rdflib.plugins.stores.berkeleydb",
-    "BerkeleyDB",
-)
+if rdflib.plugins.stores.berkeleydb.has_bsddb == True:
+    register(
+        "BerkeleyDB",
+        Store,
+        "rdflib.plugins.stores.berkeleydb",
+        "BerkeleyDB",
+    )
 register(
     "SPARQLStore",
     Store,
@@ -613,3 +615,5 @@ register(
     "rdflib.plugins.sparql.results.tsvresults",
     "TSVResultParser",
 )
+
+# if plugins whatever doesn't have bddb, unregister it

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -13,7 +13,6 @@ from rdflib import Graph, URIRef, plugin
 from rdflib.exceptions import ParserError
 from rdflib.namespace import Namespace, NamespaceManager
 from rdflib.plugin import PluginException
-from rdflib.plugins.stores.berkeleydb import has_bsddb
 from rdflib.store import Store
 from rdflib.term import BNode
 

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -76,7 +76,6 @@ def get_store_names() -> Set[Optional[str]]:
     )
     names.add(None)
 
-
     logging.debug("names = %s", names)
     return names
 

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -75,8 +75,7 @@ def get_store_names() -> Set[Optional[str]]:
         }
     )
     names.add(None)
-    if not has_bsddb:
-        names.remove("BerkeleyDB")
+
 
     logging.debug("names = %s", names)
     return names


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/master/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Fixes #1816
- Added berkeleydb check in plugin.py
- Removed exception in test_graph.py
- Removed `import rdflib.plugins.stores.berkeleydb.has_bsddb`

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

