### PR TITLE
Corrected n3 method of path objects (fixes #2503)

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -213,6 +213,15 @@ OneOrMore = "+"
 ZeroOrOne = "?"
 
 
+def _n3(
+    arg: Union["URIRef", "Path"], namespace_manager: Optional["NamespaceManager"] = None
+):
+    # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
+    if isinstance(arg, (SequencePath, AlternativePath)) and len(arg.args) > 1:
+        return "(%s)" % arg.n3(namespace_manager)
+    return arg.n3(namespace_manager)  # type: ignore[union-attr]
+
+
 @total_ordering
 class Path:
     __or__: Callable[["Path", Union["URIRef", "Path"]], "AlternativePath"]
@@ -260,8 +269,7 @@ class InvPath(Path):
         return "Path(~%s)" % (self.arg,)
 
     def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
-        # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
-        return "^%s" % self.arg.n3(namespace_manager)  # type: ignore[union-attr]
+        return "^%s" % _n3(self.arg, namespace_manager)
 
 
 class SequencePath(Path):
@@ -318,8 +326,7 @@ class SequencePath(Path):
         return "Path(%s)" % " / ".join(str(x) for x in self.args)
 
     def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
-        # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
-        return "/".join(a.n3(namespace_manager) for a in self.args)  # type: ignore[union-attr]
+        return "/".join(_n3(a, namespace_manager) for a in self.args)
 
 
 class AlternativePath(Path):
@@ -345,8 +352,7 @@ class AlternativePath(Path):
         return "Path(%s)" % " | ".join(str(x) for x in self.args)
 
     def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
-        # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
-        return "|".join(a.n3(namespace_manager) for a in self.args)  # type: ignore[union-attr]
+        return "|".join(_n3(a, namespace_manager) for a in self.args)
 
 
 class MulPath(Path):
@@ -470,8 +476,7 @@ class MulPath(Path):
         return "Path(%s%s)" % (self.path, self.mod)
 
     def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
-        # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
-        return "%s%s" % (self.path.n3(namespace_manager), self.mod)  # type: ignore[union-attr]
+        return "%s%s" % (_n3(self.path, namespace_manager), self.mod)
 
 
 class NegatedPath(Path):
@@ -505,8 +510,7 @@ class NegatedPath(Path):
         return "Path(! %s)" % ",".join(str(x) for x in self.args)
 
     def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
-        # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
-        return "!(%s)" % ("|".join(arg.n3(namespace_manager) for arg in self.args))  # type: ignore[union-attr]
+        return "!(%s)" % ("|".join(_n3(arg, namespace_manager) for arg in self.args))
 
 
 class PathList(list):

--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -215,7 +215,7 @@ ZeroOrOne = "?"
 
 def _n3(
     arg: Union["URIRef", "Path"], namespace_manager: Optional["NamespaceManager"] = None
-):
+) -> str:
     # type error: Item "Path" of "Union[Path, URIRef]" has no attribute "n3"  [union-attr]
     if isinstance(arg, (SequencePath, AlternativePath)) and len(arg.args) > 1:
         return "(%s)" % arg.n3(namespace_manager)

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -59,6 +59,11 @@ nsm = g.namespace_manager
             "rdf:type/rdfs:subClassOf*",
         ),
         (
+            RDF.type / ((SequencePath(RDFS.subClassOf)) * "*"),
+            f"<{RDF.type}>/<{RDFS.subClassOf}>*",
+            "rdf:type/rdfs:subClassOf*",
+        ),
+        (
             RDF.type / RDFS.subClassOf * "*",
             f"(<{RDF.type}>/<{RDFS.subClassOf}>)*",
             "(rdf:type/rdfs:subClassOf)*",
@@ -67,6 +72,21 @@ nsm = g.namespace_manager
             -(RDF.type | RDFS.subClassOf),
             f"!(<{RDF.type}>|<{RDFS.subClassOf}>)",
             "!(rdf:type|rdfs:subClassOf)",
+        ),
+        (
+            -(RDF.type | ((SequencePath(RDFS.subClassOf)) * "*")),
+            f"!(<{RDF.type}>|<{RDFS.subClassOf}>*)",
+            "!(rdf:type|rdfs:subClassOf*)",
+        ),
+        (
+            SequencePath(RDFS.subClassOf),
+            f"<{RDFS.subClassOf}>",
+            "rdfs:subClassOf",
+        ),
+        (
+            AlternativePath(RDFS.subClassOf),
+            f"<{RDFS.subClassOf}>",
+            "rdfs:subClassOf",
         ),
     ],
 )

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -54,9 +54,14 @@ nsm = g.namespace_manager
             "rdfs:subClassOf?",
         ),
         (
-            RDF.type / RDFS.subClassOf * "*",
+            RDF.type / MulPath(RDFS.subClassOf, "*"),
             f"<{RDF.type}>/<{RDFS.subClassOf}>*",
             "rdf:type/rdfs:subClassOf*",
+        ),
+        (
+            RDF.type / RDFS.subClassOf * "*",
+            f"(<{RDF.type}>/<{RDFS.subClassOf}>)*",
+            "(rdf:type/rdfs:subClassOf)*",
         ),
         (
             -(RDF.type | RDFS.subClassOf),


### PR DESCRIPTION
# Summary of changes

This is an attempt to fix #2503. Previously, the n3 method of path objects returned unexpected/invalid strings when the path objects were non-trivial (i.e. nested, consisting of property path groups). Examples can be found in the related issue and the tests.

This change fixes a bug. It might impact on users that previously relied on the invalid implementation of the n3 method. Not sure if/where this should be added to the documentation.

- Fixes https://github.com/RDFLib/rdflib/issues/2503

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] ~~Updated relevant documentation to avoid inaccuracies.~~
  - [x] ~~Considered adding additional documentation.~~
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

