### PR TITLE
compute_qname handle case where name could be unbound

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -394,7 +394,6 @@ class NamespaceManager(object):
     """
 
     def __init__(self, graph: "Graph", bind_namespaces: "_NamespaceSetString" = "core"):
-        logging.debug("self = %r", self)
         self.graph = graph
         self.__cache: Dict[str, Tuple[str, URIRef, str]] = {}
         self.__cache_strict: Dict[str, Tuple[str, URIRef, str]] = {}
@@ -469,7 +468,6 @@ class NamespaceManager(object):
         registered prefix) or (unlike compute_qname) the Notation 3
         form for URIs: <...URI...>
         """
-        logging.debug("normalizeUri: rdfTerm = %s", rdfTerm)
         try:
             namespace, name = split_uri(rdfTerm)
             if namespace not in self.__strie:
@@ -504,25 +502,19 @@ class NamespaceManager(object):
             try:
                 namespace, name = split_uri(uri)
             except ValueError as e:
-                logging.debug("caught, uri=%s, generate=%s", uri, generate, exc_info=True)
                 namespace = URIRef(uri)
                 prefix = self.store.prefix(namespace)
-                # name = ""  # empty prefix case, safe since not prefix is error
+                name = ""  # empty prefix case, safe since not prefix is error
                 if not prefix:
                     raise e
             if namespace not in self.__strie:
-                logging.debug("namespace %r was not already in __strie", namespace)
                 insert_strie(self.__strie, self.__trie, namespace)
-            else:
-                logging.debug("namespace %r was already in __strie", namespace)
 
             if self.__strie[namespace]:
                 pl_namespace = get_longest_namespace(self.__strie[namespace], uri)
                 if pl_namespace is not None:
                     namespace = pl_namespace
                     name = uri[len(namespace) :]
-            else:
-                logging.debug("self.__strie[namespace] is not truthish ...")
 
             namespace = URIRef(namespace)
             prefix = self.store.prefix(namespace)  # warning multiple prefixes problem
@@ -539,13 +531,7 @@ class NamespaceManager(object):
                         break
                     num += 1
                 self.bind(prefix, namespace)
-            try:
-                logging.debug("prefix = %s, namespace = %s, name = %s", prefix, namespace, name)
-            except:
-                logging.debug("caught (12zasda)", exc_info=True)
             self.__cache[uri] = (prefix, namespace, name)
-        else:
-            logging.debug("cache hit for %r", uri)
         return self.__cache[uri]
 
     def compute_qname_strict(
@@ -852,7 +838,6 @@ def insert_trie(
 
 def insert_strie(strie: Dict[str, Any], trie: Dict[str, Any], value: str) -> None:
     if value not in strie:
-        logging.debug("inserting (%r, %r) under %r", trie, value, value)
         strie[value] = insert_trie(trie, value)
 
 

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -504,6 +504,7 @@ class NamespaceManager(object):
             except ValueError as e:
                 namespace = URIRef(uri)
                 prefix = self.store.prefix(namespace)
+                name = ''  # empty prefix case, safe since not prefix is error
                 if not prefix:
                     raise e
             if namespace not in self.__strie:

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -504,7 +504,7 @@ class NamespaceManager(object):
             except ValueError as e:
                 namespace = URIRef(uri)
                 prefix = self.store.prefix(namespace)
-                name = ''  # empty prefix case, safe since not prefix is error
+                name = ""  # empty prefix case, safe since not prefix is error
                 if not prefix:
                     raise e
             if namespace not in self.__strie:

--- a/test/data/suites/n3roundtrip/n3-writer-test-32.n3
+++ b/test/data/suites/n3roundtrip/n3-writer-test-32.n3
@@ -1,0 +1,7 @@
+# Test unshortenable strict qnames no predicates for xml sanity check
+
+@prefix here: <http://example.org/here#> .
+
+# Test namespace generation
+
+[] here: [] .

--- a/test/test_namespacemanager.py
+++ b/test/test_namespacemanager.py
@@ -4,14 +4,13 @@ import logging
 import re
 import sys
 from contextlib import ExitStack
-from multiprocessing.sharedctypes import Value
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Set, Tuple, Type, Union
 
 import pytest
 
 from rdflib.graph import Dataset
-from rdflib.term import URIRef, bind
+from rdflib.term import URIRef
 
 if TYPE_CHECKING:
     from rdflib._type_checking import _NamespaceSetString
@@ -266,11 +265,6 @@ def test_compute_qname(
             nm.bind(prefix, ns)
 
     def check() -> None:
-        logging.debug(
-            "%r in nm._NamespaceManager__cache = %s",
-            uri,
-            uri in nm._NamespaceManager__cache,
-        )
         catcher: Optional[pytest.ExceptionInfo[Exception]] = None
         with ExitStack() as xstack:
             if isinstance(expected_result, type) and issubclass(
@@ -330,11 +324,6 @@ def test_compute_qname_strict(
             nm.bind(prefix, ns)
 
     def check() -> None:
-        logging.debug(
-            "%r in nm._NamespaceManager__cache = %s",
-            uri,
-            uri in nm._NamespaceManager__cache,
-        )
         catcher: Optional[pytest.ExceptionInfo[Exception]] = None
         with ExitStack() as xstack:
             if isinstance(expected_result, type) and issubclass(

--- a/test/test_namespacemanager.py
+++ b/test/test_namespacemanager.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
 import logging
+from multiprocessing.sharedctypes import Value
+import re
 import sys
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Set, Tuple, Type, Union
 
 import pytest
 
 from rdflib.graph import Dataset
-from rdflib.term import URIRef
+from rdflib.term import URIRef, bind
+
+if TYPE_CHECKING:
+    from rdflib._type_checking import _NamespaceSetString
+
 
 sys.path.append(str(Path(__file__).parent.parent.absolute()))
 from rdflib import Graph
@@ -16,6 +23,7 @@ from rdflib.namespace import (
     _NAMESPACE_PREFIXES_RDFLIB,
     OWL,
     RDFS,
+    Namespace,
     NamespaceManager,
 )
 
@@ -170,3 +178,119 @@ def test_compute_qname_no_generate() -> None:
         g.namespace_manager.compute_qname_strict(
             "https://example.org/unbound/test", generate=False
         )
+
+
+@pytest.mark.parametrize(
+    ["uri", "generate", "bind_namespaces", "additional_prefixes", "expected_result"],
+    [
+        (
+            "http://example.org/here#",
+            True,
+            "none",
+            {"here": Namespace("http://example.org/here#")},
+            ("here", URIRef("http://example.org/here#"), ""),
+        ),
+        (
+            "http://example.org/here#",
+            True,
+            "none",
+            None,
+            ValueError("Can't split"),
+        ),
+    ],
+)
+def test_compute_qname(
+    uri: str,
+    generate: bool,
+    bind_namespaces: _NamespaceSetString,
+    additional_prefixes: Optional[Mapping[str, Namespace]],
+    expected_result: Union[Tuple[str, URIRef, str], Type[Exception], Exception],
+) -> None:
+    graph = Graph(bind_namespaces=bind_namespaces)
+    nm = graph.namespace_manager
+
+    if additional_prefixes is not None:
+        for prefix, ns in additional_prefixes.items():
+            nm.bind(prefix, ns)
+
+    def check() -> None:
+        logging.debug("%r in nm._NamespaceManager__cache = %s", uri, uri in nm._NamespaceManager__cache)
+        catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+        with ExitStack() as xstack:
+            if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+                catcher = xstack.enter_context(pytest.raises(expected_result))
+            if isinstance(expected_result, Exception):
+                catcher = xstack.enter_context(pytest.raises(type(expected_result)))
+            actual_result = nm.compute_qname(uri, generate)
+            logging.debug("actual_result = %s", actual_result)
+        if catcher is not None:
+            assert catcher is not None
+            assert catcher.value is not None
+            if isinstance(expected_result, Exception):
+                assert re.match(expected_result.args[0], f"{catcher.value}")
+        else:
+            assert isinstance(expected_result, tuple)
+            assert isinstance(actual_result, tuple)
+            assert actual_result == expected_result
+
+    check()
+    # Run a second time to check caching
+    check()
+
+
+@pytest.mark.parametrize(
+    ["uri", "generate", "bind_namespaces", "additional_prefixes", "expected_result"],
+    [
+        (
+            "http://example.org/here#",
+            True,
+            "none",
+            {"here": Namespace("http://example.org/here#")},
+            ("here", URIRef("http://example.org/here#"), ""),
+        ),
+        (
+            "http://example.org/here#",
+            True,
+            "none",
+            None,
+            ValueError("Can't split"),
+        ),
+    ],
+)
+def test_compute_qname_strict(
+    uri: str,
+    generate: bool,
+    bind_namespaces: _NamespaceSetString,
+    additional_prefixes: Optional[Mapping[str, Namespace]],
+    expected_result: Union[Tuple[str, URIRef, str], Type[Exception], Exception],
+) -> None:
+    graph = Graph(bind_namespaces=bind_namespaces)
+    nm = graph.namespace_manager
+
+    if additional_prefixes is not None:
+        for prefix, ns in additional_prefixes.items():
+            nm.bind(prefix, ns)
+
+    def check() -> None:
+        logging.debug("%r in nm._NamespaceManager__cache = %s", uri, uri in nm._NamespaceManager__cache)
+        catcher: Optional[pytest.ExceptionInfo[Exception]] = None
+        with ExitStack() as xstack:
+            if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+                catcher = xstack.enter_context(pytest.raises(expected_result))
+            if isinstance(expected_result, Exception):
+                catcher = xstack.enter_context(pytest.raises(type(expected_result)))
+            actual_result = nm.compute_qname_strict(uri, generate)
+            logging.debug("actual_result = %s", actual_result)
+        if catcher is not None:
+            assert catcher is not None
+            assert catcher.value is not None
+            if isinstance(expected_result, Exception):
+                assert re.match(expected_result.args[0], f"{catcher.value}")
+        else:
+            assert isinstance(expected_result, tuple)
+            assert isinstance(actual_result, tuple)
+            assert actual_result == expected_result
+
+    check()
+    # Run a second time to check caching
+    check()

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -76,6 +76,10 @@ XFAILS = {
         reason="has predicates that cannot be shortened to strict qnames",
         raises=ValueError,
     ),
+    ("xml", "n3-writer-test-32.n3",): pytest.mark.xfail(
+        reason="has a predicate that cannot be shortened to strict qnames",
+        raises=ValueError,
+    ),
     ("xml", "qname-02.nt"): pytest.mark.xfail(
         reason="uses a property that cannot be qname'd",
         raises=ValueError,


### PR DESCRIPTION
In NamespaceManager.compute_qname it is possible for the variable name to be unbound when a namespace is used as a predicate e.g. ns2: and the namespace itself cannot be split any further.

Fixing this usually just kicks the can down the road because the only reason to hit this condition is that you are trying to serialize a predicate that has no valid NCName form into an xml format that requires one, making it impossible to complete the conversion. That said, this fix should make it easier to understand what is going on by unmasking the real issue.