### PR TITLE
Remove unused open method in SPARQLUpdateStore

### DIFF
--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -644,24 +644,6 @@ class SPARQLUpdateStore(SPARQLStore):
         self._edits: Optional[List[str]] = None
         self._updates = 0
 
-    def open(
-        self, configuration: Union[str, Tuple[str, str]], create: bool = False
-    ) -> None:
-        """
-        This method is included so that calls to this Store via Graph, e.g.
-        Graph("SPARQLStore"), can set the required parameters
-        """
-        if type(configuration) == str:  # noqa: E721
-            self.query_endpoint = configuration
-        elif type(configuration) == tuple:
-            self.query_endpoint = configuration[0]
-            self.update_endpoint = configuration[1]
-        else:
-            raise Exception(
-                "configuration must be either a string (a single query endpoint URI) "
-                "or a tuple (a query/update endpoint URI pair)"
-            )
-
     def query(self, *args: Any, **kwargs: Any) -> Result:
         if not self.autocommit and not self.dirty_reads:
             self.commit()
@@ -688,8 +670,7 @@ class SPARQLUpdateStore(SPARQLStore):
             self.commit()
         return SPARQLStore.__len__(self, *args, **kwargs)
 
-    # TODO: FIXME: open is defined twice
-    def open(self, configuration: Union[str, Tuple[str, str]], create: bool = False) -> None:  # type: ignore[no-redef]  # noqa: F811
+    def open(self, configuration: Union[str, Tuple[str, str]], create: bool = False) -> None:
         """
         sets the endpoint URLs for this SPARQLStore
 


### PR DESCRIPTION

# Summary of changes

Removes the first, unused open method in SPARQLUpdateStore

Closes #2053

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Granted [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

