### PR TITLE
added test and bugfix for the custom groupconcat separator "" (issue#2473)

### DIFF
--- a/rdflib/plugins/sparql/aggregates.py
+++ b/rdflib/plugins/sparql/aggregates.py
@@ -245,11 +245,16 @@ class Sample(Accumulator):
 
 
 class GroupConcat(Accumulator):
-    def __init__(self, aggregation):
+    value: List[Literal]
+
+    def __init__(self, aggregation: CompValue):
         super(GroupConcat, self).__init__(aggregation)
         # only GROUPCONCAT needs to have a list as accumulator
         self.value = []
-        self.separator = aggregation.separator or " "
+        if aggregation.separator is None:
+            self.separator = " "
+        else:
+            self.separator = aggregation.separator
 
     def update(self, row: FrozenBindings, aggregator: "Aggregator") -> None:
         try:

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -11,8 +11,8 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 
 import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
+from rdflib import Graph, Literal, URIRef
 from rdflib.plugins.sparql.algebra import translateAlgebra
-from rdflib import Graph, URIRef, Literal
 
 
 @pytest.fixture
@@ -309,7 +309,7 @@ def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
 
 def test_sparql_group_concat():
     """Tests if GROUP_CONCAT correctly uses the separator keyword"""
-    query="""
+    query = """
     PREFIX : <http://example.org/>
 
     SELECT ?subject (GROUP_CONCAT(?object; separator="")

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -12,6 +12,7 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
 from rdflib.plugins.sparql.algebra import translateAlgebra
+from rdflib import Graph, URIRef, Literal
 
 
 @pytest.fixture
@@ -304,3 +305,25 @@ def test_roundtrip(test_spec: AlgebraTest, data_path: Path) -> None:
     # TODO: Execute the raw query (query_text) and the reconstituted query
     # (query_from_query_from_algebra) against a well defined graph and ensure
     # they yield the same result.
+
+
+def test_sparql_group_concat():
+    """Tests if GROUP_CONCAT correctly uses the separator keyword"""
+    query="""
+    PREFIX : <http://example.org/>
+
+    SELECT ?subject (GROUP_CONCAT(?object; separator="")
+                        AS ?concatenatedObjects)
+    WHERE {
+      VALUES (?subject ?object) {
+        (:pred "a")
+        (:pred "b")
+        (:pred "c")
+      }
+    }
+    GROUP BY ?subject
+    """
+
+    g = Graph()
+    q = dict(g.query(query))
+    assert q[URIRef("http://example.org/pred")] == Literal("abc")


### PR DESCRIPTION
# Summary of changes

added test for this case
added bugfix for missing separator in groupconcat
groupconcat checked with generic bool if default " " should be used.Now it checks if aggregator has set separator not None

Also added some annotations

Bugfix for this [issue](https://github.com/RDFLib/rdflib/issues/2473#issue-1793405686) 

Fixes #2473

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

