### PR TITLE
Replace ParamList with Group

### DIFF
--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -27,7 +27,7 @@ import rdflib
 from rdflib.compat import decodeUnicodeEscape
 
 from . import operators as op
-from .parserutils import Comp, Param, ParamList
+from .parserutils import Comp, Param
 
 # from pyparsing import Keyword as CaseSensitiveKeyword
 
@@ -427,9 +427,9 @@ GraphRefAll = (
 )
 
 # [45] GraphOrDefault ::= 'DEFAULT' | 'GRAPH'? iri
-GraphOrDefault = ParamList("graph", Keyword("DEFAULT")) | Optional(
+GraphOrDefault = Group(Param("graph", Keyword("DEFAULT"))) | Optional(
     Keyword("GRAPH")
-) + ParamList("graph", iri)
+) + Group(Param("graph", iri))
 
 # [65] DataBlockValue ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | 'UNDEF'
 DataBlockValue = iri | RDFLiteral | NumericLiteral | BooleanLiteral | Keyword("UNDEF")
@@ -466,11 +466,11 @@ Path = Forward()
 # [95] PathNegatedPropertySet ::= PathOneInPropertySet | '(' ( PathOneInPropertySet ( '|' PathOneInPropertySet )* )? ')'
 PathNegatedPropertySet = Comp(
     "PathNegatedPropertySet",
-    ParamList("part", PathOneInPropertySet)
+    Group(Param("part", PathOneInPropertySet))
     | "("
     + Optional(
-        ParamList("part", PathOneInPropertySet)
-        + ZeroOrMore("|" + ParamList("part", PathOneInPropertySet))
+        Group(Param("part", PathOneInPropertySet))
+        + ZeroOrMore("|" + Group(Param("part", PathOneInPropertySet)))
     )
     + ")",
 )
@@ -498,15 +498,16 @@ PathEltOrInverse = PathElt | Suppress("^") + Comp(
 # [90] PathSequence ::= PathEltOrInverse ( '/' PathEltOrInverse )*
 PathSequence = Comp(
     "PathSequence",
-    ParamList("part", PathEltOrInverse)
-    + ZeroOrMore("/" + ParamList("part", PathEltOrInverse)),
+    Group(Param("part", PathEltOrInverse))
+    + ZeroOrMore("/" + Group(Param("part", PathEltOrInverse))),
 )
 
 
 # [89] PathAlternative ::= PathSequence ( '|' PathSequence )*
 PathAlternative = Comp(
     "PathAlternative",
-    ParamList("part", PathSequence) + ZeroOrMore("|" + ParamList("part", PathSequence)),
+    Group(Param("part", PathSequence))
+    + ZeroOrMore("|" + Group(Param("part", PathSequence))),
 )
 
 # [88] Path ::= PathAlternative
@@ -583,8 +584,8 @@ TriplesSameSubject.setParseAction(expandTriples)
 # To accommodate arbitrary amounts of triples this rule is rewritten to not be
 # recursive:
 # [52*] TriplesTemplate ::= TriplesSameSubject ( '.' TriplesSameSubject? )*
-TriplesTemplate = ParamList("triples", TriplesSameSubject) + ZeroOrMore(
-    Suppress(".") + Optional(ParamList("triples", TriplesSameSubject))
+TriplesTemplate = Group(Param("triples", TriplesSameSubject)) + ZeroOrMore(
+    Suppress(".") + Optional(Group(Param("triples", TriplesSameSubject)))
 )
 
 # [51] QuadsNotTriples ::= 'GRAPH' VarOrIri '{' Optional(TriplesTemplate) '}'
@@ -598,7 +599,7 @@ Quads = Comp(
     "Quads",
     Optional(TriplesTemplate)
     + ZeroOrMore(
-        ParamList("quadsNotTriples", QuadsNotTriples)
+        Group(Param("quadsNotTriples", QuadsNotTriples))
         + Optional(Suppress("."))
         + Optional(TriplesTemplate)
     ),
@@ -618,7 +619,7 @@ TriplesSameSubjectPath.setParseAction(expandTriples)
 
 # [55] TriplesBlock ::= TriplesSameSubjectPath ( '.' Optional(TriplesBlock) )?
 TriplesBlock = Forward()
-TriplesBlock <<= ParamList("triples", TriplesSameSubjectPath) + Optional(
+TriplesBlock <<= Group(Param("triples", TriplesSameSubjectPath)) + Optional(
     Suppress(".") + Optional(TriplesBlock)
 )
 
@@ -631,8 +632,8 @@ MinusGraphPattern = Comp(
 # [67] GroupOrUnionGraphPattern ::= GroupGraphPattern ( 'UNION' GroupGraphPattern )*
 GroupOrUnionGraphPattern = Comp(
     "GroupOrUnionGraphPattern",
-    ParamList("graph", GroupGraphPattern)
-    + ZeroOrMore(Keyword("UNION") + ParamList("graph", GroupGraphPattern)),
+    Group(Param("graph", GroupGraphPattern))
+    + ZeroOrMore(Keyword("UNION") + Group(Param("graph", GroupGraphPattern))),
 )
 
 
@@ -1000,7 +1001,7 @@ ArgList = (
     NIL
     | "("
     + Param("distinct", _Distinct)
-    + delimitedList(ParamList("expr", Expression))
+    + delimitedList(Group(Param("expr", Expression)))
     + ")"
 )
 
@@ -1045,8 +1046,8 @@ MultiplicativeExpression = Comp(
     "MultiplicativeExpression",
     Param("expr", UnaryExpression)
     + ZeroOrMore(
-        ParamList("op", "*") + ParamList("other", UnaryExpression)
-        | ParamList("op", "/") + ParamList("other", UnaryExpression)
+        Group(Param("op", "*")) + Group(Param("other", UnaryExpression))
+        | Group(Param("op", "/")) + Group(Param("other", UnaryExpression))
     ),
 ).setEvalFn(op.MultiplicativeExpression)
 
@@ -1063,8 +1064,8 @@ AdditiveExpression = Comp(
     "AdditiveExpression",
     Param("expr", MultiplicativeExpression)
     + ZeroOrMore(
-        ParamList("op", "+") + ParamList("other", MultiplicativeExpression)
-        | ParamList("op", "-") + ParamList("other", MultiplicativeExpression)
+        Group(Param("op", "+")) + Group(Param("other", MultiplicativeExpression))
+        | Group(Param("op", "-")) + Group(Param("other", MultiplicativeExpression))
     ),
 ).setEvalFn(op.AdditiveExpression)
 
@@ -1099,14 +1100,15 @@ ValueLogical = RelationalExpression
 # [112] ConditionalAndExpression ::= ValueLogical ( '&&' ValueLogical )*
 ConditionalAndExpression = Comp(
     "ConditionalAndExpression",
-    Param("expr", ValueLogical) + ZeroOrMore("&&" + ParamList("other", ValueLogical)),
+    Param("expr", ValueLogical)
+    + ZeroOrMore("&&" + Group(Param("other", ValueLogical))),
 ).setEvalFn(op.ConditionalAndExpression)
 
 # [111] ConditionalOrExpression ::= ConditionalAndExpression ( '||' ConditionalAndExpression )*
 ConditionalOrExpression = Comp(
     "ConditionalOrExpression",
     Param("expr", ConditionalAndExpression)
-    + ZeroOrMore("||" + ParamList("other", ConditionalAndExpression)),
+    + ZeroOrMore("||" + Group(Param("other", ConditionalAndExpression))),
 ).setEvalFn(op.ConditionalOrExpression)
 
 # [110] Expression ::= ConditionalOrExpression
@@ -1154,7 +1156,7 @@ GroupClause = Comp(
     "GroupClause",
     Keyword("GROUP")
     + Keyword("BY")
-    + OneOrMore(ParamList("condition", GroupCondition)),
+    + OneOrMore(Group(Param("condition", GroupCondition))),
 )
 
 
@@ -1222,7 +1224,7 @@ Modify = Comp(
         Param("delete", DeleteClause) + Optional(Param("insert", InsertClause))
         | Param("insert", InsertClause)
     )
-    + ZeroOrMore(ParamList("using", UsingClause))
+    + ZeroOrMore(Group(Param("using", UsingClause)))
     + Keyword("WHERE")
     + Param("where", GroupGraphPattern),
 )
@@ -1246,17 +1248,22 @@ Update1 = (
 
 # [63] InlineDataOneVar ::= Var '{' ZeroOrMore(DataBlockValue) '}'
 InlineDataOneVar = (
-    ParamList("var", Var) + "{" + ZeroOrMore(ParamList("value", DataBlockValue)) + "}"
+    Group(Param("var", Var))
+    + "{"
+    + ZeroOrMore(Group(Param("value", DataBlockValue)))
+    + "}"
 )
 
 # [64] InlineDataFull ::= ( NIL | '(' ZeroOrMore(Var) ')' ) '{' ( '(' ZeroOrMore(DataBlockValue) ')' | NIL )* '}'
 InlineDataFull = (
-    (NIL | "(" + ZeroOrMore(ParamList("var", Var)) + ")")
+    (NIL | "(" + ZeroOrMore(Group(Param("var", Var))) + ")")
     + "{"
     + ZeroOrMore(
-        ParamList(
-            "value",
-            Group(Suppress("(") + ZeroOrMore(DataBlockValue) + Suppress(")") | NIL),
+        Group(
+            Param(
+                "value",
+                Group(Suppress("(") + ZeroOrMore(DataBlockValue) + Suppress(")") | NIL),
+            )
         )
     )
     + "}"
@@ -1274,7 +1281,7 @@ ValuesClause = Optional(
 
 # [74] ConstructTriples ::= TriplesSameSubject ( '.' Optional(ConstructTriples) )?
 ConstructTriples = Forward()
-ConstructTriples <<= ParamList("template", TriplesSameSubject) + Optional(
+ConstructTriples <<= Group(Param("template", TriplesSameSubject)) + Optional(
     Suppress(".") + Optional(ConstructTriples)
 )
 
@@ -1331,11 +1338,11 @@ GraphPatternNotTriples = (
 # [54] GroupGraphPatternSub ::= Optional(TriplesBlock) ( GraphPatternNotTriples '.'? Optional(TriplesBlock) )*
 GroupGraphPatternSub = Comp(
     "GroupGraphPatternSub",
-    Optional(ParamList("part", Comp("TriplesBlock", TriplesBlock)))
+    Optional(Group(Param("part", Comp("TriplesBlock", TriplesBlock))))
     + ZeroOrMore(
-        ParamList("part", GraphPatternNotTriples)
+        Group(Param("part", GraphPatternNotTriples))
         + Optional(".")
-        + Optional(ParamList("part", Comp("TriplesBlock", TriplesBlock)))
+        + Optional(Group(Param("part", Comp("TriplesBlock", TriplesBlock))))
     ),
 )
 
@@ -1347,7 +1354,7 @@ HavingCondition = Constraint
 # [21] HavingClause ::= 'HAVING' HavingCondition+
 HavingClause = Comp(
     "HavingClause",
-    Keyword("HAVING") + OneOrMore(ParamList("condition", HavingCondition)),
+    Keyword("HAVING") + OneOrMore(Group(Param("condition", HavingCondition))),
 )
 
 # [24] OrderCondition ::= ( ( 'ASC' | 'DESC' ) BrackettedExpression )
@@ -1364,7 +1371,7 @@ OrderClause = Comp(
     "OrderClause",
     Keyword("ORDER")
     + Keyword("BY")
-    + OneOrMore(ParamList("condition", OrderCondition)),
+    + OneOrMore(Group(Param("condition", OrderCondition))),
 )
 
 # [26] LimitClause ::= 'LIMIT' INTEGER
@@ -1394,19 +1401,21 @@ SelectClause = (
     + Optional(Param("modifier", Keyword("DISTINCT") | Keyword("REDUCED")))
     + (
         OneOrMore(
-            ParamList(
-                "projection",
-                Comp(
-                    "vars",
-                    Param("var", Var)
-                    | (
-                        Literal("(")
-                        + Param("expr", Expression)
-                        + Keyword("AS")
-                        + Param("evar", Var)
-                        + ")"
+            Group(
+                Param(
+                    "projection",
+                    Comp(
+                        "vars",
+                        Param("var", Var)
+                        | (
+                            Literal("(")
+                            + Param("expr", Expression)
+                            + Keyword("AS")
+                            + Param("evar", Var)
+                            + ")"
+                        ),
                     ),
-                ),
+                )
             )
         )
         | "*"
@@ -1428,7 +1437,7 @@ GroupGraphPattern <<= Suppress("{") + (SubSelect | GroupGraphPatternSub) + Suppr
 SelectQuery = Comp(
     "SelectQuery",
     SelectClause
-    + ZeroOrMore(ParamList("datasetClause", DatasetClause))
+    + ZeroOrMore(Group(Param("datasetClause", DatasetClause)))
     + WhereClause
     + SolutionModifier
     + ValuesClause,
@@ -1442,11 +1451,11 @@ ConstructQuery = Comp(
     Keyword("CONSTRUCT")
     + (
         ConstructTemplate
-        + ZeroOrMore(ParamList("datasetClause", DatasetClause))
+        + ZeroOrMore(Group(Param("datasetClause", DatasetClause)))
         + WhereClause
         + SolutionModifier
         + ValuesClause
-        | ZeroOrMore(ParamList("datasetClause", DatasetClause))
+        | ZeroOrMore(Group(Param("datasetClause", DatasetClause)))
         + Keyword("WHERE")
         + "{"
         + Optional(
@@ -1454,7 +1463,7 @@ ConstructQuery = Comp(
                 "where",
                 Comp(
                     "FakeGroupGraphPatten",
-                    ParamList("part", Comp("TriplesBlock", TriplesTemplate)),
+                    Group(Param("part", Comp("TriplesBlock", TriplesTemplate))),
                 ),
             )
         )
@@ -1478,7 +1487,7 @@ AskQuery = Comp(
 DescribeQuery = Comp(
     "DescribeQuery",
     Keyword("DESCRIBE")
-    + (OneOrMore(ParamList("var", VarOrIri)) | "*")
+    + (OneOrMore(Group(Param("var", VarOrIri))) | "*")
     + Param("datasetClause", ZeroOrMore(DatasetClause))
     + Optional(WhereClause)
     + SolutionModifier
@@ -1487,8 +1496,8 @@ DescribeQuery = Comp(
 
 # [29] Update ::= Prologue ( Update1 ( ';' Update )? )?
 Update = Forward()
-Update <<= ParamList("prologue", Prologue) + Optional(
-    ParamList("request", Update1) + Optional(";" + Update)
+Update <<= Group(Param("prologue", Prologue)) + Optional(
+    Group(Param("request", Update1)) + Optional(";" + Update)
 )
 
 

--- a/rdflib/plugins/sparql/parserutils.py
+++ b/rdflib/plugins/sparql/parserutils.py
@@ -224,10 +224,11 @@ class Comp(TokenConverter):
         for t in tokenList:
             if isinstance(t, ParseResults):
                 for i in t:
-                    if isinstance(i, ParamValue):
-                        if i.name not in res:
-                            res[i.name] = []
-                        res[i.name].append(i.tokenList)
+                    if not isinstance(i, ParamValue):
+                        raise TypeError("ParseResult must be a ParamValue")
+                    if i.name not in res:
+                        res[i.name] = []
+                    res[i.name].append(i.tokenList)
             elif isinstance(t, ParamValue):
                 res[t.name] = t.tokenList
         return res

--- a/rdflib/plugins/sparql/parserutils.py
+++ b/rdflib/plugins/sparql/parserutils.py
@@ -224,11 +224,10 @@ class Comp(TokenConverter):
         for t in tokenList:
             if isinstance(t, ParseResults):
                 for i in t:
-                    if not isinstance(i, ParamValue):
-                        raise TypeError("ParseResult must be a ParamValue")
-                    if i.name not in res:
-                        res[i.name] = []
-                    res[i.name].append(i.tokenList)
+                    if isinstance(i, ParamValue):
+                        if i.name not in res:
+                            res[i.name] = []
+                        res[i.name].append(i.tokenList)
             elif isinstance(t, ParamValue):
                 res[t.name] = t.tokenList
         return res


### PR DESCRIPTION
# Summary of changes

No functional changes. I've wanted to better understand the parsing of SPARQL, and have found that `ParamList` makes the parsing unnecessarily more complex. Replacing `ParamList` with the built-in `Group` operator simplifies the ability to understand how a SPARQL query is being parsed.

In order to replace `ParamList` with `Group`, I just did a find and replace of `ParamList(foo)` with `Group(Param(foo))`. Perhaps replacing instances of `ZeroOrMore(ParamList(foo))` should be replaced with `Group(ZeroOrMore(Param(foo))` instead of `ZeroOrMore(Group(Param(foo))`, but I'm not too sure of the benefits of one over the other, so I instead opted for what semantically matches what we had prior to this change.

# Checklist

- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues and keep your PR up to date.

