### PR TITLE
Modify TriG serializer to not generate new prefixes for graph URIs

### DIFF
--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -40,7 +40,8 @@ class TrigSerializer(TurtleSerializer):
             if len(context) == 0:
                 continue
             self.store = context
-            self.getQName(context.identifier)
+            # Don't generate a new prefix for a graph URI if one already exists
+            self.getQName(context.identifier, False)
             self._subjects = {}
 
             for triple in context:
@@ -97,7 +98,8 @@ class TrigSerializer(TurtleSerializer):
                 if isinstance(store.identifier, BNode):
                     iri = store.identifier.n3()
                 else:
-                    iri = self.getQName(store.identifier)
+                    # Show the full graph URI if a prefix for it doesn't already exist
+                    iri = self.getQName(store.identifier, False)
                     if iri is None:
                         # type error: "IdentifiedNode" has no attribute "n3"
                         iri = store.identifier.n3()  # type: ignore[attr-defined]

--- a/test/test_trig.py
+++ b/test/test_trig.py
@@ -60,15 +60,15 @@ def test_remember_namespace():
     # prefix for the graph but later serialize() calls would work.
     first_out = g.serialize(format="trig", encoding="latin-1")
     second_out = g.serialize(format="trig", encoding="latin-1")
-    assert b"@prefix ns1: <http://example.com/> ." in second_out
-    assert b"@prefix ns1: <http://example.com/> ." in first_out
+    assert b"@prefix ns1: <http://example.com/> ." not in second_out
+    assert b"@prefix ns1: <http://example.com/> ." not in first_out
 
 
 def test_graph_qname_syntax():
     g = rdflib.ConjunctiveGraph()
     g.add(TRIPLE + (rdflib.URIRef("http://example.com/graph1"),))
     out = g.serialize(format="trig", encoding="latin-1")
-    assert b"ns1:graph1 {" in out
+    assert b"ns1:graph1 {" not in out
 
 
 def test_graph_uri_syntax():
@@ -178,9 +178,9 @@ def test_prefixes():
     cg.parse(data=data, format="trig")
     data = cg.serialize(format="trig", encoding="latin-1")
 
-    assert "ns2: <http://ex.org/docs/".encode("latin-1") in data, data
+    assert "ns2: <http://ex.org/docs/".encode("latin-1") not in data, data
     assert "<ns2:document1>".encode("latin-1") not in data, data
-    assert "ns2:document1".encode("latin-1") in data, data
+    assert "ns2:document1".encode("latin-1") not in data, data
 
 
 def test_issue_2154():


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

I personally have found it very annoying that the TriG serializer will generate new prefixes for named graph URIs if there is no appropriate prefix for that graph. This is a common occurrence when compiling TriG files where the named graphs each contain an ontology, and the names of the graphs are the URIs of the ontology. Many ontology URIs are the preferred namespace _without_ the trailing `#` or `/`.

For example, the [W3C Data Catalog Vocabulary](https://www.w3.org/ns/dcat.ttl) URI is `http://www.w3.org/ns/dcat` while the preferred prefix/namespace is `PREFIX dcat: <http://www.w3.org/ns/dcat#>`. If you run the following python snippet that simulates loading the DCAT ontology into the named graph `http://www.w3.org/ns/dcat` (or at least one triple in it):

```python
from rdflib import Dataset, URIRef
from rdflib.namespace import RDF, OWL

DCAT_URI = URIRef("http://www.w3.org/ns/dcat")

ds = Dataset()
g = ds.graph(DCAT_URI)
g.add((DCAT_URI, RDF.type, OWL.Ontology))

print(ds.serialize(format="trig"))
```

you should see the following output:
```trig
@prefix ns1: <http://www.w3.org/ns/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .

ns1:dcat {
    ns1:dcat a owl:Ontology .
}
```

That `ns1` prefix is generally unhelpful/unexpected, especially since you're probably expecting to see the URI written out in full [like in the source file](https://www.w3.org/ns/dcat.ttl). Since a new namespace is generated per graph (when the conditions are right), you can end up with a bunch of unhelpful prefixes if you load a bunch of graphs into the dataset. An example would be merging all the [QUDT](https://qudt.org/) Turtle files into one TriG file.

This PR includes modifications to two lines in the TriG parser to prevent this from happening. Consequently, running the above snippet with this PR will result in the following, which I think most people would expect.
```trig
@prefix owl: <http://www.w3.org/2002/07/owl#> .

<http://www.w3.org/ns/dcat> {
    <http://www.w3.org/ns/dcat> a owl:Ontology .
}
```

Of course, if an appropriate namespace does already exist or one gets bound, the graph URI will still be shortened appropriately. Adding this snippet at the end:
```python
ds.bind("MANUAL_NS", "http://www.w3.org/ns/")
print(ds.serialize(format="trig"))
```
still results in the expected output:
```trig
@prefix MANUAL_NS: <http://www.w3.org/ns/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .

MANUAL_NS:dcat {
    MANUAL_NS:dcat a owl:Ontology .
}
```

I'm not sure if there are any concerns around backwards compatibility or not- the content of the file doesn't _really_ change, it's just cosmetic.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

