### PR TITLE
trig Parser now raises SyntaxError, when finding nested graphs

### DIFF
--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -105,8 +105,7 @@ class TrigSinkParser(SinkParser):
         # type error: Incompatible types in assignment (expression has type "Graph", variable has type "Optional[Formula]")
         self._context = self._store.newGraph(graph)  # type: ignore[assignment]
         if self._context is not None and self._parentContext is not None:
-            raise SyntaxError("GRAPH may not include a GRAPH "
-                              "(#trig-graph-bad-07)")
+            raise SyntaxError("GRAPH may not include a GRAPH " "(#trig-graph-bad-07)")
 
         while 1:
             i = self.skipSpace(argstr, j)

--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -104,6 +104,9 @@ class TrigSinkParser(SinkParser):
         self._reason2 = becauseSubGraph
         # type error: Incompatible types in assignment (expression has type "Graph", variable has type "Optional[Formula]")
         self._context = self._store.newGraph(graph)  # type: ignore[assignment]
+        if self._context is not None and self._parentContext is not None:
+            raise SyntaxError("GRAPH may not include a GRAPH "
+                              "(#trig-graph-bad-07)")
 
         while 1:
             i = self.skipSpace(argstr, j)

--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -98,14 +98,15 @@ class TrigSinkParser(SinkParser):
 
         j = i + 1
 
+        if self._context is not None:
+            self.BadSyntax(argstr, i, "Nested graphs are not allowed")
+
         oldParentContext = self._parentContext
         self._parentContext = self._context
         reason2 = self._reason2
         self._reason2 = becauseSubGraph
         # type error: Incompatible types in assignment (expression has type "Graph", variable has type "Optional[Formula]")
         self._context = self._store.newGraph(graph)  # type: ignore[assignment]
-        if self._context is not None and self._parentContext is not None:
-            raise SyntaxError("GRAPH may not include a GRAPH " "(#trig-graph-bad-07)")
 
         while 1:
             i = self.skipSpace(argstr, j)

--- a/test/test_w3c_spec/test_trig_w3c.py
+++ b/test/test_w3c_spec/test_trig_w3c.py
@@ -176,9 +176,6 @@ MARK_DICT = {
     f"{REMOTE_BASE_IRI}#trig-graph-bad-01": pytest.mark.xfail(
         reason="accepts GRAPH with no name"
     ),
-    f"{REMOTE_BASE_IRI}#trig-graph-bad-07": pytest.mark.xfail(
-        reason="accepts nested GRAPH"
-    ),
 }
 
 

--- a/test_reports/rdflib_w3c_trig-HEAD.ttl
+++ b/test_reports/rdflib_w3c_trig-HEAD.ttl
@@ -971,7 +971,7 @@
     earl:assertedBy <https://github.com/RDFLib/rdflib> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            earl:outcome earl:failed ] ;
+            earl:outcome earl:passed ] ;
     earl:subject <https://github.com/RDFLib/rdflib> ;
     earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-07> .
 


### PR DESCRIPTION
# Summary of changes

When loading [trig-graph-bad-07.trig](https://www.w3.org/2013/TrigTests/trig-graph-bad-07.trig) an exception should be raised.
I implemented a normal SyntaxError for this occasion.

The xfail for the corresponding test was removed.
<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

