### PR TITLE
fix: handling of `rdf:HTML` literals

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,8 @@ from contextlib import ExitStack
 
 import pytest
 
+# This is here so that asserts from these modules are formatted for human
+# readibility.
 pytest.register_assert_rewrite("test.utils")
 
 from pathlib import Path  # noqa: E402
@@ -19,16 +21,13 @@ from typing import (  # noqa: E402
     Union,
 )
 
-from rdflib import Graph
+from rdflib import Graph  # noqa: E402
 
 from .data import TEST_DATA_DIR
 from .utils.earl import EARLReporter  # noqa: E402
 from .utils.httpservermock import ServedBaseHTTPServerMock  # noqa: E402
 
 pytest_plugins = [EARLReporter.__module__]
-
-# This is here so that asserts from these modules are formatted for human
-# readibility.
 
 
 @pytest.fixture(scope="session")

--- a/test/test_literal/test_literal.py
+++ b/test/test_literal/test_literal.py
@@ -1,3 +1,15 @@
+from __future__ import annotations
+
+import builtins
+import datetime
+import logging
+from decimal import Decimal
+from test.utils import affix_tuples
+from test.utils.literal import LiteralChecker, literal_idfn
+from test.utils.namespace import EGDC
+from test.utils.outcome import OutcomeChecker, OutcomePrimitive, OutcomePrimitives
+from typing import Any, Callable, Generator, Optional, Type, Union
+
 # NOTE: The config below enables strict mode for mypy.
 # mypy: no_ignore_errors
 # mypy: warn_unused_configs, disallow_any_generics
@@ -7,14 +19,13 @@
 # mypy: no_implicit_optional, warn_redundant_casts, warn_unused_ignores
 # mypy: warn_return_any, no_implicit_reexport, strict_equality
 
-import datetime
-import logging
-from decimal import Decimal
-from test.utils import affix_tuples
-from test.utils.literal import LiteralChecker
-from test.utils.namespace import EGDC
-from test.utils.outcome import OutcomeChecker, OutcomePrimitive, OutcomePrimitives
-from typing import Any, Callable, Generator, Optional, Type, Union
+
+try:
+    import html5lib as _  # noqa: F401
+
+    _HAVE_HTML5LIB = True
+except ImportError:
+    _HAVE_HTML5LIB = False
 
 import isodate
 import pytest
@@ -915,6 +926,21 @@ def test_exception_in_converter(
     )
 
 
+class _UnknownType:
+    """
+    A class that is not known to rdflib, used to test the how
+    rdflib.term.Literal handles unknown python types.
+    """
+
+    def __repr__(self) -> str:
+        return "_UnknownType()"
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, _UnknownType):
+            return True
+        return False
+
+
 @pytest.mark.parametrize(
     ["literal_maker", "outcome"],
     [
@@ -951,7 +977,30 @@ def test_exception_in_converter(
             lambda: Literal(Literal("blue sky", "en")),
             Literal("blue sky", "en"),
         ),
+        (
+            lambda: Literal("<body>", datatype=RDF.HTML),
+            LiteralChecker(
+                ..., None, RDF.HTML, True if _HAVE_HTML5LIB else None, "<body>"
+            ),
+        ),
+        (
+            lambda: Literal("<table></table>", datatype=RDF.HTML),
+            LiteralChecker(
+                ...,
+                None,
+                RDF.HTML,
+                False if _HAVE_HTML5LIB else None,
+                "<table></table>",
+            ),
+        ),
+        (
+            lambda: Literal(_UnknownType(), datatype=EGDC.UnknownType),
+            LiteralChecker(
+                _UnknownType(), None, EGDC.UnknownType, None, "_UnknownType()"
+            ),
+        ),
     ],
+    ids=literal_idfn,
 )
 def test_literal_construction(
     literal_maker: Callable[[], Literal],
@@ -961,3 +1010,41 @@ def test_literal_construction(
     with checker.context():
         actual_outcome = literal_maker()
         checker.check(actual_outcome)
+
+
+@pytest.mark.parametrize(
+    ["literal_maker", "normalize_literals", "outcome"],
+    [
+        (
+            lambda: Literal("001000", datatype=XSD.integer),
+            ...,
+            LiteralChecker(1000, None, XSD.integer, False, "1000"),
+        ),
+        (
+            lambda: Literal("001000", datatype=XSD.integer),
+            True,
+            LiteralChecker(1000, None, XSD.integer, False, "1000"),
+        ),
+        (
+            lambda: Literal("001000", datatype=XSD.integer),
+            False,
+            LiteralChecker(1000, None, XSD.integer, False, "001000"),
+        ),
+    ],
+    ids=literal_idfn,
+)
+def test_global_normalize(
+    literal_maker: Callable[[], Literal],
+    normalize_literals: Union[builtins.ellipsis, bool],
+    outcome: OutcomePrimitives[Literal],
+) -> None:
+    _normalize_literals = rdflib.NORMALIZE_LITERALS
+    try:
+        if normalize_literals is not ...:
+            rdflib.NORMALIZE_LITERALS = normalize_literals
+        checker = OutcomeChecker[Literal].from_primitives(outcome)
+        with checker.context():
+            actual_outcome = literal_maker()
+            checker.check(actual_outcome)
+    finally:
+        rdflib.NORMALIZE_LITERALS = _normalize_literals

--- a/test/test_literal/test_literal_html5lib.py
+++ b/test/test_literal/test_literal_html5lib.py
@@ -1,0 +1,79 @@
+import xml.dom.minidom
+from test.utils.literal import LiteralChecker
+from test.utils.outcome import OutcomeChecker, OutcomePrimitives
+from typing import Callable
+
+import pytest
+
+import rdflib.term
+from rdflib.namespace import RDF
+from rdflib.term import Literal
+
+try:
+    import html5lib as _  # noqa: F401
+except ImportError:
+    pytest.skip("html5lib not installed", allow_module_level=True)
+
+
+def test_has_html5lib() -> None:
+    assert rdflib.term._HAS_HTML5LIB is True
+    assert RDF.HTML in rdflib.term.XSDToPython
+    rule = next(
+        (
+            item
+            for item in rdflib.term._GenericPythonToXSDRules
+            if item[0] is xml.dom.minidom.DocumentFragment
+        ),
+        None,
+    )
+    assert rule is not None
+    assert rule[1][1] == RDF.HTML
+
+
+@pytest.mark.parametrize(
+    ["factory", "outcome"],
+    [
+        # Ill-typed literals, these have lexical forms that result in
+        # errors when parsed as HTML by html5lib.
+        (
+            lambda: Literal("<body><h1>Hello, World!</h1></body>", datatype=RDF.HTML),
+            LiteralChecker(
+                ..., None, RDF.HTML, True, "<body><h1>Hello, World!</h1></body>"
+            ),
+        ),
+        (
+            lambda: Literal("<body></body>", datatype=RDF.HTML),
+            LiteralChecker(..., None, RDF.HTML, True, "<body></body>"),
+        ),
+        (
+            lambda: Literal("<tr><td>THE TEXT IS IN HERE</td></tr>", datatype=RDF.HTML),
+            LiteralChecker(
+                ..., None, RDF.HTML, True, "<tr><td>THE TEXT IS IN HERE</td></tr>"
+            ),
+        ),
+        # Well-typed literals, these have lexical forms that parse
+        # without errors with html5lib.
+        (
+            lambda: Literal("<table></table>", datatype=RDF.HTML),
+            LiteralChecker(..., None, RDF.HTML, False, "<table></table>"),
+        ),
+        (
+            lambda: Literal("  <table>  </table>  ", datatype=RDF.HTML, normalize=True),
+            LiteralChecker(..., None, RDF.HTML, False, "  <table>  </table>  "),
+        ),
+        (
+            lambda: Literal(
+                "  <table>  </table>  ", datatype=RDF.HTML, normalize=False
+            ),
+            LiteralChecker(..., None, RDF.HTML, False, "  <table>  </table>  "),
+        ),
+    ],
+)
+def test_literal_construction(
+    factory: Callable[[], Literal],
+    outcome: OutcomePrimitives[Literal],
+) -> None:
+    checker = OutcomeChecker[Literal].from_primitives(outcome)
+    with checker.context():
+        actual_outcome = factory()
+        checker.check(actual_outcome)

--- a/test/test_sparql/test_sparql.py
+++ b/test/test_sparql/test_sparql.py
@@ -844,6 +844,23 @@ def test_operator_exception(
             ],
             id="select-group-concat-optional-many",
         ),
+        pytest.param(
+            """
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+            SELECT * WHERE {
+                BIND(STRDT("<body>", rdf:HTML) as ?tag1) # incorrectly disappearing literal
+                BIND("<body>" as ?tag2)                  # correctly appearing literal
+            }
+            """,
+            [
+                {
+                    Variable("tag1"): Literal("<body>", datatype=RDF.HTML),
+                    Variable("tag2"): Literal("<body>"),
+                }
+            ],
+            id="select-bind-strdt-html",
+        ),
     ],
 )
 def test_queries(

--- a/test/utils/literal.py
+++ b/test/utils/literal.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import builtins
+import logging
 from dataclasses import dataclass
 from test.utils.outcome import NoExceptionChecker
-from typing import Any, Union
+from typing import Any, Optional, Union
+from xml.dom.minidom import DocumentFragment
 
 from rdflib.term import Literal, URIRef
 
@@ -17,13 +19,40 @@ class LiteralChecker(NoExceptionChecker[Literal]):
     lexical: Union[builtins.ellipsis, str] = ...
 
     def check(self, actual: Literal) -> None:
+        logging.debug(
+            "actual = %r, value = %r, ill_typed = %r",
+            actual,
+            actual.value,
+            actual.ill_typed,
+        )
         if self.value is not Ellipsis:
+            if callable(self.value):
+                logging.debug(f"Checking value {actual.value} with {self.value}")
+                if isinstance(actual.value, DocumentFragment):
+                    logging.debug(f"childNodes = {actual.value.childNodes}")
+                assert self.value(actual.value)
+            else:
+                assert self.value == actual.value
             assert self.value == actual.value
         if self.lexical is not Ellipsis:
-            assert self.lexical == f"{actual}"
+            assert self.lexical == f"{actual}", "Literal lexical form does not match"
         if self.ill_typed is not Ellipsis:
-            assert self.ill_typed == actual.ill_typed
+            assert (
+                self.ill_typed == actual.ill_typed
+            ), "Literal ill_typed flag does not match"
         if self.language is not Ellipsis:
-            assert self.language == actual.language
+            assert self.language == actual.language, "Literal language does not match"
         if self.datatype is not Ellipsis:
-            assert self.datatype == actual.datatype
+            assert self.datatype == actual.datatype, "Literal datatype does not match"
+
+
+def literal_idfn(value: Any) -> Optional[str]:
+    if callable(value):
+        try:
+            literal = value()
+        except Exception:
+            return None
+        return f"{literal}"
+    if isinstance(value, LiteralChecker):
+        return f"{value}"
+    return None


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

Previously, if without `html5lib` installed, literals with`rdf:HTML` datatypes were treated as
[ill-typed](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal), even if they were not ill-typed.

With this change, if `html5lib` is not installed, literals with the `rdf:HTML` datatype will not be treated as ill-typed, and will have `Null` as their `ill_typed` attribute value, which means that it is unknown whether they are ill-typed or not.

This change also fixes the mapping from `rdf:HTML` literal values to lexical forms.

Other changes:

- Add tests for `rdflib.NORMALIZE_LITERALS` to ensure it behaves correctly.

Related issues:

- Fixes <https://github.com/RDFLib/rdflib/issues/2475>


<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

