### PR TITLE
Add namespace_manager argument for n3 method on Paths

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -188,6 +188,7 @@ from rdflib.term import Node, URIRef
 
 if TYPE_CHECKING:
     from rdflib.graph import Graph, _ObjectType, _SubjectType
+    from rdflib.namespace import NamespaceManager
 
 
 # property paths
@@ -233,8 +234,8 @@ class InvPath(Path):
     def __repr__(self):
         return "Path(~%s)" % (self.arg,)
 
-    def n3(self):
-        return "^%s" % self.arg.n3()
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None):
+        return "^%s" % self.arg.n3(namespace_manager)
 
 
 class SequencePath(Path):
@@ -277,8 +278,8 @@ class SequencePath(Path):
     def __repr__(self):
         return "Path(%s)" % " / ".join(str(x) for x in self.args)
 
-    def n3(self):
-        return "/".join(a.n3() for a in self.args)
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None):
+        return "/".join(a.n3(namespace_manager) for a in self.args)
 
 
 class AlternativePath(Path):
@@ -298,8 +299,8 @@ class AlternativePath(Path):
     def __repr__(self):
         return "Path(%s)" % " | ".join(str(x) for x in self.args)
 
-    def n3(self):
-        return "|".join(a.n3() for a in self.args)
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None):
+        return "|".join(a.n3(namespace_manager) for a in self.args)
 
 
 class MulPath(Path):
@@ -402,8 +403,8 @@ class MulPath(Path):
     def __repr__(self):
         return "Path(%s%s)" % (self.path, self.mod)
 
-    def n3(self):
-        return "%s%s" % (self.path.n3(), self.mod)
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None):
+        return "%s%s" % (self.path.n3(namespace_manager), self.mod)
 
 
 class NegatedPath(Path):
@@ -435,8 +436,8 @@ class NegatedPath(Path):
     def __repr__(self):
         return "Path(! %s)" % ",".join(str(x) for x in self.args)
 
-    def n3(self):
-        return "!(%s)" % ("|".join(self.args))
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None):
+        return "!(%s)" % ("|".join(arg.n3(namespace_manager) for arg in self.args))
 
 
 class PathList(list):

--- a/test/test_paths_n3.py
+++ b/test/test_paths_n3.py
@@ -1,0 +1,42 @@
+import pytest
+
+from rdflib import RDF, RDFS, Graph
+from rdflib.paths import OneOrMore, ZeroOrMore, ZeroOrOne
+
+g = Graph()
+nsm = g.namespace_manager
+
+
+@pytest.mark.parametrize(
+    "path, no_nsm, with_nsm",
+    [
+        (~RDF.type, f"^<{RDF.type}>", "^rdf:type"),
+        (
+            RDF.type / RDFS.subClassOf,
+            f"<{RDF.type}>/<{RDFS.subClassOf}>",
+            "rdf:type/rdfs:subClassOf",
+        ),
+        (
+            RDF.type | RDFS.subClassOf,
+            f"<{RDF.type}>|<{RDFS.subClassOf}>",
+            "rdf:type|rdfs:subClassOf",
+        ),
+        (-RDF.type, f"!(<{RDF.type}>)", "!(rdf:type)"),
+        (RDFS.subClassOf * ZeroOrMore, f"<{RDFS.subClassOf}>*", "rdfs:subClassOf*"),
+        (RDFS.subClassOf * OneOrMore, f"<{RDFS.subClassOf}>+", "rdfs:subClassOf+"),
+        (RDFS.subClassOf * ZeroOrOne, f"<{RDFS.subClassOf}>?", "rdfs:subClassOf?"),
+        (
+            RDF.type / RDFS.subClassOf * "*",
+            f"<{RDF.type}>/<{RDFS.subClassOf}>*",
+            "rdf:type/rdfs:subClassOf*",
+        ),
+        (
+            -(RDF.type | RDFS.subClassOf),
+            f"!(<{RDF.type}>|<{RDFS.subClassOf}>)",
+            "!(rdf:type|rdfs:subClassOf)",
+        ),
+    ],
+)
+def test_paths_n3(path, no_nsm, with_nsm):
+    assert path.n3() == no_nsm
+    assert path.n3(nsm) == with_nsm


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->
The `n3` method on the `Term` class optionally takes a `NamespaceManager` as an argument which, if provided, is used to create a prefixed name instead of fully qualified URIs for `URIRef`s and typed `Literal`s where applicable if an appropriate prefix has been bound for the relevant namespace. `Path` objects also have a `n3` method to create N3/SPARQL compatible serializations for those objects which call the `n3` method on the underlying `URIRef`s. However, `Path.n3` did not have the argument for the `NamespaceManager`.

This PR simply adds the same optional `NamespaceManager` argument to the `n3` method for `Path`s to be consistent with the `n3` method on `Term`s and passes that `NamespaceManager` to any nested calls to `n3` so it behaves as expected.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [x] Considered adding an example in `./examples` for new features.
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

