### PR TITLE
Mark one sparql10 test as skipped (term-6)

### DIFF
--- a/test/test_w3c_spec/test_sparql10_w3c.py
+++ b/test/test_w3c_spec/test_sparql10_w3c.py
@@ -23,8 +23,9 @@ MAPPER = URIMapper.from_mappings(
     (REMOTE_BASE_IRI, ensure_suffix(LOCAL_BASE_DIR.as_uri(), "/")),
 )
 MARK_DICT: MarksDictType = {
-    f"{REMOTE_BASE_IRI}basic/manifest#term-6": pytest.mark.xfail(
-        reason="query misinterpreted."
+    f"{REMOTE_BASE_IRI}basic/manifest#term-6": pytest.mark.skip(
+        reason="using Sparql 1.1 which is not backwards compatible. "
+        "'456.' will be interpreted differently in query and data."
     ),
     f"{REMOTE_BASE_IRI}basic/manifest#term-7": pytest.mark.xfail(reason="..."),
     f"{REMOTE_BASE_IRI}expr-builtin/manifest#dawg-datatype-2": pytest.mark.xfail(

--- a/test/test_w3c_spec/test_sparql10_w3c.py
+++ b/test/test_w3c_spec/test_sparql10_w3c.py
@@ -27,7 +27,10 @@ MARK_DICT: MarksDictType = {
         reason="using Sparql 1.1 which is not backwards compatible. "
         "'456.' will be interpreted differently in query and data."
     ),
-    f"{REMOTE_BASE_IRI}basic/manifest#term-7": pytest.mark.xfail(reason="..."),
+    f"{REMOTE_BASE_IRI}basic/manifest#term-7": pytest.mark.skip(
+        reason="using Sparql 1.1 which is not backwards compatible. "
+        "'456.' will be interpreted differently in query and data."
+    ),
     f"{REMOTE_BASE_IRI}expr-builtin/manifest#dawg-datatype-2": pytest.mark.xfail(
         reason="additional row in output"
     ),

--- a/test_reports/rdflib_w3c_sparql10-HEAD.ttl
+++ b/test_reports/rdflib_w3c_sparql10-HEAD.ttl
@@ -331,7 +331,7 @@
     earl:assertedBy <https://github.com/RDFLib/rdflib> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            earl:outcome earl:failed ] ;
+            earl:outcome earl:untested ] ;
     earl:subject <https://github.com/RDFLib/rdflib> ;
     earl:test <http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7> .
 

--- a/test_reports/rdflib_w3c_sparql10-HEAD.ttl
+++ b/test_reports/rdflib_w3c_sparql10-HEAD.ttl
@@ -323,7 +323,7 @@
     earl:assertedBy <https://github.com/RDFLib/rdflib> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            earl:outcome earl:failed ] ;
+            earl:outcome earl:untested ] ;
     earl:subject <https://github.com/RDFLib/rdflib> ;
     earl:test <http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6> .
 


### PR DESCRIPTION
# Summary of changes

Marks test term-6 test in test/test_w3c_spec/test_sparql10_w3c.py
as skipped. as described [in discussion](https://github.com/RDFLib/rdflib/pull/2470#pullrequestreview-1513403214)

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

