### PR TITLE
Remove redundant PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,0 @@
-Fixes #
-
-## Proposed Changes
-
-  -
-  -
-  -


### PR DESCRIPTION
As far as I can tell, this template is not used anywhere. The actual PR template is located at https://github.com/RDFLib/rdflib/blob/main/.github/PULL_REQUEST_TEMPLATE.md, and having this other one is confusing.