### PR TITLE
fix: JSON-LD context construction from a `dict`

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -421,13 +421,13 @@ class Context(object):
     ):
         for source in inputs:
             source_url = in_source_url
+            new_base = base
             if isinstance(source, str):
                 source_url = source
                 source_doc_base = base or self.doc_base
                 new_ctx = self._fetch_context(
                     source, source_doc_base, referenced_contexts
                 )
-                new_base = base
                 if new_ctx is None:
                     continue
                 else:

--- a/test/jsonld/test_context.py
+++ b/test/jsonld/test_context.py
@@ -3,6 +3,7 @@ JSON-LD Context Spec
 """
 
 from functools import wraps
+from pathlib import Path
 from typing import Any, Dict
 
 from rdflib.plugins.shared.jsonld import context, errors
@@ -213,3 +214,23 @@ def test_invalid_remote_context():
     ctx_url = "http://example.org/recursive.jsonld"
     SOURCES[ctx_url] = {"key": "value"}
     ctx = Context(ctx_url)
+
+
+def test_file_source(tmp_path: Path) -> None:
+    """
+    A file URI source to `Context` gets processed correctly.
+    """
+    file = tmp_path / "context.jsonld"
+    file.write_text(r"""{ "@context": { "ex": "http://example.com/" } }""")
+    ctx = Context(source=file.as_uri())
+    assert "http://example.com/" == ctx.terms["ex"].id
+
+
+def test_dict_source(tmp_path: Path) -> None:
+    """
+    A dictionary source to `Context` gets processed correctly.
+    """
+    file = tmp_path / "context.jsonld"
+    file.write_text(r"""{ "@context": { "ex": "http://example.com/" } }""")
+    ctx = Context(source=[{"@context": file.as_uri()}])
+    assert "http://example.com/" == ctx.terms["ex"].id


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

A variable was only being initialized for string-valued inputs, but if a `dict` input was passed the variable would still be accessed, resulting in a `UnboundLocalError`.

This change initializes the variable always, instead of only when string-valued input is used to construct a JSON-LD context.

- Closes <https://github.com/RDFLib/rdflib/issues/2303>.

<!--
Briefly explain what changes the pull request is making and why. Ideally this
should cover all changes in the pull request as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

