### PR TITLE
more type-hinting for SPARQL plugin

### DIFF
--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import Any
 from typing import Optional as OptionalType
-from typing import TextIO, Tuple, Union
+from typing import IO, Tuple, Union
 
 from pyparsing import CaselessKeyword as Keyword  # watch out :)
 from pyparsing import (
@@ -1531,7 +1531,7 @@ def expandUnicodeEscapes(q: str) -> str:
     return expandUnicodeEscapes_re.sub(expand, q)
 
 
-def parseQuery(q: Union[str, bytes, TextIO]) -> ParseResults:
+def parseQuery(q: Union[str, bytes, IO]) -> ParseResults:
     if hasattr(q, "read"):
         q = q.read()
     if isinstance(q, bytes):
@@ -1541,7 +1541,7 @@ def parseQuery(q: Union[str, bytes, TextIO]) -> ParseResults:
     return Query.parseString(q, parseAll=True)
 
 
-def parseUpdate(q: Union[str, bytes, TextIO]):
+def parseUpdate(q: Union[str, bytes, IO]):
     if hasattr(q, "read"):
         q = q.read()
 

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -6,9 +6,9 @@ based on pyparsing
 
 import re
 import sys
-from typing import Any
+from typing import IO, Any
 from typing import Optional as OptionalType
-from typing import IO, Tuple, Union
+from typing import Tuple, Union
 
 from pyparsing import CaselessKeyword as Keyword  # watch out :)
 from pyparsing import (
@@ -1537,7 +1537,8 @@ def parseQuery(q: Union[str, bytes, IO]) -> ParseResults:
     if isinstance(q, bytes):
         q = q.decode("utf-8")
 
-    q = expandUnicodeEscapes(q)
+    # type error: Argument 1 to "expandUnicodeEscapes" has incompatible type "Union[str, IO[Any]]"; expected "str"
+    q = expandUnicodeEscapes(q)  # type: ignore[arg-type]
     return Query.parseString(q, parseAll=True)
 
 
@@ -1548,5 +1549,6 @@ def parseUpdate(q: Union[str, bytes, IO]):
     if isinstance(q, bytes):
         q = q.decode("utf-8")
 
-    q = expandUnicodeEscapes(q)
+    # type error: Argument 1 to "expandUnicodeEscapes" has incompatible type "Union[str, IO[Any]]"; expected "str"
+    q = expandUnicodeEscapes(q)  # type: ignore[arg-type]
     return UpdateUnit.parseString(q, parseAll=True)[0]

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -6,9 +6,9 @@ based on pyparsing
 
 import re
 import sys
-from typing import IO, Any
+from typing import Any, BinaryIO
 from typing import Optional as OptionalType
-from typing import Tuple, Union
+from typing import TextIO, Tuple, Union
 
 from pyparsing import CaselessKeyword as Keyword  # watch out :)
 from pyparsing import (
@@ -1531,24 +1531,22 @@ def expandUnicodeEscapes(q: str) -> str:
     return expandUnicodeEscapes_re.sub(expand, q)
 
 
-def parseQuery(q: Union[str, bytes, IO]) -> ParseResults:
+def parseQuery(q: Union[str, bytes, TextIO, BinaryIO]) -> ParseResults:
     if hasattr(q, "read"):
         q = q.read()
     if isinstance(q, bytes):
         q = q.decode("utf-8")
 
-    # type error: Argument 1 to "expandUnicodeEscapes" has incompatible type "Union[str, IO[Any]]"; expected "str"
-    q = expandUnicodeEscapes(q)  # type: ignore[arg-type]
+    q = expandUnicodeEscapes(q)
     return Query.parseString(q, parseAll=True)
 
 
-def parseUpdate(q: Union[str, bytes, IO]):
+def parseUpdate(q: Union[str, bytes, TextIO, BinaryIO]):
     if hasattr(q, "read"):
         q = q.read()
 
     if isinstance(q, bytes):
         q = q.decode("utf-8")
 
-    # type error: Argument 1 to "expandUnicodeEscapes" has incompatible type "Union[str, IO[Any]]"; expected "str"
-    q = expandUnicodeEscapes(q)  # type: ignore[arg-type]
+    q = expandUnicodeEscapes(q)
     return UpdateUnit.parseString(q, parseAll=True)[0]

--- a/test/test_sparql/test_sparql.py
+++ b/test/test_sparql/test_sparql.py
@@ -972,7 +972,7 @@ def test_sparql_describe(
         (r"1234\u001000e5", "1234\U001000e5", True),
     ],
 )
-def test_expandUnicodeEscapes(arg: str, expected_result: str, expected_valid: bool):
+def test_expand_unicode_escapes(arg: str, expected_result: str, expected_valid: bool):
     if expected_valid:
         actual_result = expandUnicodeEscapes(arg)
         assert actual_result == expected_result


### PR DESCRIPTION

<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

Here, adding type-hints to some of the SPARQL parser plugin code.

Includes a couple of small consequent changes:

1. Minor refactor of `prettify_parsetree()`, separating the public-facing callable from the internal code that does not need to be public-facing.  That allows the public-facing callable to have more informative and restrictive type-hints for its arguments.
2. Added some test-coverage for `expandUnicodeEscapes()` - initially for my own understanding, but seems useful to leave it in place since I didn't see test-coverage for that function.

There should be no backwards-incompatible changes in this PR - at least, not intentionally.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
  - [ ] Considered adding an example in `./examples` for new features.
  - [ ] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

