### PR TITLE
add charset encoding to SPARQLConnector.update() request.

### DIFF
--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -167,7 +167,7 @@ class SPARQLConnector(object):
 
         headers = {
             "Accept": _response_mime_types[self.returnFormat],
-            "Content-Type": "application/sparql-update",
+            "Content-Type": "application/sparql-update; charset=UTF-8",
         }
 
         args = dict(self.kwargs)  # other QSAs

--- a/test/test_store/test_store_sparqlstore.py
+++ b/test/test_store/test_store_sparqlstore.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -457,22 +458,23 @@ class SPARQL11ProtocolStoreMock(BaseHTTPRequestHandler):
         print(body)
         ```
         """
-        contenttype = self.headers.get("Content-Type")
+        contenttype = [part.strip() for part in f"{self.headers.get('Content-Type')}".split(";")]
+        logging.debug("contenttype = %s", contenttype)
         if self.path == "/query" or self.path == "/query?":
-            if self.headers.get("Content-Type") == "application/sparql-query":
+            if "application/sparql-query" in contenttype:
                 pass
             elif (
-                self.headers.get("Content-Type") == "application/x-www-form-urlencoded"
+                "application/x-www-form-urlencoded" in contenttype
             ):
                 pass
             else:
                 self.send_response(406, "Not Acceptable")
                 self.end_headers()
         elif self.path == "/update" or self.path == "/update?":
-            if self.headers.get("Content-Type") == "application/sparql-update":
+            if "application/sparql-update" in contenttype:
                 pass
             elif (
-                self.headers.get("Content-Type") == "application/x-www-form-urlencoded"
+                "application/x-www-form-urlencoded" in contenttype
             ):
                 pass
             else:

--- a/test/test_store/test_store_sparqlstore.py
+++ b/test/test_store/test_store_sparqlstore.py
@@ -458,14 +458,14 @@ class SPARQL11ProtocolStoreMock(BaseHTTPRequestHandler):
         print(body)
         ```
         """
-        contenttype = [part.strip() for part in f"{self.headers.get('Content-Type')}".split(";")]
+        contenttype = [
+            part.strip() for part in f"{self.headers.get('Content-Type')}".split(";")
+        ]
         logging.debug("contenttype = %s", contenttype)
         if self.path == "/query" or self.path == "/query?":
             if "application/sparql-query" in contenttype:
                 pass
-            elif (
-                "application/x-www-form-urlencoded" in contenttype
-            ):
+            elif "application/x-www-form-urlencoded" in contenttype:
                 pass
             else:
                 self.send_response(406, "Not Acceptable")
@@ -473,9 +473,7 @@ class SPARQL11ProtocolStoreMock(BaseHTTPRequestHandler):
         elif self.path == "/update" or self.path == "/update?":
             if "application/sparql-update" in contenttype:
                 pass
-            elif (
-                "application/x-www-form-urlencoded" in contenttype
-            ):
+            elif "application/x-www-form-urlencoded" in contenttype:
                 pass
             else:
                 self.send_response(406, "Not Acceptable")

--- a/test/test_store/test_store_sparqlupdatestore_mock.py
+++ b/test/test_store/test_store_sparqlupdatestore_mock.py
@@ -58,3 +58,26 @@ class TestSPARQLConnector:
         req = self.httpmock.requests[MethodName.POST].pop(0)
         assert req.parsed_path.path == self.update_path
         assert "application/sparql-update" in req.headers.get("content-type")
+
+    def test_update_encoding(self):
+        graph = ConjunctiveGraph("SPARQLUpdateStore")
+        graph.open((self.query_endpoint, self.update_endpoint))
+        update_statement = f"INSERT DATA {{ {EG['subj']} {EG['pred']} {EG['obj']}. }}"
+
+        self.httpmock.responses[MethodName.POST].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                b"Update succeeded",
+                {"Content-Type": ["text/plain; charset=UTF-8"]},
+            )
+        )
+
+        # This test assumes that updates are performed using POST
+        # at the moment this is the only supported way for SPARQLUpdateStore
+        # to do updates.
+        graph.update(update_statement)
+        assert self.httpmock.call_count == 1
+        req = self.httpmock.requests[MethodName.POST].pop(0)
+        assert req.parsed_path.path == self.update_path
+        assert "charset=UTF-8" in req.headers.get("content-type")


### PR DESCRIPTION
# Summary of changes

Add encoding "charset=UTF-8" to Content-Type header in SPARQLConnector.update() request.

Fixes #2095 

I added a separate test which is basically a copy of the existing test_graph_update(). The assertion could be integrated in the existing test instead.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

