### PR TITLE
Update to https for dbpedia

### DIFF
--- a/docs/intro_to_sparql.rst
+++ b/docs/intro_to_sparql.rst
@@ -140,7 +140,7 @@ The ``SERVICE`` keyword of SPARQL 1.1 can send a query to a remote SPARQL endpoi
         """
         SELECT ?s
         WHERE {
-          SERVICE <http://dbpedia.org/sparql> {
+          SERVICE <https://dbpedia.org/sparql> {
             ?s a ?o .
           }
         }


### PR DESCRIPTION


# Summary of changes

The URL for the service keyword had the http address for the dbpedia endpoint, which does no longer work. Changing it to https does the trick.

I only modified this one example in the documentation.

# Checklist

- [X] Checked that there aren't other open pull requests for
  the same change.
- [X] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

