### PR TITLE
BREAKING CHANGE: Don't use `publicID` as the name for the default graph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Help with maintenance of all of the RDFLib family of packages is always welcome 
 
 ## Versions & Releases
 
-* `6.4.0a0` current `main` branch
+* `7.0.0a0` current `main` branch
 * `6.x.y` current release and support Python 3.7+ only. Many improvements over 5.0.0
     * see [Releases](https://github.com/RDFLib/rdflib/releases)
 * `5.x.y` supports Python 2.7 and 3.4+ and is [mostly backwards compatible with 4.2.2](https://rdflib.readthedocs.io/en/stable/upgrade4to5.html).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ apidoc_output_dir = "apidocs"
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 autodoc_default_options = {"special-members": True}
+autodoc_inherit_docstrings = True
 
 # https://github.com/tox-dev/sphinx-autodoc-typehints
 always_document_param_types = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ If you are familiar with RDF and are looking for details on how RDFLib handles i
    namespaces_and_bindings
    persistence
    merging
+   upgrade6to7
    upgrade5to6
    upgrade4to5
    security_considerations

--- a/docs/upgrade6to7.rst
+++ b/docs/upgrade6to7.rst
@@ -28,7 +28,7 @@ into a named graph, use the following code:
     from rdflib import ConjunctiveGraph
 
     cg = ConjunctiveGraph()
-    cg.get_context("example:graph_name").parse("http://example.com/source.trig", format="trig")
+    cg.get_context("example:graph_name").parse("http://example.com/source.ttl", format="turtle")
 
 If you want to move triples from the default graph into a named graph, use the
 following code:

--- a/docs/upgrade6to7.rst
+++ b/docs/upgrade6to7.rst
@@ -1,0 +1,45 @@
+.. _upgrade4to5: Upgrading from RDFLib version 6 to 7
+
+============================================
+Upgrading 6 to 7
+============================================
+
+New behaviour for ``publicID`` in ``parse`` methods.
+----------------------------------------------------
+
+Before version 7, the ``publicID`` argument to the
+:meth:`~rdflib.graph.ConjunctiveGraph.parse` and
+:meth:`~rdflib.graph.Dataset.parse` methods was used as the name for the default
+graph, and triples from the default graph in a source were loaded into the graph
+named ``publicID``.
+
+In version 7, the ``publicID`` argument is only used as the base URI for relative
+URI resolution as defined in `IETF RFC 3986
+<https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.4>`_.
+
+To accommodate this change, ensure that use of the ``publicID`` argument is
+consistent with the new behaviour.
+
+If you want to load triples from a format that does not support named graphs
+into a named graph, use the following code:
+
+.. code-block:: python
+    
+    from rdflib import ConjunctiveGraph
+
+    cg = ConjunctiveGraph()
+    cg.get_context("example:graph_name").parse("http://example.com/source.trig", format="trig")
+
+If you want to move triples from the default graph into a named graph, use the
+following code:
+
+.. code-block:: python
+
+    from rdflib import ConjunctiveGraph
+
+    cg = ConjunctiveGraph()
+    cg.parse("http://example.com/source.trig", format="trig")
+    destination_graph = cg.get_context("example:graph_name")
+    for triple in cg.default_context.triples((None, None, None)):
+        destination_graph.add(triple)
+        cg.default_context.remove(triple)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rdflib"
-version = "6.4.0a0"
+version = "7.0.0a0"
 description = """RDFLib is a Python library for working with RDF, \
 a simple yet powerful language for representing information."""
 authors = ["Daniel 'eikeon' Krech <eikeon@eikeon.com>"]

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1400,26 +1400,26 @@ class Graph(Node):
            :doc:`Security Considerations </security_considerations>`
            documentation.
 
-        :Parameters:
-
-          - ``source``: An InputSource, file-like object, or string. In the case
-            of a string the string is the location of the source.
-          - ``location``: A string indicating the relative or absolute URL of
-            the source. Graph's absolutize method is used if a relative location
+        :param source: An `InputSource`, file-like object, `Path` like object,
+            or string. In the case of a string the string is the location of the
+            source.
+        :param location: A string indicating the relative or absolute URL of the
+            source. `Graph`'s absolutize method is used if a relative location
             is specified.
-          - ``file``: A file-like object.
-          - ``data``: A string containing the data to be parsed.
-          - ``format``: Used if format can not be determined from source, e.g.
+        :param file: A file-like object.
+        :param data: A string containing the data to be parsed.
+        :param format: Used if format can not be determined from source, e.g.
             file extension or Media Type. Defaults to text/turtle. Format
             support can be extended with plugins, but "xml", "n3" (use for
             turtle), "nt" & "trix" are built in.
-          - ``publicID``: the logical URI to use as the document base. If None
+        :param publicID: the logical URI to use as the document base. If None
             specified the document location is used (at least in the case where
-            there is a document location).
-
-        :Returns:
-
-          - self, the graph instance.
+            there is a document location). This is used as the base URI when
+            resolving relative URIs in the source document, as defined in `IETF
+            RFC 3986
+            <https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.4>`_,
+            given the source document does not define a base URI.
+        :return: ``self``, i.e. the :class:`~rdflib.graph.Graph` instance.
 
         Examples:
 
@@ -2206,15 +2206,18 @@ class ConjunctiveGraph(Graph):
         **args: Any,
     ) -> "Graph":
         """
-        Parse source adding the resulting triples to its own context
-        (sub graph of this graph).
+        Parse source adding the resulting triples to its own context (sub graph
+        of this graph).
 
         See :meth:`rdflib.graph.Graph.parse` for documentation on arguments.
 
+        If the source is in a format that does not support named graphs it's triples
+        will be added to the default graph (i.e. `Dataset.default_context`).
+
         :Returns:
 
-        The graph into which the source was parsed. In the case of n3
-        it returns the root context.
+        The graph into which the source was parsed. In the case of n3 it returns
+        the root context.
 
         .. caution::
 
@@ -2228,6 +2231,14 @@ class ConjunctiveGraph(Graph):
            For information on available security measures, see the RDFLib
            :doc:`Security Considerations </security_considerations>`
            documentation.
+
+        *Changed in 7.0*: The ``publicID`` argument is no longer used as the
+        identifier (i.e. name) of the default graph as was the case before
+        version 7.0. In the case of sources that do not support named graphs,
+        the ``publicID`` parameter will also not be used as the name for the
+        graph that the data is loaded into, and instead the triples from sources
+        that do not support named graphs will be loaded into the default graph
+        (i.e. `ConjunctionGraph.default_context`).
         """
 
         source = create_input_source(
@@ -2246,12 +2257,8 @@ class ConjunctiveGraph(Graph):
         # create_input_source will ensure that publicId is not None, though it
         # would be good if this guarantee was made more explicit i.e. by type
         # hint on InputSource (TODO/FIXME).
-        g_id: str = publicID and publicID or source.getPublicId()
-        if not isinstance(g_id, Node):
-            g_id = URIRef(g_id)
 
-        context = Graph(store=self.store, identifier=g_id)
-        context.remove((None, None, None))  # hmm ?
+        context = self.default_context
         context.parse(source, publicID=publicID, format=format, **args)
         # TODO: FIXME: This should not return context, but self.
         return context
@@ -2459,6 +2466,14 @@ class Dataset(ConjunctiveGraph):
         **args: Any,
     ) -> "Graph":
         """
+        Parse an RDF source adding the resulting triples to the Graph.
+
+        See :meth:`rdflib.graph.Graph.parse` for documentation on arguments.
+
+        The source is specified using one of source, location, file or data.
+
+        If the source is in a format that does not support named graphs it's triples
+        will be added to the default graph (i.e. `Dataset.default_context`).
 
         .. caution::
 
@@ -2472,6 +2487,14 @@ class Dataset(ConjunctiveGraph):
            For information on available security measures, see the RDFLib
            :doc:`Security Considerations </security_considerations>`
            documentation.
+
+        *Changed in 7.0*: The ``publicID`` argument is no longer used as the
+        identifier (i.e. name) of the default graph as was the case before
+        version 7.0. In the case of sources that do not support named graphs,
+        the ``publicID`` parameter will also not be used as the name for the
+        graph that the data is loaded into, and instead the triples from sources
+        that do not support named graphs will be loaded into the default graph
+        (i.e. `ConjunctionGraph.default_context`).
         """
 
         c = ConjunctiveGraph.parse(

--- a/rdflib/plugins/sparql/sparql.py
+++ b/rdflib/plugins/sparql/sparql.py
@@ -312,6 +312,17 @@ class QueryContext:
         return self._dataset
 
     def load(self, source: URIRef, default: bool = False, **kwargs: Any) -> None:
+        """
+        Load data from the source into the query context's.
+
+        :param source: The source to load from.
+        :param default: If `True`, triples from the source will be added to the
+            default graph, otherwise it will be loaded into a graph with
+            ``source`` URI as its name.
+        :param kwargs: Keyword arguments to pass to
+            :meth:`rdflib.graph.Graph.parse`.
+        """
+
         def _load(graph, source):
             try:
                 return graph.parse(source, format="turtle", **kwargs)
@@ -342,7 +353,7 @@ class QueryContext:
             if default:
                 _load(self.graph, source)
             else:
-                _load(self.dataset, source)
+                _load(self.dataset.get_context(source), source)
 
     def __getitem__(self, key: Union[str, Path]) -> Optional[Union[str, Path]]:
         # in SPARQL BNodes are just labels

--- a/test/data/variants/more_quads-asserts.json
+++ b/test/data/variants/more_quads-asserts.json
@@ -1,4 +1,4 @@
 {
-  "quad_count": 6,
+  "quad_count": 8,
   "exact_match": true
 }

--- a/test/data/variants/more_quads.jsonld
+++ b/test/data/variants/more_quads.jsonld
@@ -1,56 +1,65 @@
 {
-  "@graph": [
-    {
-      "@graph": [
+    "@graph": [
         {
-          "@id": "example:s20",
-          "example:p20": {
-            "@id": "example:o20"
-          }
+            "@id": "example:s10",
+            "example:p10": {
+                "@id": "example:o10"
+            }
         },
         {
-          "@id": "example:s21",
-          "example:p21": {
-            "@id": "example:o21"
-          }
+            "@id": "example:s01",
+            "example:p01": {
+                "@id": "example:o01"
+            }
+        },
+        {
+            "@id": "example:s00",
+            "example:p00": {
+                "@id": "example:o02"
+            }
+        },
+        {
+            "@id": "example:s11",
+            "example:p11": {
+                "@id": "example:o11"
+            }
+        },
+        {
+            "@id": "example:g3",
+            "@graph": [
+                {
+                    "@id": "example:s31",
+                    "example:p31": {
+                        "@id": "example:o31"
+                    }
+                },
+                {
+                    "@id": "example:s30",
+                    "example:p30": {
+                        "@id": "example:o30"
+                    }
+                }
+            ]
+        },
+        {
+            "@id": "example:g2",
+            "@graph": [
+                {
+                    "@id": "example:s21",
+                    "example:p21": {
+                        "@id": "example:o21"
+                    }
+                },
+                {
+                    "@id": "example:s20",
+                    "example:p20": {
+                        "@id": "example:o20"
+                    }
+                }
+            ]
         }
-      ],
-      "@id": "example:g2"
-    },
-    {
-      "@id": "example:s00",
-      "p00": "example:o02"
-    },
-    {
-      "@id": "example:s01",
-      "p01": "example:o01"
-    },
-    {
-      "@id": "example:s10",
-      "p10": "example:o10"
-    },
-    {
-      "@id": "example:s11",
-      "p11": "example:o11"
+    ],
+    "@context": {
+        "example": "http://example.org/"
     }
-  ],
-  "@context": {
-    "p10": {
-      "@id": "http://example.org/p10",
-      "@type": "@id"
-    },
-    "p01": {
-      "@id": "http://example.org/p01",
-      "@type": "@id"
-    },
-    "p00": {
-      "@id": "http://example.org/p00",
-      "@type": "@id"
-    },
-    "p11": {
-      "@id": "http://example.org/p11",
-      "@type": "@id"
-    },
-    "example": "http://example.org/"
-  }
 }

--- a/test/data/variants/more_quads.nq
+++ b/test/data/variants/more_quads.nq
@@ -1,6 +1,8 @@
-<http://example.org/s00> <http://example.org/p00> <http://example.org/o02> .
-<http://example.org/s01> <http://example.org/p01> <http://example.org/o01> .
 <http://example.org/s10> <http://example.org/p10> <http://example.org/o10> .
+<http://example.org/s01> <http://example.org/p01> <http://example.org/o01> .
+<http://example.org/s00> <http://example.org/p00> <http://example.org/o02> .
 <http://example.org/s11> <http://example.org/p11> <http://example.org/o11> .
-<http://example.org/s20> <http://example.org/p20> <http://example.org/o20> <http://example.org/g2> .
 <http://example.org/s21> <http://example.org/p21> <http://example.org/o21> <http://example.org/g2> .
+<http://example.org/s20> <http://example.org/p20> <http://example.org/o20> <http://example.org/g2> .
+<http://example.org/s31> <http://example.org/p31> <http://example.org/o31> <http://example.org/g3> .
+<http://example.org/s30> <http://example.org/p30> <http://example.org/o30> <http://example.org/g3> .

--- a/test/data/variants/more_quads.trig
+++ b/test/data/variants/more_quads.trig
@@ -13,3 +13,8 @@ example:g2 {
 	example:s20 example:p20 example:o20 .
 	example:s21 example:p21 example:o21 .
 }
+
+example:g3 {
+    example:s30 example:p30 example:o30 .
+    example:s31 example:p31 example:o31 .
+}

--- a/test/data/variants/simple_triple.n3
+++ b/test/data/variants/simple_triple.n3
@@ -1,0 +1,1 @@
+<http://example.org/subject> <http://example.org/predicate> <http://example.org/object> .

--- a/test/data/variants/simple_triple.trig
+++ b/test/data/variants/simple_triple.trig
@@ -1,0 +1,2 @@
+<http://example.org/subject>
+        <http://example.org/predicate>  <http://example.org/object> .

--- a/test/test_conjunctivegraph/test_conjunctive_graph.py
+++ b/test/test_conjunctivegraph/test_conjunctive_graph.py
@@ -22,7 +22,7 @@ def test_bnode_publicid():
     b = BNode()
     data = "<d:d> <e:e> <f:f> ."
     print("Parsing %r into %r" % (data, b))
-    g.parse(data=data, format="turtle", publicID=b)
+    g.get_context(b).parse(data=data, format="turtle", publicID=b)
 
     triples = list(g.get_context(b).triples((None, None, None)))
     if not triples:

--- a/test/test_dataset/test_dataset_default_graph.py
+++ b/test/test_dataset/test_dataset_default_graph.py
@@ -1,0 +1,152 @@
+import itertools
+import logging
+from test.data import TEST_DATA_DIR
+from typing import Iterable, Type, Union
+
+import pytest
+from _pytest.mark.structures import ParameterSet
+
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset
+from rdflib.term import BNode, URIRef
+
+
+def make_load_default_and_named() -> Iterable[ParameterSet]:
+    for container_type, file_extension in itertools.product(
+        (Dataset, ConjunctiveGraph), ("trig", "nq", "jsonld")
+    ):
+        yield pytest.param(
+            container_type,
+            file_extension,
+            id=f"{container_type.__name__}-{file_extension}",
+        )
+
+
+EXTENSION_FORMATS = {
+    "trig": "trig",
+    "nq": "nquads",
+    "jsonld": "json-ld",
+    "nt": "ntriples",
+    "ttl": "turtle",
+    "hext": "hext",
+    "n3": "n3",
+}
+
+
+@pytest.mark.parametrize(
+    ["container_type", "file_extension"], make_load_default_and_named()
+)
+def test_load_default_and_named(
+    container_type: Union[Type[Dataset], Type[ConjunctiveGraph]], file_extension: str
+) -> None:
+    logging.debug("container_type = %s", container_type)
+    container = container_type()
+
+    if container_type is Dataset:
+        # An empty dataset has 1 default graph and no named graphs, so 1 graph in
+        # total.
+        assert 1 == sum(1 for _ in container.contexts())
+        assert DATASET_DEFAULT_GRAPH_ID == next(
+            (context.identifier for context in container.contexts()), None
+        )
+        assert container.default_context == next(container.contexts(), None)
+    else:
+        assert isinstance(container.default_context.identifier, BNode)
+
+    # Load an RDF document with triples in three graphs into the container.
+    format = EXTENSION_FORMATS[file_extension]
+    source = TEST_DATA_DIR / "variants" / f"more_quads.{file_extension}"
+    container.parse(source=source, format=format)
+
+    context_identifiers = set(context.identifier for context in container.contexts())
+
+    logging.info("context_identifiers = %s", context_identifiers)
+    logging.info(
+        "container.default_context.triples(...) = %s",
+        set(container.default_context.triples((None, None, None))),
+    )
+
+    all_contexts = set(container.contexts())
+    logging.info(
+        "all_contexts = %s", set(context.identifier for context in all_contexts)
+    )
+
+    non_default_contexts = set(container.contexts()) - {container.default_context}
+    # There should now be two graphs in the container that are not the default graph.
+    logging.info(
+        "non_default_graphs = %s",
+        set(context.identifier for context in non_default_contexts),
+    )
+    assert 2 == len(non_default_contexts)
+
+    # The identifiers of the the non-default graphs should be the ones from the document.
+    assert {
+        URIRef("http://example.org/g2"),
+        URIRef("http://example.org/g3"),
+    } == set(context.identifier for context in non_default_contexts)
+
+    # The default graph should have 4 triples.
+    assert 4 == len(container.default_context)
+
+
+def make_load_default_only_cases() -> Iterable[ParameterSet]:
+    for container_type, file_extension in itertools.product(
+        (Dataset, ConjunctiveGraph), ("trig", "ttl", "nq", "nt", "jsonld", "hext", "n3")
+    ):
+        yield pytest.param(
+            container_type,
+            file_extension,
+            id=f"{container_type.__name__}-{file_extension}",
+        )
+
+
+@pytest.mark.parametrize(
+    ["container_type", "file_extension"], make_load_default_only_cases()
+)
+def test_load_default_only(
+    container_type: Union[Type[Dataset], Type[ConjunctiveGraph]], file_extension: str
+) -> None:
+    logging.debug("container_type = %s", container_type)
+    container = container_type()
+
+    if container_type is Dataset:
+        # An empty dataset has 1 default graph and no named graphs, so 1 graph in
+        # total.
+        assert 1 == sum(1 for _ in container.contexts())
+        assert DATASET_DEFAULT_GRAPH_ID == next(
+            (context.identifier for context in container.contexts()), None
+        )
+        assert container.default_context == next(container.contexts(), None)
+    else:
+        assert isinstance(container.default_context.identifier, BNode)
+
+    # Load an RDF document with only triples in the default graph into the container.
+    format = EXTENSION_FORMATS[file_extension]
+    source = TEST_DATA_DIR / "variants" / f"simple_triple.{file_extension}"
+    container.parse(source=source, format=format)
+
+    context_identifiers = set(context.identifier for context in container.contexts())
+
+    logging.info("context_identifiers = %s", context_identifiers)
+    logging.info(
+        "container.default_context.triples(...) = %s",
+        set(container.default_context.triples((None, None, None))),
+    )
+
+    all_contexts = set(container.contexts())
+    logging.info(
+        "all_contexts = %s", set(context.identifier for context in all_contexts)
+    )
+
+    non_default_contexts = set(container.contexts()) - {container.default_context}
+    # There should now be no graphs in the container that are not the default graph.
+    logging.info(
+        "non_default_graphs = %s",
+        set(context.identifier for context in non_default_contexts),
+    )
+    assert 0 == len(non_default_contexts)
+
+    # The identifiers of the the non-default graphs should be an empty set.
+    assert set() == set(context.identifier for context in non_default_contexts)
+
+    # The default graph should have 3 triples.
+    assert 1 == len(container.default_context)

--- a/test/test_issues/test_issue535.py
+++ b/test/test_issues/test_issue535.py
@@ -16,4 +16,4 @@ def test_nquads_default_graph():
 
     assert len(ds) == 3, len(g)
     assert len(list(ds.contexts())) == 2, len(list(ds.contexts()))
-    assert len(ds.get_context(publicID)) == 2, len(ds.get_context(publicID))
+    assert len(ds.default_context) == 2, len(ds.get_context(publicID))

--- a/test/test_store/test_store_berkeleydb.py
+++ b/test/test_store/test_store_berkeleydb.py
@@ -1,10 +1,15 @@
+import logging
 import tempfile
+from typing import Iterable, Optional, Tuple
 
 import pytest
 
 from rdflib import ConjunctiveGraph, URIRef
 from rdflib.plugins.stores.berkeleydb import has_bsddb
+from rdflib.query import ResultRow
 from rdflib.store import VALID_STORE
+
+logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.skipif(
     not has_bsddb, reason="skipping berkeleydb tests, modile not available"
@@ -12,7 +17,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def get_graph():
+def get_graph() -> Iterable[Tuple[str, ConjunctiveGraph]]:
     path = tempfile.NamedTemporaryFile().name
     g = ConjunctiveGraph("BerkeleyDB")
     rt = g.open(path, create=True)
@@ -35,7 +40,7 @@ def get_graph():
     g.destroy(path)
 
 
-def test_write(get_graph):
+def test_write(get_graph: Tuple[str, ConjunctiveGraph]):
     path, g = get_graph
     assert (
         len(g) == 3
@@ -60,7 +65,7 @@ def test_write(get_graph):
     ), "There must still be four triples in the graph after the third data chunk parse"
 
 
-def test_read(get_graph):
+def test_read(get_graph: Tuple[str, ConjunctiveGraph]):
     path, g = get_graph
     sx = None
     for s in g.subjects(
@@ -71,7 +76,7 @@ def test_read(get_graph):
     assert sx == URIRef("https://example.org/d")
 
 
-def test_sparql_query(get_graph):
+def test_sparql_query(get_graph: Tuple[str, ConjunctiveGraph]):
     path, g = get_graph
     q = """
         PREFIX : <https://example.org/>
@@ -83,11 +88,12 @@ def test_sparql_query(get_graph):
 
     c = 0
     for row in g.query(q):
+        assert isinstance(row, ResultRow)
         c = int(row.c)
     assert c == 2, "SPARQL COUNT must return 2"
 
 
-def test_sparql_insert(get_graph):
+def test_sparql_insert(get_graph: Tuple[str, ConjunctiveGraph]):
     path, g = get_graph
     q = """
         PREFIX : <https://example.org/>
@@ -100,8 +106,15 @@ def test_sparql_insert(get_graph):
     assert len(g) == 4, "After extra triple insert, length must be 4"
 
 
-def test_multigraph(get_graph):
+def test_multigraph(get_graph: Tuple[str, ConjunctiveGraph]):
     path, g = get_graph
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logging.debug(
+            "graph before = \n%s",
+            g.serialize(format="trig"),
+        )
+
     q = """
         PREFIX : <https://example.org/>
 
@@ -116,6 +129,12 @@ def test_multigraph(get_graph):
 
     g.update(q)
 
+    if logger.isEnabledFor(logging.DEBUG):
+        logging.debug(
+            "graph after = \n%s",
+            g.serialize(format="trig"),
+        )
+
     q = """
         SELECT (COUNT(?g) AS ?c)
         WHERE {
@@ -129,11 +148,13 @@ def test_multigraph(get_graph):
         """
     c = 0
     for row in g.query(q):
+        assert isinstance(row, ResultRow)
         c = int(row.c)
-    assert c == 3, "SPARQL COUNT must return 3 (default, :m & :n)"
+    assert c == 2, "SPARQL COUNT must return 2 (default, :m & :n)"
 
 
-def test_open_shut(get_graph):
+def test_open_shut(get_graph: Tuple[str, ConjunctiveGraph]):
+    g: Optional[ConjunctiveGraph]
     path, g = get_graph
     assert len(g) == 3, "Initially we must have 3 triples from setUp"
     g.close()

--- a/test/test_trig.py
+++ b/test/test_trig.py
@@ -1,7 +1,5 @@
 import re
 
-import pytest
-
 import rdflib
 
 TRIPLE = (
@@ -125,13 +123,6 @@ def test_graph_parsing():
     assert len(list(g.contexts())) == 2
 
 
-@pytest.mark.xfail(
-    raises=AssertionError,
-    reason="""
-    This is failing because conjuncitve graph assigns things in the default graph to
-    a graph with a bnode as name. On every parse iteration a new BNode is generated
-    resulting in the default graph content appearing multipile times in the output.""",
-)
 def test_round_trips():
     data = """
 <http://example.com/thing#thing_a> <http://example.com/knows> <http://example.com/thing#thing_b> .

--- a/test/test_w3c_spec/test_sparql10_w3c.py
+++ b/test/test_w3c_spec/test_sparql10_w3c.py
@@ -1,6 +1,7 @@
 """
 Runs the SPARQL 1.0 test suite from.
 """
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -118,5 +119,7 @@ def configure_rdflib() -> Generator[None, None, None]:
         report_prefix="rdflib_w3c_sparql10",
     ),
 )
-def test_entry_sparql10(monkeypatch: MonkeyPatch, manifest_entry: SPARQLEntry) -> None:
-    check_entry(monkeypatch, manifest_entry)
+def test_entry_sparql10(
+    monkeypatch: MonkeyPatch, exit_stack: ExitStack, manifest_entry: SPARQLEntry
+) -> None:
+    check_entry(monkeypatch, exit_stack, manifest_entry)

--- a/test/test_w3c_spec/test_sparql11_w3c.py
+++ b/test/test_w3c_spec/test_sparql11_w3c.py
@@ -1,6 +1,7 @@
 """
 Runs the SPARQL 1.1 test suite from.
 """
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -259,5 +260,7 @@ def configure_rdflib() -> Generator[None, None, None]:
         report_prefix="rdflib_w3c_sparql11",
     ),
 )
-def test_entry_sparql11(monkeypatch: MonkeyPatch, manifest_entry: SPARQLEntry) -> None:
-    check_entry(monkeypatch, manifest_entry)
+def test_entry_sparql11(
+    monkeypatch: MonkeyPatch, exit_stack: ExitStack, manifest_entry: SPARQLEntry
+) -> None:
+    check_entry(monkeypatch, exit_stack, manifest_entry)

--- a/test/test_w3c_spec/test_sparql_rdflib.py
+++ b/test/test_w3c_spec/test_sparql_rdflib.py
@@ -1,6 +1,7 @@
 """
 Runs the RDFLib SPARQL test suite.
 """
+from contextlib import ExitStack
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -61,5 +62,7 @@ def configure_rdflib() -> Generator[None, None, None]:
         report_prefix="rdflib_sparql",
     ),
 )
-def test_entry_rdflib(monkeypatch: MonkeyPatch, manifest_entry: SPARQLEntry) -> None:
-    check_entry(monkeypatch, manifest_entry)
+def test_entry_rdflib(
+    monkeypatch: MonkeyPatch, exit_stack: ExitStack, manifest_entry: SPARQLEntry
+) -> None:
+    check_entry(monkeypatch, exit_stack, manifest_entry)

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -349,6 +349,10 @@ class GraphHelper:
                     else:
                         raise AssertionError("BNode labelled graphs not supported")
                 elif isinstance(context.identifier, URIRef):
+                    if len(context) == 0:
+                        # If a context has no triples it does not exist in a
+                        # meaningful way.
+                        continue
                     result[context.identifier] = context
                 else:
                     raise AssertionError(

--- a/test/utils/test/test_testutils.py
+++ b/test/utils/test/test_testutils.py
@@ -288,21 +288,21 @@ def test_assert_sets_equal(test_case: SetsEqualTestCase):
     rhs_graph: Graph = Graph().parse(data=test_case.rhs, format=test_case.rhs_format)
 
     public_id = URIRef("example:graph")
-    lhs_cgraph: ConjunctiveGraph = ConjunctiveGraph()
-    lhs_cgraph.parse(
+    lhs_dataset: Dataset = Dataset()
+    lhs_dataset.parse(
         data=test_case.lhs, format=test_case.lhs_format, publicID=public_id
     )
 
-    rhs_cgraph: ConjunctiveGraph = ConjunctiveGraph()
-    rhs_cgraph.parse(
+    rhs_dataset: Dataset = Dataset()
+    rhs_dataset.parse(
         data=test_case.rhs, format=test_case.rhs_format, publicID=public_id
     )
 
-    assert isinstance(lhs_cgraph, ConjunctiveGraph)
-    assert isinstance(rhs_cgraph, ConjunctiveGraph)
+    assert isinstance(lhs_dataset, Dataset)
+    assert isinstance(rhs_dataset, Dataset)
     graph: Graph
-    cgraph: ConjunctiveGraph
-    for graph, cgraph in ((lhs_graph, lhs_cgraph), (rhs_graph, rhs_cgraph)):
+    cgraph: Dataset
+    for graph, cgraph in ((lhs_graph, lhs_dataset), (rhs_graph, rhs_dataset)):
         GraphHelper.assert_sets_equals(graph, graph, BNodeHandling.COLLAPSE)
         GraphHelper.assert_sets_equals(cgraph, cgraph, BNodeHandling.COLLAPSE)
         GraphHelper.assert_triple_sets_equals(graph, graph, BNodeHandling.COLLAPSE)
@@ -316,7 +316,7 @@ def test_assert_sets_equal(test_case: SetsEqualTestCase):
             )
         with pytest.raises(AssertionError):
             GraphHelper.assert_sets_equals(
-                lhs_cgraph, rhs_cgraph, test_case.bnode_handling
+                lhs_dataset, rhs_dataset, test_case.bnode_handling
             )
         with pytest.raises(AssertionError):
             GraphHelper.assert_triple_sets_equals(
@@ -324,23 +324,25 @@ def test_assert_sets_equal(test_case: SetsEqualTestCase):
             )
         with pytest.raises(AssertionError):
             GraphHelper.assert_triple_sets_equals(
-                lhs_cgraph, rhs_cgraph, test_case.bnode_handling
+                lhs_dataset, rhs_dataset, test_case.bnode_handling
             )
         with pytest.raises(AssertionError):
             GraphHelper.assert_quad_sets_equals(
-                lhs_cgraph, rhs_cgraph, test_case.bnode_handling
+                lhs_dataset, rhs_dataset, test_case.bnode_handling
             )
     else:
         GraphHelper.assert_sets_equals(lhs_graph, rhs_graph, test_case.bnode_handling)
-        GraphHelper.assert_sets_equals(lhs_cgraph, rhs_cgraph, test_case.bnode_handling)
+        GraphHelper.assert_sets_equals(
+            lhs_dataset, rhs_dataset, test_case.bnode_handling
+        )
         GraphHelper.assert_triple_sets_equals(
             lhs_graph, rhs_graph, test_case.bnode_handling
         )
         GraphHelper.assert_triple_sets_equals(
-            lhs_cgraph, rhs_cgraph, test_case.bnode_handling
+            lhs_dataset, rhs_dataset, test_case.bnode_handling
         )
         GraphHelper.assert_quad_sets_equals(
-            lhs_cgraph, rhs_cgraph, test_case.bnode_handling
+            lhs_dataset, rhs_dataset, test_case.bnode_handling
         )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

When parsing data into a `ConjunctiveGraph` or `Dataset`, the triples in the
default graphs in the sources were loaded into a graph named `publicID`.

This behaviour has been changed, and now the triples from the default graph in
source RDF documents will be loaded into `ConjunctiveGraph.default_context` or
`Dataset.default_context`.

The `publicID` parameter to `ConjunctiveGraph.parse` and `Dataset.parse`
constructors will now only be used as the base URI for relative URI resolution.

- Fixes https://github.com/RDFLib/rdflib/issues/2404
- Fixes https://github.com/RDFLib/rdflib/issues/2375
- Fixes https://github.com/RDFLib/rdflib/issues/436
- Fixes https://github.com/RDFLib/rdflib/issues/1804

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
  - [x] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

