### PR TITLE
feat: more type hints for `rdflib.plugins.sparql`

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -51,7 +51,6 @@ from rdflib.term import (
     Node,
     RDFLibGenid,
     URIRef,
-    Variable,
 )
 
 if TYPE_CHECKING:
@@ -1501,7 +1500,7 @@ class Graph(Node):
         processor: Union[str, query.Processor] = "sparql",
         result: Union[str, Type[query.Result]] = "sparql",
         initNs: Optional[Mapping[str, Any]] = None,  # noqa: N803
-        initBindings: Optional[Mapping[Variable, Identifier]] = None,
+        initBindings: Optional[Mapping[str, Identifier]] = None,
         use_store_provided: bool = True,
         **kwargs: Any,
     ) -> query.Result:
@@ -1547,7 +1546,7 @@ class Graph(Node):
         update_object: Union[Update, str],
         processor: Union[str, rdflib.query.UpdateProcessor] = "sparql",
         initNs: Optional[Mapping[str, Any]] = None,  # noqa: N803
-        initBindings: Optional[Mapping[Variable, Identifier]] = None,
+        initBindings: Optional[Mapping[str, Identifier]] = None,
         use_store_provided: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -1,10 +1,29 @@
-from decimal import Decimal
+from __future__ import annotations
 
-from rdflib import XSD, Literal
+from decimal import Decimal
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
+
+from rdflib.namespace import XSD
 from rdflib.plugins.sparql.datatypes import type_promotion
-from rdflib.plugins.sparql.evalutils import NotBoundError, _eval, _val
+from rdflib.plugins.sparql.evalutils import _eval, _val
 from rdflib.plugins.sparql.operators import numeric
-from rdflib.plugins.sparql.sparql import SPARQLTypeError
+from rdflib.plugins.sparql.parserutils import CompValue
+from rdflib.plugins.sparql.sparql import FrozenBindings, NotBoundError, SPARQLTypeError
+from rdflib.term import BNode, Identifier, Literal, URIRef, Variable
 
 """
 Aggregation functions
@@ -14,38 +33,43 @@ Aggregation functions
 class Accumulator(object):
     """abstract base class for different aggregation functions"""
 
-    def __init__(self, aggregation):
+    def __init__(self, aggregation: CompValue):
+        self.get_value: Callable[[], Optional[Literal]]
+        self.update: Callable[[FrozenBindings, "Aggregator"], None]
         self.var = aggregation.res
         self.expr = aggregation.vars
         if not aggregation.distinct:
-            self.use_row = self.dont_care
+            # type error: Cannot assign to a method
+            self.use_row = self.dont_care  # type: ignore[assignment]
             self.distinct = False
         else:
             self.distinct = aggregation.distinct
-            self.seen = set()
+            self.seen: Set[Any] = set()
 
-    def dont_care(self, row):
+    def dont_care(self, row: FrozenBindings) -> bool:
         """skips distinct test"""
         return True
 
-    def use_row(self, row):
+    def use_row(self, row: FrozenBindings) -> bool:
         """tests distinct with set"""
         return _eval(self.expr, row) not in self.seen
 
-    def set_value(self, bindings):
+    def set_value(self, bindings: MutableMapping[Variable, Identifier]) -> None:
         """sets final value in bindings"""
-        bindings[self.var] = self.get_value()
+        # type error: Incompatible types in assignment (expression has type "Optional[Literal]", target has type "Identifier")
+        bindings[self.var] = self.get_value()  # type: ignore[assignment]
 
 
 class Counter(Accumulator):
-    def __init__(self, aggregation):
+    def __init__(self, aggregation: CompValue):
         super(Counter, self).__init__(aggregation)
         self.value = 0
         if self.expr == "*":
             # cannot eval "*" => always use the full row
-            self.eval_row = self.eval_full_row
+            # type error: Cannot assign to a method
+            self.eval_row = self.eval_full_row  # type: ignore[assignment]
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             val = self.eval_row(row)
         except NotBoundError:
@@ -55,41 +79,54 @@ class Counter(Accumulator):
         if self.distinct:
             self.seen.add(val)
 
-    def get_value(self):
+    def get_value(self) -> Literal:
         return Literal(self.value)
 
-    def eval_row(self, row):
+    def eval_row(self, row: FrozenBindings) -> Identifier:
         return _eval(self.expr, row)
 
-    def eval_full_row(self, row):
+    def eval_full_row(self, row: FrozenBindings) -> FrozenBindings:
         return row
 
-    def use_row(self, row):
+    def use_row(self, row: FrozenBindings) -> bool:
         return self.eval_row(row) not in self.seen
 
 
-def type_safe_numbers(*args):
+@overload
+def type_safe_numbers(*args: int) -> Tuple[int]:
+    ...
+
+
+@overload
+def type_safe_numbers(*args: Union[Decimal, float, int]) -> Tuple[Union[float, int]]:
+    ...
+
+
+def type_safe_numbers(*args: Union[Decimal, float, int]) -> Iterable[Union[float, int]]:
     if any(isinstance(arg, float) for arg in args) and any(
         isinstance(arg, Decimal) for arg in args
     ):
         return map(float, args)
-    return args
+    # type error: Incompatible return value type (got "Tuple[Union[Decimal, float, int], ...]", expected "Iterable[Union[float, int]]")
+    # NOTE on type error: if args contains a Decimal it will nopt get here.
+    return args  # type: ignore[return-value]
 
 
 class Sum(Accumulator):
-    def __init__(self, aggregation):
+    def __init__(self, aggregation: CompValue):
         super(Sum, self).__init__(aggregation)
         self.value = 0
-        self.datatype = None
+        self.datatype: Optional[str] = None
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             value = _eval(self.expr, row)
             dt = self.datatype
             if dt is None:
                 dt = value.datatype
             else:
-                dt = type_promotion(dt, value.datatype)
+                # type error: Argument 1 to "type_promotion" has incompatible type "str"; expected "URIRef"
+                dt = type_promotion(dt, value.datatype)  # type: ignore[arg-type]
             self.datatype = dt
             self.value = sum(type_safe_numbers(self.value, numeric(value)))
             if self.distinct:
@@ -98,18 +135,18 @@ class Sum(Accumulator):
             # skip UNDEF
             pass
 
-    def get_value(self):
+    def get_value(self) -> Literal:
         return Literal(self.value, datatype=self.datatype)
 
 
 class Average(Accumulator):
-    def __init__(self, aggregation):
+    def __init__(self, aggregation: CompValue):
         super(Average, self).__init__(aggregation)
         self.counter = 0
         self.sum = 0
-        self.datatype = None
+        self.datatype: Optional[str] = None
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             value = _eval(self.expr, row)
             dt = self.datatype
@@ -117,7 +154,8 @@ class Average(Accumulator):
             if dt is None:
                 dt = value.datatype
             else:
-                dt = type_promotion(dt, value.datatype)
+                # type error: Argument 1 to "type_promotion" has incompatible type "str"; expected "URIRef"
+                dt = type_promotion(dt, value.datatype)  # type: ignore[arg-type]
             self.datatype = dt
             if self.distinct:
                 self.seen.add(value)
@@ -128,7 +166,7 @@ class Average(Accumulator):
         except SPARQLTypeError:
             pass
 
-    def get_value(self):
+    def get_value(self) -> Literal:
         if self.counter == 0:
             return Literal(0)
         if self.datatype in (XSD.float, XSD.double):
@@ -140,18 +178,20 @@ class Average(Accumulator):
 class Extremum(Accumulator):
     """abstract base class for Minimum and Maximum"""
 
-    def __init__(self, aggregation):
+    def __init__(self, aggregation: CompValue):
+        self.compare: Callable[[Any, Any], Any]
         super(Extremum, self).__init__(aggregation)
-        self.value = None
+        self.value: Any = None
         # DISTINCT would not change the value for MIN or MAX
-        self.use_row = self.dont_care
+        # type error: Cannot assign to a method
+        self.use_row = self.dont_care  # type: ignore[assignment]
 
-    def set_value(self, bindings):
+    def set_value(self, bindings: MutableMapping[Variable, Identifier]) -> None:
         if self.value is not None:
             # simply do not set if self.value is still None
             bindings[self.var] = Literal(self.value)
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             if self.value is None:
                 self.value = _eval(self.expr, row)
@@ -165,13 +205,16 @@ class Extremum(Accumulator):
             pass
 
 
+_ValueT = TypeVar("_ValueT", Variable, BNode, URIRef, Literal)
+
+
 class Minimum(Extremum):
-    def compare(self, val1, val2):
+    def compare(self, val1: _ValueT, val2: _ValueT) -> _ValueT:
         return min(val1, val2, key=_val)
 
 
 class Maximum(Extremum):
-    def compare(self, val1, val2):
+    def compare(self, val1: _ValueT, val2: _ValueT) -> _ValueT:
         return max(val1, val2, key=_val)
 
 
@@ -183,7 +226,7 @@ class Sample(Accumulator):
         # DISTINCT would not change the value
         self.use_row = self.dont_care
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             # set the value now
             aggregator.bindings[self.var] = _eval(self.expr, row)
@@ -192,7 +235,7 @@ class Sample(Accumulator):
         except NotBoundError:
             pass
 
-    def get_value(self):
+    def get_value(self) -> None:
         # set None if no value was set
         return None
 
@@ -204,7 +247,7 @@ class GroupConcat(Accumulator):
         self.value = []
         self.separator = aggregation.separator or " "
 
-    def update(self, row, aggregator):
+    def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:
             value = _eval(self.expr, row)
             # skip UNDEF
@@ -221,7 +264,7 @@ class GroupConcat(Accumulator):
         except NotBoundError:
             pass
 
-    def get_value(self):
+    def get_value(self) -> Literal:
         return Literal(self.separator.join(str(v) for v in self.value))
 
 
@@ -238,16 +281,16 @@ class Aggregator(object):
         "Aggregate_GroupConcat": GroupConcat,
     }
 
-    def __init__(self, aggregations):
-        self.bindings = {}
-        self.accumulators = {}
+    def __init__(self, aggregations: List[CompValue]):
+        self.bindings: Dict[Variable, Identifier] = {}
+        self.accumulators: Dict[str, Accumulator] = {}
         for a in aggregations:
             accumulator_class = self.accumulator_classes.get(a.name)
             if accumulator_class is None:
                 raise Exception("Unknown aggregate function " + a.name)
             self.accumulators[a.res] = accumulator_class(a)
 
-    def update(self, row):
+    def update(self, row: FrozenBindings) -> None:
         """update all own accumulators"""
         # SAMPLE accumulators may delete themselves
         # => iterate over list not generator
@@ -256,7 +299,7 @@ class Aggregator(object):
             if acc.use_row(row):
                 acc.update(row, self)
 
-    def get_bindings(self):
+    def get_bindings(self) -> Mapping[Variable, Identifier]:
         """calculate and set last values"""
         for acc in self.accumulators.values():
             acc.set_value(self.bindings)

--- a/rdflib/plugins/sparql/datatypes.py
+++ b/rdflib/plugins/sparql/datatypes.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
+
 """
 Utility functions for supporting the XML Schema Datatypes hierarchy
 """
 
-from rdflib import XSD
+from rdflib.namespace import XSD
 
-XSD_DTs = set(
+if TYPE_CHECKING:
+    from rdflib.term import URIRef
+
+XSD_DTs: Set[URIRef] = set(
     (
         XSD.integer,
         XSD.decimal,
@@ -35,7 +42,7 @@ XSD_DateTime_DTs = set((XSD.dateTime, XSD.date, XSD.time))
 
 XSD_Duration_DTs = set((XSD.duration, XSD.dayTimeDuration, XSD.yearMonthDuration))
 
-_sub_types = {
+_sub_types: Dict[URIRef, List[URIRef]] = {
     XSD.integer: [
         XSD.nonPositiveInteger,
         XSD.negativeInteger,
@@ -52,13 +59,13 @@ _sub_types = {
     ],
 }
 
-_super_types = {}
+_super_types: Dict[URIRef, URIRef] = {}
 for superdt in XSD_DTs:
     for subdt in _sub_types.get(superdt, []):
         _super_types[subdt] = superdt
 
 # we only care about float, double, integer, decimal
-_typePromotionMap = {
+_typePromotionMap: Dict[URIRef, Dict[URIRef, URIRef]] = {
     XSD.float: {XSD.integer: XSD.float, XSD.decimal: XSD.float, XSD.double: XSD.double},
     XSD.double: {
         XSD.integer: XSD.double,
@@ -78,7 +85,7 @@ _typePromotionMap = {
 }
 
 
-def type_promotion(t1, t2):
+def type_promotion(t1: URIRef, t2: Optional[URIRef]) -> URIRef:
     if t2 is None:
         return t1
     t1 = _super_types.get(t1, t1)
@@ -86,6 +93,9 @@ def type_promotion(t1, t2):
     if t1 == t2:
         return t1  # matching super-types
     try:
+        if TYPE_CHECKING:
+            # type assert because mypy is confused and thinks t2 can be None
+            assert t2 is not None
         return _typePromotionMap[t1][t2]
     except KeyError:
         raise TypeError("Operators cannot combine datatypes %s and %s" % (t1, t2))

--- a/rdflib/plugins/sparql/evalutils.py
+++ b/rdflib/plugins/sparql/evalutils.py
@@ -1,13 +1,37 @@
+from __future__ import annotations
+
 import collections
-from typing import Dict, Iterable
+from typing import (
+    Any,
+    DefaultDict,
+    Generator,
+    Iterable,
+    Mapping,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from rdflib.plugins.sparql.operators import EBV
 from rdflib.plugins.sparql.parserutils import CompValue, Expr
-from rdflib.plugins.sparql.sparql import FrozenDict, NotBoundError, SPARQLError
-from rdflib.term import BNode, Literal, URIRef, Variable
+from rdflib.plugins.sparql.sparql import (
+    FrozenBindings,
+    FrozenDict,
+    NotBoundError,
+    QueryContext,
+    SPARQLError,
+)
+from rdflib.term import BNode, Identifier, Literal, URIRef, Variable
+
+_ContextType = Union[FrozenBindings, QueryContext]
+_FrozenDictT = TypeVar("_FrozenDictT", bound=FrozenDict)
 
 
-def _diff(a: Iterable[FrozenDict], b: Iterable[FrozenDict], expr):
+def _diff(
+    a: Iterable[_FrozenDictT], b: Iterable[_FrozenDictT], expr
+) -> Set[_FrozenDictT]:
     res = set()
 
     for x in a:
@@ -17,20 +41,38 @@ def _diff(a: Iterable[FrozenDict], b: Iterable[FrozenDict], expr):
     return res
 
 
-def _minus(a: Iterable[FrozenDict], b: Iterable[FrozenDict]):
+def _minus(
+    a: Iterable[_FrozenDictT], b: Iterable[_FrozenDictT]
+) -> Generator[_FrozenDictT, None, None]:
     for x in a:
         if all((not x.compatible(y)) or x.disjointDomain(y) for y in b):
             yield x
 
 
-def _join(a: Iterable[FrozenDict], b: Iterable[Dict]):
+@overload
+def _join(
+    a: Iterable[FrozenBindings], b: Iterable[Mapping[Identifier, Identifier]]
+) -> Generator[FrozenBindings, None, None]:
+    ...
+
+
+@overload
+def _join(
+    a: Iterable[FrozenDict], b: Iterable[Mapping[Identifier, Identifier]]
+) -> Generator[FrozenDict, None, None]:
+    ...
+
+
+def _join(
+    a: Iterable[FrozenDict], b: Iterable[Mapping[Identifier, Identifier]]
+) -> Generator[FrozenDict, None, None]:
     for x in a:
         for y in b:
             if x.compatible(y):
                 yield x.merge(y)
 
 
-def _ebv(expr, ctx):
+def _ebv(expr: Union[Literal, Variable, Expr], ctx: FrozenDict) -> bool:
     """
     Return true/false for the given expr
     Either the expr is itself true/false
@@ -48,7 +90,8 @@ def _ebv(expr, ctx):
             return EBV(expr.eval(ctx))
         except SPARQLError:
             return False  # filter error == False
-    elif isinstance(expr, CompValue):
+    # type error: Subclass of "Literal" and "CompValue" cannot exist: would have incompatible method signatures
+    elif isinstance(expr, CompValue):  # type: ignore[unreachable]
         raise Exception("Weird - filter got a CompValue without evalfn! %r" % expr)
     elif isinstance(expr, Variable):
         try:
@@ -58,7 +101,29 @@ def _ebv(expr, ctx):
     return False
 
 
-def _eval(expr, ctx, raise_not_bound_error=True):
+@overload
+def _eval(
+    expr: Union[Literal, URIRef],
+    ctx: FrozenBindings,
+    raise_not_bound_error: bool = ...,
+) -> Union[Literal, URIRef]:
+    ...
+
+
+@overload
+def _eval(
+    expr: Union[Variable, Expr],
+    ctx: FrozenBindings,
+    raise_not_bound_error: bool = ...,
+) -> Union[Any, SPARQLError]:
+    ...
+
+
+def _eval(
+    expr: Union[Literal, URIRef, Variable, Expr],
+    ctx: FrozenBindings,
+    raise_not_bound_error: bool = True,
+) -> Any:
     if isinstance(expr, (Literal, URIRef)):
         return expr
     if isinstance(expr, Expr):
@@ -71,26 +136,31 @@ def _eval(expr, ctx, raise_not_bound_error=True):
                 raise NotBoundError("Variable %s is not bound" % expr)
             else:
                 return None
-    elif isinstance(expr, CompValue):
+    elif isinstance(expr, CompValue):  # type: ignore[unreachable]
         raise Exception("Weird - _eval got a CompValue without evalfn! %r" % expr)
     else:
         raise Exception("Cannot eval thing: %s (%s)" % (expr, type(expr)))
 
 
-def _filter(a, expr):
+def _filter(
+    a: Iterable[FrozenDict], expr: Union[Literal, Variable, Expr]
+) -> Generator[FrozenDict, None, None]:
     for c in a:
         if _ebv(expr, c):
             yield c
 
 
-def _fillTemplate(template, solution):
+def _fillTemplate(
+    template: Iterable[Tuple[Identifier, Identifier, Identifier]],
+    solution: _ContextType,
+) -> Generator[Tuple[Identifier, Identifier, Identifier], None, None]:
     """
     For construct/deleteWhere and friends
 
     Fill a triple template with instantiated variables
     """
 
-    bnodeMap = collections.defaultdict(BNode)
+    bnodeMap: DefaultDict[BNode, BNode] = collections.defaultdict(BNode)
     for t in template:
         s, p, o = t
 
@@ -107,7 +177,10 @@ def _fillTemplate(template, solution):
             yield (_s, _p, _o)
 
 
-def _val(v):
+_ValueT = TypeVar("_ValueT", Variable, BNode, URIRef, Literal)
+
+
+def _val(v: _ValueT) -> Tuple[int, _ValueT]:
     """utilitity for ordering things"""
     if isinstance(v, Variable):
         return (0, v)

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -3,10 +3,11 @@ SPARQL 1.1 Parser
 
 based on pyparsing
 """
+from __future__ import annotations
 
 import re
 import sys
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, List
 from typing import Optional as OptionalType
 from typing import TextIO, Tuple, Union
 
@@ -30,7 +31,7 @@ import rdflib
 from rdflib.compat import decodeUnicodeEscape
 
 from . import operators as op
-from .parserutils import Comp, Param, ParamList
+from .parserutils import Comp, CompValue, Param, ParamList
 
 # from pyparsing import Keyword as CaseSensitiveKeyword
 
@@ -40,7 +41,7 @@ DEBUG = False
 # ---------------- ACTIONS
 
 
-def neg(literal) -> rdflib.Literal:
+def neg(literal: rdflib.Literal) -> rdflib.Literal:
     return rdflib.Literal(-literal, datatype=literal.datatype)
 
 
@@ -52,13 +53,13 @@ def setDataType(terms: Tuple[Any, OptionalType[str]]) -> rdflib.Literal:
     return rdflib.Literal(terms[0], datatype=terms[1])
 
 
-def expandTriples(terms):
+def expandTriples(terms: ParseResults) -> List[Any]:
     """
     Expand ; and , syntax for repeat predicates, subjects
     """
     # import pdb; pdb.set_trace()
     try:
-        res = []
+        res: List[Any] = []
         if DEBUG:
             print("Terms", terms)
         l_ = len(terms)
@@ -105,7 +106,7 @@ def expandTriples(terms):
         raise
 
 
-def expandBNodeTriples(terms):
+def expandBNodeTriples(terms: ParseResults) -> List[Any]:
     """
     expand [ ?p ?o ] syntax for implicit bnodes
     """
@@ -122,14 +123,14 @@ def expandBNodeTriples(terms):
         raise
 
 
-def expandCollection(terms):
+def expandCollection(terms: ParseResults) -> List[List[Any]]:
     """
     expand ( 1 2 3 ) notation for collections
     """
     if DEBUG:
         print("Collection: ", terms)
 
-    res = []
+    res: List[Any] = []
     other = []
     for x in terms:
         if isinstance(x, list):  # is this a [ .. ] ?
@@ -1541,7 +1542,7 @@ def parseQuery(q: Union[str, bytes, TextIO, BinaryIO]) -> ParseResults:
     return Query.parseString(q, parseAll=True)
 
 
-def parseUpdate(q: Union[str, bytes, TextIO, BinaryIO]):
+def parseUpdate(q: Union[str, bytes, TextIO, BinaryIO]) -> CompValue:
     if hasattr(q, "read"):
         q = q.read()
 

--- a/rdflib/plugins/sparql/processor.py
+++ b/rdflib/plugins/sparql/processor.py
@@ -4,17 +4,23 @@ Code for tying SPARQL Engine into RDFLib
 These should be automatically registered with RDFLib
 
 """
+from __future__ import annotations
 
+from typing import Any, Mapping, Optional, Union
 
+from rdflib.graph import Graph
 from rdflib.plugins.sparql.algebra import translateQuery, translateUpdate
 from rdflib.plugins.sparql.evaluate import evalQuery
 from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
-from rdflib.plugins.sparql.sparql import Query
+from rdflib.plugins.sparql.sparql import Query, Update
 from rdflib.plugins.sparql.update import evalUpdate
 from rdflib.query import Processor, Result, UpdateProcessor
+from rdflib.term import Identifier
 
 
-def prepareQuery(queryString, initNs={}, base=None) -> Query:
+def prepareQuery(
+    queryString: str, initNs: Mapping[str, Any] = {}, base: Optional[str] = None
+) -> Query:
     """
     Parse and translate a SPARQL Query
     """
@@ -23,7 +29,9 @@ def prepareQuery(queryString, initNs={}, base=None) -> Query:
     return ret
 
 
-def prepareUpdate(updateString, initNs={}, base=None):
+def prepareUpdate(
+    updateString: str, initNs: Mapping[str, Any] = {}, base: Optional[str] = None
+) -> Update:
     """
     Parse and translate a SPARQL Update
     """
@@ -32,7 +40,13 @@ def prepareUpdate(updateString, initNs={}, base=None):
     return ret
 
 
-def processUpdate(graph, updateString, initBindings={}, initNs={}, base=None):
+def processUpdate(
+    graph: Graph,
+    updateString: str,
+    initBindings: Mapping[str, Identifier] = {},
+    initNs: Mapping[str, Any] = {},
+    base: Optional[str] = None,
+) -> None:
     """
     Process a SPARQL Update Request
     returns Nothing on success or raises Exceptions on error
@@ -43,10 +57,11 @@ def processUpdate(graph, updateString, initBindings={}, initNs={}, base=None):
 
 
 class SPARQLResult(Result):
-    def __init__(self, res):
+    def __init__(self, res: Mapping[str, Any]):
         Result.__init__(self, res["type_"])
         self.vars = res.get("vars_")
-        self.bindings = res.get("bindings")
+        # type error: Incompatible types in assignment (expression has type "Optional[Any]", variable has type "MutableSequence[Mapping[Variable, Identifier]]")
+        self.bindings = res.get("bindings")  # type: ignore[assignment]
         self.askAnswer = res.get("askAnswer")
         self.graph = res.get("graph")
 
@@ -55,7 +70,12 @@ class SPARQLUpdateProcessor(UpdateProcessor):
     def __init__(self, graph):
         self.graph = graph
 
-    def update(self, strOrQuery, initBindings={}, initNs={}):
+    def update(
+        self,
+        strOrQuery: Union[str, Update],
+        initBindings: Mapping[str, Identifier] = {},
+        initNs: Mapping[str, Any] = {},
+    ) -> None:
         if isinstance(strOrQuery, str):
             strOrQuery = translateUpdate(parseUpdate(strOrQuery), initNs=initNs)
 
@@ -66,7 +86,18 @@ class SPARQLProcessor(Processor):
     def __init__(self, graph):
         self.graph = graph
 
-    def query(self, strOrQuery, initBindings={}, initNs={}, base=None, DEBUG=False):
+    # NOTE on type error: this is because the super type constructor does not
+    # accept base argument and thie position of the DEBUG argument is
+    # different.
+    # type error: Signature of "query" incompatible with supertype "Processor"
+    def query(  # type: ignore[override]
+        self,
+        strOrQuery: Union[str, Query],
+        initBindings: Mapping[str, Identifier] = {},
+        initNs: Mapping[str, Any] = {},
+        base: Optional[str] = None,
+        DEBUG: bool = False,
+    ) -> Mapping[str, Any]:
         """
         Evaluate a query with the given initial bindings, and initial
         namespaces. The given base is used to resolve relative URIs in

--- a/rdflib/plugins/sparql/update.py
+++ b/rdflib/plugins/sparql/update.py
@@ -3,29 +3,38 @@
 Code for carrying out Update Operations
 
 """
+from __future__ import annotations
 
-from rdflib import Graph, Variable
+from typing import TYPE_CHECKING, Iterator, Mapping, Optional, Sequence
+
+from rdflib.graph import Graph
 from rdflib.plugins.sparql.evaluate import evalBGP, evalPart
 from rdflib.plugins.sparql.evalutils import _fillTemplate, _join
-from rdflib.plugins.sparql.sparql import QueryContext
+from rdflib.plugins.sparql.parserutils import CompValue
+from rdflib.plugins.sparql.sparql import FrozenDict, QueryContext, Update
+from rdflib.term import Identifier, URIRef, Variable
 
 
-def _graphOrDefault(ctx, g):
+def _graphOrDefault(ctx: QueryContext, g: str) -> Optional[Graph]:
     if g == "DEFAULT":
         return ctx.graph
     else:
         return ctx.dataset.get_context(g)
 
 
-def _graphAll(ctx, g):
+def _graphAll(ctx: QueryContext, g: str) -> Sequence[Graph]:
     """
     return a list of graphs
     """
     if g == "DEFAULT":
-        return [ctx.graph]
+        # type error: List item 0 has incompatible type "Optional[Graph]"; expected "Graph"
+        return [ctx.graph]  # type: ignore[list-item]
     elif g == "NAMED":
         return [
-            c for c in ctx.dataset.contexts() if c.identifier != ctx.graph.identifier
+            # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+            c
+            for c in ctx.dataset.contexts()
+            if c.identifier != ctx.graph.identifier  # type: ignore[union-attr]
         ]
     elif g == "ALL":
         return list(ctx.dataset.contexts())
@@ -33,10 +42,13 @@ def _graphAll(ctx, g):
         return [ctx.dataset.get_context(g)]
 
 
-def evalLoad(ctx, u):
+def evalLoad(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#load
     """
+
+    if TYPE_CHECKING:
+        assert isinstance(u.iri, URIRef)
 
     if u.graphiri:
         ctx.load(u.iri, default=False, publicID=u.graphiri)
@@ -44,7 +56,7 @@ def evalLoad(ctx, u):
         ctx.load(u.iri, default=True)
 
 
-def evalCreate(ctx, u):
+def evalCreate(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#create
     """
@@ -54,16 +66,15 @@ def evalCreate(ctx, u):
     raise Exception("Create not implemented!")
 
 
-def evalClear(ctx, u):
+def evalClear(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#clear
     """
-
     for g in _graphAll(ctx, u.graphiri):
         g.remove((None, None, None))
 
 
-def evalDrop(ctx, u):
+def evalDrop(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#drop
     """
@@ -74,22 +85,22 @@ def evalDrop(ctx, u):
         evalClear(ctx, u)
 
 
-def evalInsertData(ctx, u):
+def evalInsertData(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#insertData
     """
     # add triples
     g = ctx.graph
     g += u.triples
-
     # add quads
     # u.quads is a dict of graphURI=>[triples]
     for g in u.quads:
-        cg = ctx.dataset.get_context(g)
+        # type error: Argument 1 to "get_context" of "ConjunctiveGraph" has incompatible type "Optional[Graph]"; expected "Union[IdentifiedNode, str, None]"
+        cg = ctx.dataset.get_context(g)  # type: ignore[arg-type]
         cg += u.quads[g]
 
 
-def evalDeleteData(ctx, u):
+def evalDeleteData(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#deleteData
     """
@@ -100,22 +111,24 @@ def evalDeleteData(ctx, u):
     # remove quads
     # u.quads is a dict of graphURI=>[triples]
     for g in u.quads:
-        cg = ctx.dataset.get_context(g)
+        # type error: Argument 1 to "get_context" of "ConjunctiveGraph" has incompatible type "Optional[Graph]"; expected "Union[IdentifiedNode, str, None]"
+        cg = ctx.dataset.get_context(g)  # type: ignore[arg-type]
         cg -= u.quads[g]
 
 
-def evalDeleteWhere(ctx, u):
+def evalDeleteWhere(ctx: QueryContext, u: CompValue) -> None:
     """
     http://www.w3.org/TR/sparql11-update/#deleteWhere
     """
 
-    res = evalBGP(ctx, u.triples)
+    res: Iterator[FrozenDict] = evalBGP(ctx, u.triples)
     for g in u.quads:
         cg = ctx.dataset.get_context(g)
         c = ctx.pushGraph(cg)
         res = _join(res, list(evalBGP(c, u.quads[g])))
 
-    for c in res:
+    # type error: Incompatible types in assignment (expression has type "FrozenBindings", variable has type "QueryContext")
+    for c in res:  # type: ignore[assignment]
         g = ctx.graph
         g -= _fillTemplate(u.triples, c)
 
@@ -124,10 +137,11 @@ def evalDeleteWhere(ctx, u):
             cg -= _fillTemplate(u.quads[g], c)
 
 
-def evalModify(ctx, u):
+def evalModify(ctx: QueryContext, u: CompValue) -> None:
     originalctx = ctx
 
     # Using replaces the dataset for evaluating the where-clause
+    dg: Optional[Graph]
     if u.using:
         otherDefault = False
         for d in u.using:
@@ -169,21 +183,25 @@ def evalModify(ctx, u):
     for c in res:
         dg = ctx.graph
         if u.delete:
-            dg -= _fillTemplate(u.delete.triples, c)
+            # type error: Unsupported left operand type for - ("None")
+            # type error: Unsupported operand types for - ("Graph" and "Generator[Tuple[Identifier, Identifier, Identifier], None, None]")
+            dg -= _fillTemplate(u.delete.triples, c)  # type: ignore[operator]
 
             for g, q in u.delete.quads.items():
                 cg = ctx.dataset.get_context(c.get(g))
                 cg -= _fillTemplate(q, c)
 
         if u.insert:
-            dg += _fillTemplate(u.insert.triples, c)
+            # type error: Unsupported left operand type for + ("None")
+            # type error: Unsupported operand types for + ("Graph" and "Generator[Tuple[Identifier, Identifier, Identifier], None, None]")
+            dg += _fillTemplate(u.insert.triples, c)  # type: ignore[operator]
 
             for g, q in u.insert.quads.items():
                 cg = ctx.dataset.get_context(c.get(g))
                 cg += _fillTemplate(q, c)
 
 
-def evalAdd(ctx, u):
+def evalAdd(ctx: QueryContext, u: CompValue) -> None:
     """
 
     add all triples from src to dst
@@ -195,13 +213,15 @@ def evalAdd(ctx, u):
     srcg = _graphOrDefault(ctx, src)
     dstg = _graphOrDefault(ctx, dst)
 
-    if srcg.identifier == dstg.identifier:
+    # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+    if srcg.identifier == dstg.identifier:  # type: ignore[union-attr]
         return
 
-    dstg += srcg
+    # type error: Unsupported left operand type for + ("None")
+    dstg += srcg  # type: ignore[operator]
 
 
-def evalMove(ctx, u):
+def evalMove(ctx: QueryContext, u: CompValue) -> None:
     """
 
     remove all triples from dst
@@ -216,20 +236,25 @@ def evalMove(ctx, u):
     srcg = _graphOrDefault(ctx, src)
     dstg = _graphOrDefault(ctx, dst)
 
-    if srcg.identifier == dstg.identifier:
+    # type error: Item "None" of "Optional[Graph]" has no attribute "identifier"
+    if srcg.identifier == dstg.identifier:  # type: ignore[union-attr]
         return
 
-    dstg.remove((None, None, None))
+    # type error: Item "None" of "Optional[Graph]" has no attribute "remove"
+    dstg.remove((None, None, None))  # type: ignore[union-attr]
 
-    dstg += srcg
+    # type error: Unsupported left operand type for + ("None")
+    dstg += srcg  # type: ignore[operator]
 
     if ctx.dataset.store.graph_aware:
-        ctx.dataset.store.remove_graph(srcg)
+        # type error: Argument 1 to "remove_graph" of "Store" has incompatible type "Optional[Graph]"; expected "Graph"
+        ctx.dataset.store.remove_graph(srcg)  # type: ignore[arg-type]
     else:
-        srcg.remove((None, None, None))
+        # type error: Item "None" of "Optional[Graph]" has no attribute "remove"
+        srcg.remove((None, None, None))  # type: ignore[union-attr]
 
 
-def evalCopy(ctx, u):
+def evalCopy(ctx: QueryContext, u: CompValue) -> None:
     """
 
     remove all triples from dst
@@ -243,15 +268,20 @@ def evalCopy(ctx, u):
     srcg = _graphOrDefault(ctx, src)
     dstg = _graphOrDefault(ctx, dst)
 
-    if srcg.identifier == dstg.identifier:
+    # type error: Item "None" of "Optional[Graph]" has no attribute "remove"
+    if srcg.identifier == dstg.identifier:  # type: ignore[union-attr]
         return
 
-    dstg.remove((None, None, None))
+    # type error: Item "None" of "Optional[Graph]" has no attribute "remove"
+    dstg.remove((None, None, None))  # type: ignore[union-attr]
 
-    dstg += srcg
+    # type error: Unsupported left operand type for + ("None")
+    dstg += srcg  # type: ignore[operator]
 
 
-def evalUpdate(graph, update, initBindings={}):
+def evalUpdate(
+    graph: Graph, update: Update, initBindings: Mapping[str, Identifier] = {}
+) -> None:
     """
 
     http://www.w3.org/TR/sparql11-update/#updateLanguage

--- a/rdflib/plugins/stores/memory.py
+++ b/rdflib/plugins/stores/memory.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     )
     from rdflib.plugins.sparql.sparql import Query, Update
     from rdflib.query import Result
-    from rdflib.term import Identifier, URIRef, Variable
+    from rdflib.term import Identifier, URIRef
 
 __all__ = ["SimpleMemory", "Memory"]
 
@@ -246,7 +246,7 @@ class SimpleMemory(Store):
         self,
         query: Union["Query", str],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: "str",  # noqa: N803
         **kwargs: Any,
     ) -> "Result":
@@ -258,7 +258,7 @@ class SimpleMemory(Store):
         self,
         update: Union["Update", str],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: "str",  # noqa: N803
         **kwargs: Any,
     ) -> None:
@@ -722,7 +722,7 @@ class Memory(Store):
         self,
         query: Union["Query", str],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: "str",
         **kwargs,
     ) -> "Result":
@@ -732,7 +732,7 @@ class Memory(Store):
         self,
         update: Union["Update", Any],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: "str",
         **kwargs,
     ) -> None:

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -193,7 +193,7 @@ class SPARQLStore(SPARQLConnector, Store):
         self,
         query: Union["Update", str],
         initNs: Dict[str, Any] = {},  # noqa: N803
-        initBindings: Dict["Variable", "Identifier"] = {},
+        initBindings: Dict["str", "Identifier"] = {},
         queryGraph: "Identifier" = None,
         DEBUG: bool = False,
     ) -> None:
@@ -222,7 +222,7 @@ class SPARQLStore(SPARQLConnector, Store):
         self,
         query: Union["Query", str],
         initNs: Optional[Mapping[str, Any]] = None,  # noqa: N803
-        initBindings: Optional[Mapping["Variable", "Identifier"]] = None,
+        initBindings: Optional[Mapping["str", "Identifier"]] = None,
         queryGraph: Optional["str"] = None,
         DEBUG: bool = False,
     ) -> "Result":
@@ -826,7 +826,7 @@ class SPARQLUpdateStore(SPARQLStore):
         self,
         query: Union["Update", str],
         initNs: Dict[str, Any] = {},  # noqa: N803
-        initBindings: Dict["Variable", "Identifier"] = {},
+        initBindings: Dict["str", "Identifier"] = {},
         queryGraph: Optional[str] = None,
         DEBUG: bool = False,
     ):

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -57,7 +57,7 @@ class Processor(object):
     def query(  # type: ignore[empty-body]
         self,
         strOrQuery: Union[str, "Query"],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"] = {},  # noqa: N803
+        initBindings: Mapping["str", "Identifier"] = {},  # noqa: N803
         initNs: Mapping[str, Any] = {},  # noqa: N803
         DEBUG: bool = False,
     ) -> Mapping[str, Any]:
@@ -83,7 +83,7 @@ class UpdateProcessor(object):
     def update(
         self,
         strOrQuery: Union[str, "Update"],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"] = {},  # noqa: N803
+        initBindings: Mapping["str", "Identifier"] = {},  # noqa: N803
         initNs: Mapping[str, Any] = {},
     ) -> None:
         pass

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     )
     from rdflib.plugins.sparql.sparql import Query, Update
     from rdflib.query import Result
-    from rdflib.term import Identifier, Node, URIRef, Variable
+    from rdflib.term import Identifier, Node, URIRef
 
 """
 ============
@@ -392,7 +392,7 @@ class Store(object):
         self,
         query: Union["Query", str],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: str,  # noqa: N803
         **kwargs: Any,
     ) -> "Result":
@@ -415,7 +415,7 @@ class Store(object):
         self,
         update: Union["Update", str],
         initNs: Mapping[str, Any],  # noqa: N803
-        initBindings: Mapping["Variable", "Identifier"],  # noqa: N803
+        initBindings: Mapping["str", "Identifier"],  # noqa: N803
         queryGraph: str,  # noqa: N803
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

A bit of a roundabout reason why this matters now, but basically:

I want to add examples for securing RDFLib with `sys.addaudithook` and `urllib.request.install_opener`. I also want to be sure examples are actually valid, and runnable, so I was adding static analysis and simple execution of examples to our CI.

During this I noticed that examples use `initBindings` with `Dict[str,...]`, which was not valid according to mypy, but then after some investigation I realized the type hints in some places were too strict.

So the main impetus for this is actually to relax the type hints in `rdflib.graph`, but to ensure this is valid I'm adding a bunch of type hints I had saved up to `rdflib.plugins.sparql`.

Even though this PR looks big, it has no runtime changes, as can be seen from the compact diff [here](https://gist.github.com/aucampia/37995587ce3296f74f7ed32e1943689d).

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

