### PR TITLE
Add a cbd_subject() method

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -951,6 +951,12 @@ class Graph(Node):
         ):
             yield s, p, o
 
+    def roots(self) -> Generator["_SubjectType", None, None]:
+        """A generator of subjects that are roots of the graph"""
+        for s in self.subjects(unique=True):
+            if (None, None, s) not in self:
+                yield s
+
     @overload
     def value(
         self,

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1879,6 +1879,23 @@ class Graph(Node):
 
         return subgraph
 
+    def cbd_subject(self) -> Optional[_SubjectType]:
+        """Determine the subject for which the graph is a Concise Bounded Description
+
+        :return: The subject of the CBD or None
+        """
+        roots = set(self.roots())
+        if len(roots) != 1:
+            # A CBD has exactly one root
+            return None
+        root = roots.pop()
+
+        real_cbd = self.cbd(root)
+        if not real_cbd.isomorphic(self):
+            return None
+
+        return root
+
 
 _ContextType = Graph
 

--- a/test/test_graph/test_graph_cbd.py
+++ b/test/test_graph/test_graph_cbd.py
@@ -159,3 +159,27 @@ def test_cbd_target(rdfs_graph: Graph):
 
     assert result is target
     assert expected_result == set(result.triples((None, None, None)))
+
+
+def test_cbd_subject(get_graph):
+    g = get_graph
+
+    assert g.cbd(EX.R1).cbd_subject() == (
+        EX.R1
+    ), "cbd_subject() for CBD of EX.R1 should be EX.R1"
+    assert g.cbd(EX.R2).cbd_subject() == (
+        EX.R2
+    ), "cbd_subject() for CBD of EX.R2 should be EX.R2"
+    assert g.cbd(EX.R3).cbd_subject() == (
+        EX.R3
+    ), "cbd_subject() for CBD of EX.R3 should be EX.R3"
+    assert g.cbd(EX.R4).cbd_subject() == (
+        None
+    ), "cbd_subject() for CBD of EX.R4 should be None"
+
+    test_g = g.cbd(EX.R1)
+    test_g.add((EX.R2, EX.propOne, EX.P1))
+
+    assert test_g.cbd_subject() is (
+        None
+    ), "cbd_subject() of graph with an additional subject should be None"


### PR DESCRIPTION
# Summary of changes

This PR adds a new `Graph.cbd_subject()` method. It is the counter-part to `Graph.cbd()`: It checks whether the graph is a CBD for some resource and, if it is, returns the subject of that resource.

I need this for implementing federation between graphs, where incoming pushes shall be ckecked to be CBDs because CBDs are nice to test against ACLs (cf. https://socialhub.activitypub.rocks/t/formalizing-inbox-posts-to-be-cbds/3123)

It also adds a `Graph.roots()` method returning the roots of the graph, used as a utility in `cbd_subject`, but also useful otherwise.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Added tests for any changes that have a runtime impact.
- [x] Checked that all tests and type checking passes.
- For changes that have a potential impact on users of this project:
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
  - [ ] Considered adding an example in `./examples` for new features.
  - [ ] Considered updating our changelog (`CHANGELOG.md`).
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

