### PR TITLE
Added '_' to recognized endings of prefixes for jsonld.

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -66,7 +66,7 @@ class Defined(int):
 UNDEF = Defined(0)
 
 # From <https://tools.ietf.org/html/rfc3986#section-2.2>
-URI_GEN_DELIMS = (":", "/", "?", "#", "[", "]", "@")
+URI_GEN_DELIMS = (":", "/", "?", "#", "[", "]", "@", "_")
 
 
 class Context:


### PR DESCRIPTION
# Summary of changes

Added '_' as possible ending for a prefix for the `jsonld`-parser.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

