### PR TITLE
Fix docs comment doesn't describe behavior

### DIFF
--- a/docs/intro_to_graphs.rst
+++ b/docs/intro_to_graphs.rst
@@ -105,7 +105,7 @@ node, not a generator:
     # get any name of bob
     name = g.value(bob, FOAF.name)
     # get the one person that knows bob and raise an exception if more are found
-    person = g.value(predicate = FOAF.knows, object=bob, any=False)
+    person = g.value(predicate=FOAF.knows, object=bob, any=False)
 
 
 :class:`~rdflib.graph.Graph` methods for accessing triples

--- a/docs/intro_to_graphs.rst
+++ b/docs/intro_to_graphs.rst
@@ -105,7 +105,7 @@ node, not a generator:
     # get any name of bob
     name = g.value(bob, FOAF.name)
     # get the one person that knows bob and raise an exception if more are found
-    mbox = g.value(predicate = FOAF.name, object=bob, any=False)
+    person = g.value(predicate = FOAF.knows, object=bob, any=False)
 
 
 :class:`~rdflib.graph.Graph` methods for accessing triples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ pep8-naming = ["-N815"]
 pep8-naming = ["-N802"]
 [tool.flakeheaven.exceptions."rdflib/plugins/parsers/trix.py"]
 pep8-naming = ["-N802"]
+[tool.flakeheaven.exceptions."docs/*.rst"]
+pyflakes = ["-F821"]
+
 
 [tool.black]
 required-version = "23.3.0"


### PR DESCRIPTION
Comment refers to a person that knows bob and code would return a name, but this would only work if the triple 
`person foaf:name bob .`
is part of the dataset. As this is a very uncommon way to model a `foaf:knows` the code was adjusted to match the description.