### PR TITLE
fix: make rdflib.term.Node abstract (fixes #2518)

### DIFF
--- a/rdflib/collection.py
+++ b/rdflib/collection.py
@@ -82,8 +82,7 @@ class Collection:
           "2"^^<http://www.w3.org/2001/XMLSchema#integer>
           "3"^^<http://www.w3.org/2001/XMLSchema#integer> )
         """
-        # type error: "Node" has no attribute "n3"
-        return "( %s )" % (" ".join([i.n3() for i in self]))  # type: ignore[attr-defined]
+        return "( %s )" % (" ".join([i.n3() for i in self]))
 
     def _get_container(self, index: int) -> Optional[Node]:
         """Gets the first, rest holding node at index."""

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1609,10 +1609,9 @@ class Graph(Node):
 
         return processor.update(update_object, initBindings, initNs, **kwargs)
 
-    def n3(self) -> str:
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         """Return an n3 identifier for the Graph"""
-        # type error: "IdentifiedNode" has no attribute "n3"
-        return "[%s]" % self.identifier.n3()  # type: ignore[attr-defined]
+        return "[%s]" % self.identifier.n3(namespace_manager=namespace_manager)
 
     def __reduce__(self) -> Tuple[Type[Graph], Tuple[Store, _ContextIdentifierType]]:
         return (
@@ -2591,14 +2590,12 @@ class QuotedGraph(Graph):
         )
         return self
 
-    def n3(self) -> str:
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
         """Return an n3 identifier for the Graph"""
-        # type error: "IdentifiedNode" has no attribute "n3"
-        return "{%s}" % self.identifier.n3()  # type: ignore[attr-defined]
+        return "{%s}" % self.identifier.n3(namespace_manager=namespace_manager)
 
     def __str__(self) -> str:
-        # type error: "IdentifiedNode" has no attribute "n3"
-        identifier = self.identifier.n3()  # type: ignore[attr-defined]
+        identifier = self.identifier.n3()
         label = self.store.__class__.__name__
         pattern = (
             "{this rdflib.identifier %s;rdflib:storage "
@@ -2900,7 +2897,7 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
     ) -> NoReturn:  # noqa: N803
         raise ModificationException()
 
-    def n3(self) -> NoReturn:
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> NoReturn:
         raise UnSupportedAggregateOperation()
 
     def __reduce__(self) -> NoReturn:

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -60,14 +60,12 @@ class NT11Serializer(NTSerializer):
 def _nt_row(triple: _TripleType) -> str:
     if isinstance(triple[2], Literal):
         return "%s %s %s .\n" % (
-            # type error: "Node" has no attribute "n3"
-            triple[0].n3(),  # type: ignore[attr-defined]
-            triple[1].n3(),  # type: ignore[attr-defined]
+            triple[0].n3(),
+            triple[1].n3(),
             _quoteLiteral(triple[2]),
         )
     else:
-        # type error: "Node" has no attribute "n3"
-        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())  # type: ignore[attr-defined]
+        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())
 
 
 def _quoteLiteral(l_: Literal) -> str:  # noqa: N802

--- a/rdflib/plugins/serializers/trig.py
+++ b/rdflib/plugins/serializers/trig.py
@@ -101,8 +101,7 @@ class TrigSerializer(TurtleSerializer):
                     # Show the full graph URI if a prefix for it doesn't already exist
                     iri = self.getQName(store.identifier, False)
                     if iri is None:
-                        # type error: "IdentifiedNode" has no attribute "n3"
-                        iri = store.identifier.n3()  # type: ignore[attr-defined]
+                        iri = store.identifier.n3()
                 self.write(self.indent() + "\n%s {" % iri)
 
             self.depth += 1

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -1010,12 +1010,10 @@ class _AlgebraTranslator:
     ) -> str:
         if isinstance(node_arg, Identifier):
             if node_arg in self.aggr_vars.keys():
-                # type error: "Identifier" has no attribute "n3"
-                grp_var = self.aggr_vars[node_arg].pop(0).n3()  # type: ignore[attr-defined]
+                grp_var = self.aggr_vars[node_arg].pop(0).n3()
                 return grp_var
             else:
-                # type error: "Identifier" has no attribute "n3"
-                return node_arg.n3()  # type: ignore[attr-defined]
+                return node_arg.n3()
         elif isinstance(node_arg, CompValue):
             return "{" + node_arg.name + "}"
         elif isinstance(node_arg, Expr):

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -61,8 +61,7 @@ def _node_to_sparql(node: "Node") -> str:
             "SPARQLStore does not support BNodes! "
             "See http://www.w3.org/TR/sparql11-query/#BGPsparqlBNodes"
         )
-    # type error: "Node" has no attribute "n3"
-    return node.n3()  # type: ignore[attr-defined]
+    return node.n3()
 
 
 class SPARQLStore(SPARQLConnector, Store):

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -20,6 +20,7 @@ underlying Graph:
 * Numerical Ranges
 
 """
+import abc
 import re
 from fractions import Fraction
 
@@ -128,12 +129,16 @@ def _is_valid_unicode(value: Union[str, bytes]) -> bool:
     return True
 
 
-class Node:
+class Node(abc.ABC):
     """
     A Node in the Graph.
     """
 
     __slots__ = ()
+
+    @abc.abstractmethod
+    def n3(self, namespace_manager: Optional["NamespaceManager"] = None) -> str:
+        ...
 
 
 class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph

--- a/test/utils/dawg_manifest.py
+++ b/test/utils/dawg_manifest.py
@@ -46,12 +46,12 @@ class ManifestEntry:
     result_cardinality: Optional[URIRef] = field(init=False)
 
     def __post_init__(self) -> None:
-        type = self.value(RDF.type, IdentifiedNode)
+        type = self.value(RDF.type, IdentifiedNode)  # type: ignore[type-abstract]
         assert type is not None
         self.type = type
 
-        self.action = self.value(MF.action, IdentifiedNode)
-        self.result = self.value(MF.result, IdentifiedNode)
+        self.action = self.value(MF.action, IdentifiedNode)  # type: ignore[type-abstract]
+        self.result = self.value(MF.result, IdentifiedNode)  # type: ignore[type-abstract]
         self.result_cardinality = self.value(MF.resultCardinality, URIRef)
         if self.result_cardinality is not None:
             assert self.result_cardinality == MF.LaxCardinality


### PR DESCRIPTION
# Summary of changes

Attempt to make `rdflib.term.Node` as well as `rdflib.term.Identifier` and `rdflib.term.IdentifiedNode` abstract base classes.
Due to this change a few `type: ignore` comments can be removed from the main library. However, three `type: ignore` comments also need to be added to a test file (though this seems reasonable in the specific case).

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

