### PR TITLE
Fix typo in NamespaceManager documentation

### DIFF
--- a/docs/namespaces_and_bindings.rst
+++ b/docs/namespaces_and_bindings.rst
@@ -70,7 +70,7 @@ Valid strategies are:
 * rdflib:
     * binds all the namespaces shipped with RDFLib as DefinedNamespace instances
     * all the core namespaces and all the following: brick, csvw, dc, dcat
-    * dcmitype, cdterms, dcam, doap, foaf, geo, odrl, org, prof, prov, qb, sdo
+    * dcmitype, dcterms, dcam, doap, foaf, geo, odrl, org, prof, prov, qb, sdo
     * sh, skos, sosa, ssn, time, vann, void
     * see the NAMESPACE_PREFIXES_RDFLIB object in :class:`rdflib.namespace` for up-to-date list
 * none:


### PR DESCRIPTION
This PR fixes a typo in the NamespaceManager documentation (i.e., `cdterms` -> `dcterms`) suggested by @dargueta in #2196. I deleted the checklist since this is a purely superficial fix.