### PR TITLE
Hotfix so that: literal html uses initial value instead

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -654,7 +654,11 @@ class Literal(Identifier):
             if value is not None and normalize:
                 _value, _datatype = _castPythonToLiteral(value, datatype)
                 if _value is not None and _is_valid_unicode(_value):
-                    lexical_or_value = _value
+                    if _datatype != _RDF_HTMLLITERAL:
+                        # Hotfix. See here for more information:
+                        # https://github.com/RDFLib/rdflib/issues/2475
+                        # html produce an empty _value
+                        lexical_or_value = _value
 
         else:
             # passed some python object


### PR DESCRIPTION
# Summary of changes

Created a hotfix for Problem missing [literal-html string](https://github.com/RDFLib/rdflib/issues/2475).

If Literal is XSD:HTML the literal value wont be overwritten by the value produced in Literal.__init__

In its current form `Literal` produces an empty string if `datatype=xsd:HTML`.

If `Literal(..,datatype=xsd.HTML)` prodcues an empty `value`, this hotfix doesnt fix that. (I havent checked this.)


# Longer description

For more information see the discussion in Issue above. In short:
`Literal.__init__` doesnt respect [Literal-term-equality](https://www.w3.org/TR/rdf11-concepts/#dfn-literal-term-equality). Instead it produces for builtin-datatypes a special `value`. Because Literal is a subclass to str, it needs a `str` back from the produced `value`. During this process the value of the html string is lost and so only an empty `str` remains.
This hotfix circumvents this by checking if `datatype==xsd.HTML` and just uses the original string given to `__init__`.

The value that is produced within `Literal.__init__` may be corrupted because it just consists of an empty `""`
It is created at this position:

https://github.com/RDFLib/rdflib/blob/0ea6ca579442219d67ffb1fc7313f05fd16d8d49/rdflib/term.py#L1641C1-L1648C22

At this position it is transformed back to a string:

https://github.com/RDFLib/rdflib/blob/0ea6ca579442219d67ffb1fc7313f05fd16d8d49/rdflib/term.py#L1656C1-L1663C31

The type of the value is `xml.dom.minidom.DocumentFragment`. Checking what is inside that object may be a little bit harder.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

