### PR TITLE
namespace.get_longest_namespace avoid concurrent modification issues

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -842,7 +842,7 @@ def insert_strie(strie: Dict[str, Any], trie: Dict[str, Any], value: str) -> Non
 
 
 def get_longest_namespace(trie: Dict[str, Any], value: str) -> Optional[str]:
-    for key in trie:
+    for key in trie.keys():
         if value.startswith(key):
             out = get_longest_namespace(trie[key], value)
             if out is None:


### PR DESCRIPTION
When using async code that operates on namespaces it is possible for the namespacies trie dict to be modified in one coro while it is being iterated through in another, causing a RuntimeError. To avoid this we switch to always iterate over trie.keys(). This is safe because any concurrent modification will either have no impact or will duplicate the operation leaving the trie in the same state.

<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [x] Considered adding an example in `./examples` for new features.
  - [x] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

