### PR TITLE
Stopping normalization of invalid html literals

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1641,16 +1641,17 @@ def _parseXML(xmlstring: str) -> xml.dom.minidom.Document:  # noqa: N802
 def _parseHTML(htmltext: str) -> xml.dom.minidom.DocumentFragment:  # noqa: N802
     try:
         import html5lib
-
-        parser = html5lib.HTMLParser(tree=html5lib.treebuilders.getTreeBuilder("dom"))
-        retval = parser.parseFragment(htmltext)
-        retval.normalize()
-        return retval
     except ImportError:
         raise ImportError(
             "HTML5 parser not available. Try installing"
             + " html5lib <http://code.google.com/p/html5lib>"
         )
+    parser = html5lib.HTMLParser(tree=html5lib.treebuilders.getTreeBuilder("dom"))
+    retval = parser.parseFragment(htmltext)
+    if parser.errors:
+        raise ValueError("html5lib failed to parse.", htmltext)
+    retval.normalize()
+    return retval
 
 
 def _writeXML(  # noqa: N802

--- a/test/test_literal/test_xmlliterals.py
+++ b/test/test_literal/test_xmlliterals.py
@@ -100,6 +100,11 @@ def testHTML():
     assert l2.value is not None, "xml must have been parsed"
     assert l2.datatype == RDF.HTML, "literal must have right datatype"
 
+    l3 = Literal("<invalid", datatype=RDF.HTML)
+    assert l3.value is None, "invalid html must not be parsed/normalized"
+    assert l3.datatype == RDF.HTML, "literal must have right datatype"
+    assert str(l3) == "<invalid", "literal must have right datatype"
+
     assert l1 != l2
     assert not l1.eq(l2)
 


### PR DESCRIPTION



# Summary of changes

literal stops normalization process if html5lib cant parse literal
Tests now check, that invalid html literals wont be normalized

Fixes #2475

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

