### PR TITLE
Issue2179 incorrect headers

### DIFF
--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -94,7 +94,7 @@ class SPARQLConnector(object):
 
         headers = {"Accept": _response_mime_types[self.returnFormat]}
 
-        args = dict(self.kwargs)
+        args = dict(self.kwargs).copy()
 
         # merge params/headers dicts
         args.setdefault("params", {})

--- a/test/test_store/test_store_sparqlupdatestore_mock.py
+++ b/test/test_store/test_store_sparqlupdatestore_mock.py
@@ -119,6 +119,5 @@ class TestSPARQLConnector:
         # Now make GET request and check that Content-Type header is not "application/sparql-update"
         query_statement = "ASK { ?s ?p ?o }"
         store.query(query_statement)
-        print(store.kwargs)
         req = self.httpmock.requests[MethodName.GET].pop(0)
         assert "application/sparql-update" not in req.headers.get("Content-Type")

--- a/test/test_store/test_store_sparqlupdatestore_mock.py
+++ b/test/test_store/test_store_sparqlupdatestore_mock.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 
 from rdflib import Namespace
 from rdflib.graph import ConjunctiveGraph
+from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
 
 EG = Namespace("http://example.org/")
 
@@ -81,3 +82,43 @@ class TestSPARQLConnector:
         req = self.httpmock.requests[MethodName.POST].pop(0)
         assert req.parsed_path.path == self.update_path
         assert "charset=UTF-8" in req.headers.get("content-type")
+
+    def test_content_type(self):
+        store = SPARQLUpdateStore(self.query_endpoint, self.update_endpoint, auth=("admin","admin"))
+        update_statement = f"INSERT DATA {{ {EG['subj']} {EG['pred']} {EG['obj']}. }}"
+
+        self.httpmock.responses[MethodName.POST].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                b"Update succeeded",
+                {"Content-Type": ["text/plain; charset=UTF-8"]},
+            )
+        )
+
+        self.httpmock.responses[MethodName.GET].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                b"""<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+  <boolean>true</boolean>
+</sparql>
+""",
+                {"Content-Type": ["application/sparql-results+xml"]},
+            )
+        )
+
+        # First make update request and check if Content-Type header is set
+        store.update(update_statement)
+        req = self.httpmock.requests[MethodName.POST].pop(0)
+        assert "application/sparql-update" in req.headers.get("Content-Type")
+
+        # Now make GET request and check that Content-Type header is not "application/sparql-update"
+        query_statement = "ASK { ?s ?p ?o }"
+        store.query(query_statement)
+        print(store.kwargs)
+        req = self.httpmock.requests[MethodName.GET].pop(0)
+        assert "application/sparql-update" not in req.headers.get("Content-Type")


### PR DESCRIPTION
# Summary of changes

<!--
This PR solves issue 2179. Wrong Content-Type header was sent with query GET request after a POST update request.
-->

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

