### PR TITLE
trig GRAPH needs graphname (as in w3c-test:trig-graph-bad-01)

### DIFF
--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -82,7 +82,7 @@ class TrigSinkParser(SinkParser):
             graph = r[0]
             i = j
         elif need_graphid:
-            return -1
+            self.BadSyntax(argstr, i, "GRAPH keyword must be followed by graph name")
         else:
             graph = self._store.graph.identifier  # hack
 

--- a/rdflib/plugins/parsers/trig.py
+++ b/rdflib/plugins/parsers/trig.py
@@ -69,16 +69,20 @@ class TrigSinkParser(SinkParser):
         raise Exception if it looks like a graph, but isn't.
         """
 
+        need_graphid = False
         # import pdb; pdb.set_trace()
         j = self.sparqlTok("GRAPH", argstr, i)  # optional GRAPH keyword
         if j >= 0:
             i = j
+            need_graphid = True
 
         r: MutableSequence[Any] = []
         j = self.labelOrSubject(argstr, i, r)
         if j >= 0:
             graph = r[0]
             i = j
+        elif need_graphid:
+            return -1
         else:
             graph = self._store.graph.identifier  # hack
 

--- a/test/test_w3c_spec/test_trig_w3c.py
+++ b/test/test_w3c_spec/test_trig_w3c.py
@@ -173,9 +173,6 @@ MARK_DICT = {
     f"{REMOTE_BASE_IRI}#trig-syntax-bad-list-04": pytest.mark.xfail(
         reason="ignores badly formed quad"
     ),
-    f"{REMOTE_BASE_IRI}#trig-graph-bad-01": pytest.mark.xfail(
-        reason="accepts GRAPH with no name"
-    ),
     f"{REMOTE_BASE_IRI}#trig-graph-bad-07": pytest.mark.xfail(
         reason="accepts nested GRAPH"
     ),

--- a/test_reports/rdflib_w3c_trig-HEAD.ttl
+++ b/test_reports/rdflib_w3c_trig-HEAD.ttl
@@ -923,7 +923,7 @@
     earl:assertedBy <https://github.com/RDFLib/rdflib> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            earl:outcome earl:failed ] ;
+            earl:outcome earl:passed ] ;
     earl:subject <https://github.com/RDFLib/rdflib> ;
     earl:test <http://www.w3.org/2013/TriGTests/#trig-graph-bad-01> .
 


### PR DESCRIPTION
# Summary of changes

trig parser will now expect a graphname if Keyword GRAPH is used before {...}.
removed expected failure for testcase https://www.w3.org/2013/TrigTests/#trig-graph-bad-01

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

