### PR TITLE
Fix: query over empty optional aggregate; added test and fix for issue #2229

### DIFF
--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -89,7 +89,11 @@ class Counter(Accumulator):
         return row
 
     def use_row(self, row: FrozenBindings) -> bool:
-        return self.eval_row(row) not in self.seen
+        try:
+            return self.eval_row(row) not in self.seen
+        except NotBoundError:
+            # happens when counting zero optional nodes. See issue #2229
+            return False
 
 
 @overload

--- a/test/test_sparql/test_agg_distinct.py
+++ b/test/test_sparql/test_agg_distinct.py
@@ -1,4 +1,5 @@
 from rdflib import Graph, URIRef
+from rdflib.term import Literal
 
 query_tpl = """
 SELECT ?x (MIN(?y_) as ?y) (%s(DISTINCT ?z_) as ?z) {
@@ -147,4 +148,8 @@ def test_count_optional_values():
     }  GROUP BY ?x
     """
     results = dict(g.query(query))
-    assert results[URIRef("http://example.com/3")].toPython() == 0
+    assert results == {
+        URIRef("http://example.com/1"): Literal(1),
+        URIRef("http://example.com/2"): Literal(2),
+        URIRef("http://example.com/3"): Literal(0),
+    }

--- a/test/test_sparql/test_agg_distinct.py
+++ b/test/test_sparql/test_agg_distinct.py
@@ -1,4 +1,4 @@
-from rdflib import Graph
+from rdflib import Graph, URIRef
 
 query_tpl = """
 SELECT ?x (MIN(?y_) as ?y) (%s(DISTINCT ?z_) as ?z) {
@@ -116,3 +116,32 @@ def test_count_distinct():
     """
     )
     assert list(results)[0][0].toPython() == 2
+
+
+def test_count_optional_values():
+    """Problematic query because ?inst may be not bound.
+    So when counting over not bound variables it throws a NotBoundError.
+    """
+    g = Graph()
+    g.bind("ex", "http://example.com/")
+    g.parse(format="ttl", data="""@prefix ex: <http://example.com/>.
+            ex:1 a ex:a;
+                ex:d ex:b.
+            ex:2 a ex:a;
+                ex:d ex:c;
+                ex:d ex:b.
+            ex:3 a ex:a.
+    """)
+
+    query = """
+    SELECT DISTINCT ?x (COUNT(DISTINCT ?inst) as ?cnt)
+    WHERE {
+        ?x a ex:a
+        OPTIONAL {
+            VALUES ?inst {ex:b ex:c}.
+            ?x ex:d ?inst.
+        }
+    }  GROUP BY ?x
+    """
+    results = dict(g.query(query))
+    assert results[URIRef("http://example.com/3")].toPython() == 0

--- a/test/test_sparql/test_agg_distinct.py
+++ b/test/test_sparql/test_agg_distinct.py
@@ -124,14 +124,17 @@ def test_count_optional_values():
     """
     g = Graph()
     g.bind("ex", "http://example.com/")
-    g.parse(format="ttl", data="""@prefix ex: <http://example.com/>.
+    g.parse(
+        format="ttl",
+        data="""@prefix ex: <http://example.com/>.
             ex:1 a ex:a;
                 ex:d ex:b.
             ex:2 a ex:a;
                 ex:d ex:c;
                 ex:d ex:b.
             ex:3 a ex:a.
-    """)
+    """,
+    )
 
     query = """
     SELECT DISTINCT ?x (COUNT(DISTINCT ?inst) as ?cnt)


### PR DESCRIPTION
testing counting of optional nodes. Zero optional nodes may throw a NotBoundError
Added fix for NotBoundError, for this test.

<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

As stated in [issue 2229](https://github.com/RDFLib/rdflib/issues/2229#issue-1583853300) a sparql query fails, if you count over an aggregate of optional values and zero values where found.
This patch catches the resulting NotBoundError and enables with that the count over the empty value-list. Also added the reason for the catch as comment.
Also added a test, that makes such a query. 

- Fixes <https://github.com/RDFLib/rdflib/issues/2229>

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
- If the change has a potential impact on users of this project:
  - [x] Added or updated tests that fail without the change.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

