### PR TITLE
Widen `Graph.__contains__` type hint

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -105,8 +105,6 @@ _QuadSelectorType = Tuple[
 _TripleOrQuadSelectorType = Union["_TripleSelectorType", "_QuadSelectorType"]
 _TriplePathType = Tuple["_SubjectType", Path, "_ObjectType"]
 _TripleOrTriplePathType = Union["_TripleType", "_TriplePathType"]
-# _QuadPathType = Tuple["_SubjectType", Path, "_ObjectType", "_ContextType"]
-# _QuadOrQuadPathType = Union["_QuadType", "_QuadPathType"]
 
 _GraphT = TypeVar("_GraphT", bound="Graph")
 _ConjunctiveGraphT = TypeVar("_ConjunctiveGraphT", bound="ConjunctiveGraph")

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -675,7 +675,7 @@ class Graph(Node):
         """Iterates over all triples in the store"""
         return self.triples((None, None, None))
 
-    def __contains__(self, triple: _TriplePatternType) -> bool:
+    def __contains__(self, triple: _TripleSelectorType) -> bool:
         """Support for 'triple in graph' syntax"""
         for triple in self.triples(triple):
             return True
@@ -1977,7 +1977,7 @@ class ConjunctiveGraph(Graph):
             c = self._graph(c)
         return s, p, o, c
 
-    def __contains__(self, triple_or_quad: _TripleOrQuadPatternType) -> bool:
+    def __contains__(self, triple_or_quad: _TripleOrQuadSelectorType) -> bool:
         """Support for 'triple/quad in graph' syntax"""
         s, p, o, c = self._spoc(triple_or_quad)
         for t in self.triples((s, p, o), context=c):
@@ -2751,7 +2751,7 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
                 for s1, p1, o1 in graph.triples((s, p, o)):
                     yield s1, p1, o1
 
-    def __contains__(self, triple_or_quad: _TripleOrQuadPatternType) -> bool:
+    def __contains__(self, triple_or_quad: _TripleOrQuadSelectorType) -> bool:
         context = None
         if len(triple_or_quad) == 4:
             # type error: Tuple index out of range


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

As a reminder, PRs that are smaller in size and scope will be reviewed and
merged quicker, so please consider if your PR could be split up into more than
one independent part before submitting it, no PR is too small. The maintainers
of this project may also split up larger PRs into smaller more manageable PRs
if they deem it necessary.

PRs should be reviewed and approved by at least two people other than the
author using GitHub's review system before being merged. Reviews are open to
anyone, so please consider reviewing other open pull requests as this will also
free up the capacity required for your PR to be reviewed.
-->

# Summary of changes

The typing on `Graph.__contains__` doesn't currently allow `rdflib.paths.Path`s in the predicate position of the triple argument, even though the implementation supports this (it calls the `triple` method, which is type hinted to accept `Path`s and handles them fine). This can cause mypy errors for rdflib users on valid code. Minimal repro:

```python
import rdflib

g = rdflib.Graph()


skos_xl_label_path = rdflib.URIRef("http://www.w3.org/2008/05/skos-xl#Label") / rdflib.URIRef("http://www.w3.org/2008/05/skos-xl#literalForm")

print((rdflib.URIRef("http://example.org/ns#bob"), skos_xl_label_path, rdflib.Literal("Bob")) in g)
```

gives a mypy error:

```
test_rdflib_typing.py:8: error: Unsupported operand types for in ("Tuple[URIRef, SequencePath, Literal]" and "Graph")  [operator]
```

which goes away after the change in this PR.

Occurence in my codebase [here](https://github.com/AstraZeneca/KAZU/blob/4f5b5298ce915226eb2e3c1bc699fa3ca2a10aa1/kazu/modelling/ontology_preprocessing/base.py#L779) that triggers the above error (although some context is required to see why, I just wanted to point out that this was a real problem I faced and had to add a # type: ignore for, not just a hypothetical).


I also removed some commented out type hints that aren't used or referenced anywhere while I was staring at them - this looked like useful cleanup but let me know if it isn't and I'll happily remove the commit from the PR.

Thanks for rdflib, and for adding (and distributing) the type hints!

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes. (checked mypy - no new/related errors)
- For changes that have a potential impact on users of this project:
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
  - [ ] Considered adding an example in `./examples` for new features.
  - [ ] Considered updating our changelog (`CHANGELOG.md`).
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

