### PR TITLE
fix: `queryGraph` selection for `query` and `update`

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1544,13 +1544,19 @@ class Graph(Node):
         initBindings = initBindings or {}  # noqa: N806
         initNs = initNs or dict(self.namespaces())  # noqa: N806
 
+        if self.default_union:
+            query_graph = "__UNION__"
+        elif isinstance(self, ConjunctiveGraph):
+            query_graph = self.default_context.identifier
+        else:
+            query_graph = self.identifier
         if hasattr(self.store, "query") and use_store_provided:
             try:
                 return self.store.query(
                     query_object,
                     initNs,
                     initBindings,
-                    self.default_union and "__UNION__" or self.identifier,
+                    query_graph,
                     **kwargs,
                 )
             except NotImplementedError:
@@ -1592,13 +1598,20 @@ class Graph(Node):
         initBindings = initBindings or {}  # noqa: N806
         initNs = initNs or dict(self.namespaces())  # noqa: N806
 
+        if self.default_union:
+            query_graph = "__UNION__"
+        elif isinstance(self, ConjunctiveGraph):
+            query_graph = self.default_context.identifier
+        else:
+            query_graph = self.identifier
+
         if hasattr(self.store, "update") and use_store_provided:
             try:
                 return self.store.update(
                     update_object,
                     initNs,
                     initBindings,
-                    self.default_union and "__UNION__" or self.identifier,
+                    query_graph,
                     **kwargs,
                 )
             except NotImplementedError:

--- a/test/test_graph/test_graph_store.py
+++ b/test/test_graph/test_graph_store.py
@@ -4,27 +4,32 @@ Tests for usage of the Store interface from Graph/NamespaceManager.
 
 import itertools
 import logging
+from test.data import SIMPLE_TRIPLE_GRAPH
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Iterable,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
     Type,
     Union,
 )
+from unittest.mock import patch
 
 import pytest
 
 import rdflib.namespace
-from rdflib.graph import Graph
+from rdflib.graph import ConjunctiveGraph, Dataset, Graph
 from rdflib.namespace import Namespace
+from rdflib.plugins.sparql.sparql import Query
 from rdflib.plugins.stores.memory import Memory
+from rdflib.query import Result
 from rdflib.store import Store
-from rdflib.term import URIRef
+from rdflib.term import Identifier, URIRef, Variable
 
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet
@@ -69,7 +74,7 @@ EGNS_V1 = EGNS["v1"]
 EGNS_V2 = EGNS["v2"]
 
 
-def make_test_graph_store_bind_cases(
+def make_graph_store_bind_cases(
     store_type: Type[Store] = Memory,
     graph_type: Type[Graph] = Graph,
 ) -> Iterable[Union[Tuple[Any, ...], "ParameterSet"]]:
@@ -194,9 +199,9 @@ def make_test_graph_store_bind_cases(
 @pytest.mark.parametrize(
     ["graph_factory", "ops", "expected_bindings"],
     itertools.chain(
-        make_test_graph_store_bind_cases(),
-        make_test_graph_store_bind_cases(store_type=MemoryWithoutBindOverride),
-        make_test_graph_store_bind_cases(graph_type=GraphWithoutBindOverrideFix),
+        make_graph_store_bind_cases(),
+        make_graph_store_bind_cases(store_type=MemoryWithoutBindOverride),
+        make_graph_store_bind_cases(graph_type=GraphWithoutBindOverrideFix),
     ),
 )
 def test_graph_store_bind(
@@ -205,9 +210,121 @@ def test_graph_store_bind(
     expected_bindings: NamespaceBindings,
 ) -> None:
     """
-    The expected sequence of graph operations results in the expected namespace bindings.
+    The expected sequence of graph operations results in the expected
+    namespace bindings.
     """
     graph = graph_factory()
     for op in ops:
         op(graph)
     check_ns(graph, expected_bindings)
+
+
+@pytest.mark.parametrize(
+    ("graph_factory", "query_graph"),
+    [
+        (Graph, lambda graph: graph.identifier),
+        (ConjunctiveGraph, "__UNION__"),
+        (Dataset, lambda graph: graph.default_context.identifier),
+        (lambda store: Dataset(store=store, default_union=True), "__UNION__"),
+    ],
+)
+def test_query_query_graph(
+    graph_factory: Callable[[Store], Graph],
+    query_graph: Union[str, Callable[[Graph], str]],
+) -> None:
+    """
+    The `Graph.query` method passes the correct ``queryGraph`` argument
+    to stores that have implemented a `Store.query` method.
+    """
+
+    result = Result("SELECT")
+    result.vars = [Variable("s"), Variable("p"), Variable("o")]
+    result.bindings = [
+        {
+            Variable("s"): URIRef("http://example.org/subject"),
+            Variable("p"): URIRef("http://example.org/predicate"),
+            Variable("o"): URIRef("http://example.org/object"),
+        },
+    ]
+
+    query_string = r"FAKE QUERY, NOT USED"
+    store = Memory()
+    graph = graph_factory(store)
+
+    if callable(query_graph):
+        query_graph = query_graph(graph)
+
+    def mock_query(
+        query: Union[Query, str],
+        initNs: Mapping[str, Any],  # noqa: N803
+        initBindings: Mapping[str, Identifier],  # noqa: N803
+        queryGraph: str,
+        **kwargs,
+    ) -> Result:
+        assert query_string == query
+        assert dict(store.namespaces()) == initNs
+        assert {} == initBindings
+        assert query_graph == queryGraph
+        assert {} == kwargs
+        return result
+
+    with patch.object(store, "query", wraps=mock_query) as wrapped_query:
+        result = graph.query(query_string)
+        assert result.type == "SELECT"
+        assert list(result) == list(SIMPLE_TRIPLE_GRAPH.triples((None, None, None)))
+        assert wrapped_query.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("graph_factory", "query_graph"),
+    [
+        (Graph, lambda graph: graph.identifier),
+        (ConjunctiveGraph, "__UNION__"),
+        (Dataset, lambda graph: graph.default_context.identifier),
+        (lambda store: Dataset(store=store, default_union=True), "__UNION__"),
+    ],
+)
+def test_update_query_graph(
+    graph_factory: Callable[[Store], Graph],
+    query_graph: Union[str, Callable[[Graph], str]],
+) -> None:
+    """
+    The `Graph.update` method passes the correct ``queryGraph`` argument
+    to stores that have implemented a `Store.update` method.
+    """
+
+    result = Result("SELECT")
+    result.vars = [Variable("s"), Variable("p"), Variable("o")]
+    result.bindings = [
+        {
+            Variable("s"): URIRef("http://example.org/subject"),
+            Variable("p"): URIRef("http://example.org/predicate"),
+            Variable("o"): URIRef("http://example.org/object"),
+        },
+    ]
+
+    update_string = r"FAKE UPDATE, NOT USED"
+    store = Memory()
+    graph = graph_factory(store)
+
+    if callable(query_graph):
+        query_graph = query_graph(graph)
+
+    def mock_update(
+        query: Union[Query, str],
+        initNs: Mapping[str, Any],  # noqa: N803
+        initBindings: Mapping[str, Identifier],  # noqa: N803
+        queryGraph: str,
+        **kwargs,
+    ) -> None:
+        assert update_string == query
+        assert dict(store.namespaces()) == initNs
+        assert {} == initBindings
+        assert query_graph == queryGraph
+        assert {} == kwargs
+
+    with patch.object(store, "update", wraps=mock_update) as wrapped_update:
+        graph.update(update_string)
+        assert result.type == "SELECT"
+        assert list(result) == list(SIMPLE_TRIPLE_GRAPH.triples((None, None, None)))
+        assert wrapped_update.call_count == 1

--- a/test/test_graph/test_graph_store.py
+++ b/test/test_graph/test_graph_store.py
@@ -237,9 +237,9 @@ def test_query_query_graph(
     to stores that have implemented a `Store.query` method.
     """
 
-    result = Result("SELECT")
-    result.vars = [Variable("s"), Variable("p"), Variable("o")]
-    result.bindings = [
+    mock_result = Result("SELECT")
+    mock_result.vars = [Variable("s"), Variable("p"), Variable("o")]
+    mock_result.bindings = [
         {
             Variable("s"): URIRef("http://example.org/subject"),
             Variable("p"): URIRef("http://example.org/predicate"),
@@ -266,12 +266,14 @@ def test_query_query_graph(
         assert {} == initBindings
         assert query_graph == queryGraph
         assert {} == kwargs
-        return result
+        return mock_result
 
     with patch.object(store, "query", wraps=mock_query) as wrapped_query:
-        result = graph.query(query_string)
-        assert result.type == "SELECT"
-        assert list(result) == list(SIMPLE_TRIPLE_GRAPH.triples((None, None, None)))
+        actual_result = graph.query(query_string)
+        assert actual_result.type == "SELECT"
+        assert list(actual_result) == list(
+            SIMPLE_TRIPLE_GRAPH.triples((None, None, None))
+        )
         assert wrapped_query.call_count == 1
 
 
@@ -292,16 +294,6 @@ def test_update_query_graph(
     The `Graph.update` method passes the correct ``queryGraph`` argument
     to stores that have implemented a `Store.update` method.
     """
-
-    result = Result("SELECT")
-    result.vars = [Variable("s"), Variable("p"), Variable("o")]
-    result.bindings = [
-        {
-            Variable("s"): URIRef("http://example.org/subject"),
-            Variable("p"): URIRef("http://example.org/predicate"),
-            Variable("o"): URIRef("http://example.org/object"),
-        },
-    ]
 
     update_string = r"FAKE UPDATE, NOT USED"
     store = Memory()
@@ -325,6 +317,4 @@ def test_update_query_graph(
 
     with patch.object(store, "update", wraps=mock_update) as wrapped_update:
         graph.update(update_string)
-        assert result.type == "SELECT"
-        assert list(result) == list(SIMPLE_TRIPLE_GRAPH.triples((None, None, None)))
         assert wrapped_update.call_count == 1


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

`Store.query` and `Store.update` have a parameter `queryGraph`, which
presumably specifies the initial [active
graph](https://www.w3.org/TR/sparql11-query/#sparqlDataset).

When SPARQL is evaluated against a `Dataset`, the initial active graph
should be the default graph
[[ref](https://www.w3.org/TR/sparql11-query/#sparqlAlgebraEval)],
however, when calling `rdflib.graph.Graph.query` or
`rdflib.graph.Graph.update`, they were passing
`rdflib.graph.Dataset.identifier` as the value of `queryGraph` to
`Store.query` and `Store.update`. The passed value would not have been
the identifier of the default graph of the Dataset, and would instead
have been an identifier that has really no meaning whatsoever (see
<https://github.com/RDFLib/rdflib/issues/2537>).

This change fixes the selection of the initial active graph by passing
`ConjunctiveGraph.default_context.identifier` if the `Graph.query` or
`Graph.update` method is called on a `ConjunctiveGraph` and
`ConjunctiveGraph.default_union` is `False`.

Related issues:
- Fixes <https://github.com/RDFLib/rdflib/issues/2538>.

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

