### PR TITLE
Add SHACL path to RDFLib Path utility and corresponding tests

### DIFF
--- a/rdflib/extras/shacl.py
+++ b/rdflib/extras/shacl.py
@@ -1,0 +1,92 @@
+"""
+Utilities for interacting with SHACL Shapes Graphs more easily.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from rdflib import Graph, Literal, URIRef, paths
+from rdflib.namespace import RDF, SH
+from rdflib.paths import Path
+from rdflib.term import Node
+
+
+class SHACLPathError(Exception):
+    pass
+
+
+# This implementation is roughly based on
+# pyshacl.helper.sparql_query_helper::SPARQLQueryHelper._shacl_path_to_sparql_path
+def parse_shacl_path(
+    shapes_graph: Graph,
+    path_identifier: Node,
+) -> Union[URIRef, Path]:
+    """
+    Parse a valid SHACL path (e.g. the object of a triple with predicate sh:path)
+    from a :class:`Graph` as a :class:`URIRef` if the path is simply a predicate
+    or a :class:`Path` otherwise.
+
+    :param shapes_graph: A :class:`Graph` containing the path to be parsed
+    :param path_identifier: A :class:`URIRef` or A :class:`BNode` of the path
+    :return: A :class:`URIRef` or a :class:`Path` representing the SHACL Path
+    """
+    path: Optional[Union[URIRef, Path]] = None
+
+    # Literals are not allowed.
+    if isinstance(path_identifier, Literal):
+        raise TypeError("Literals are not a valid SHACL path.")
+
+    # If a path is a URI, that's the whole path.
+    elif isinstance(path_identifier, URIRef):
+        if path_identifier == RDF.nil:
+            raise SHACLPathError(
+                "A list of SHACL Paths must contain at least two path items."
+            )
+        path = path_identifier
+
+    # Handle Sequence Paths
+    elif shapes_graph.value(path_identifier, RDF.first) is not None:
+        sequence = list(shapes_graph.items(path_identifier))
+        if len(sequence) < 2:
+            raise SHACLPathError(
+                "A list of SHACL Sequence Paths must contain at least two path items."
+            )
+        path = paths.SequencePath(
+            *(parse_shacl_path(shapes_graph, path) for path in sequence)
+        )
+
+    # Handle sh:inversePath
+    elif inverse_path := shapes_graph.value(path_identifier, SH.inversePath):
+        path = paths.InvPath(parse_shacl_path(shapes_graph, inverse_path))
+
+    # Handle sh:alternativePath
+    elif alternative_path := shapes_graph.value(path_identifier, SH.alternativePath):
+        alternatives = list(shapes_graph.items(alternative_path))
+        if len(alternatives) < 2:
+            raise SHACLPathError(
+                "List of SHACL alternate paths must have at least two path items."
+            )
+        path = paths.AlternativePath(
+            *(
+                parse_shacl_path(shapes_graph, alternative)
+                for alternative in alternatives
+            )
+        )
+
+    # Handle sh:zeroOrMorePath
+    elif zero_or_more_path := shapes_graph.value(path_identifier, SH.zeroOrMorePath):
+        path = paths.MulPath(parse_shacl_path(shapes_graph, zero_or_more_path), "*")
+
+    # Handle sh:oneOrMorePath
+    elif one_or_more_path := shapes_graph.value(path_identifier, SH.oneOrMorePath):
+        path = paths.MulPath(parse_shacl_path(shapes_graph, one_or_more_path), "+")
+
+    # Handle sh:zeroOrOnePath
+    elif zero_or_one_path := shapes_graph.value(path_identifier, SH.zeroOrOnePath):
+        path = paths.MulPath(parse_shacl_path(shapes_graph, zero_or_one_path), "?")
+
+    # Raise error if none of the above options were found
+    elif path is None:
+        raise SHACLPathError(f"Cannot parse {repr(path_identifier)} as a SHACL Path.")
+
+    return path

--- a/rdflib/extras/shacl.py
+++ b/rdflib/extras/shacl.py
@@ -23,12 +23,12 @@ def parse_shacl_path(
 ) -> Union[URIRef, Path]:
     """
     Parse a valid SHACL path (e.g. the object of a triple with predicate sh:path)
-    from a :class:`Graph` as a :class:`URIRef` if the path is simply a predicate
-    or a :class:`Path` otherwise.
+    from a :class:`~rdflib.graph.Graph` as a :class:`~rdflib.term.URIRef` if the path
+    is simply a predicate or a :class:`~rdflib.paths.Path` otherwise.
 
-    :param shapes_graph: A :class:`Graph` containing the path to be parsed
-    :param path_identifier: A :class:`URIRef` or A :class:`BNode` of the path
-    :return: A :class:`URIRef` or a :class:`Path` representing the SHACL Path
+    :param shapes_graph: A :class:`~rdflib.graph.Graph` containing the path to be parsed
+    :param path_identifier: A :class:`~rdflib.term.Node` of the path
+    :return: A :class:`~rdflib.term.URIRef` or a :class:`~rdflib.paths.Path`
     """
     path: Optional[Union[URIRef, Path]] = None
 

--- a/test/test_extras/test_shacl_extras.py
+++ b/test/test_extras/test_shacl_extras.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Union
+
+import pytest
+
+from rdflib import Graph, URIRef
+from rdflib.extras.shacl import SHACLPathError, parse_shacl_path
+from rdflib.namespace import SH, Namespace
+from rdflib.paths import Path
+
+EX = Namespace("http://example.org/")
+
+
+# Create a graph that gets loaded only once
+@pytest.fixture(scope="module")
+def path_source_data():
+    data = """
+        @prefix ex: <http://example.org/> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+
+
+        ex:TestPropShape1
+            sh:path ex:pred1 ;
+        .
+        ex:TestPropShape2a
+            sh:path (
+                ex:pred1
+                ex:pred2
+                ex:pred3
+            ) ;
+        .
+        ex:TestPropShape2b
+            sh:path (
+                (
+                    ex:pred1
+                    ex:pred2
+                )
+                ex:pred3
+            ) ;
+        .
+        ex:TestPropShape3
+            sh:path [
+                sh:inversePath ex:pred1 ;
+            ] ;
+        .
+        ex:TestPropShape4a
+            sh:path [
+                sh:alternativePath (
+                    ex:pred1
+                    ex:pred2
+                    ex:pred3
+                ) ;
+            ] ;
+        .
+        ex:TestPropShape4b
+            sh:path [
+                sh:alternativePath (
+                    [
+                        sh:alternativePath (
+                            ex:pred1
+                            ex:pred2
+                        ) ;
+                    ]
+                    ex:pred3
+                ) ;
+            ] ;
+        .
+        ex:TestPropShape5
+            sh:path [
+                sh:zeroOrMorePath ex:pred1 ;
+            ] ;
+        .
+        ex:TestPropShape6
+            sh:path [
+                sh:oneOrMorePath ex:pred1 ;
+            ] ;
+        .
+        ex:TestPropShape7
+            sh:path [
+                sh:zeroOrOnePath ex:pred1 ;
+            ] ;
+        .
+        ex:TestPropShape8
+            sh:path [
+                sh:zeroOrMorePath [
+                    sh:inversePath ex:pred1 ;
+                ] ;
+            ] ;
+        .
+        ex:TestPropShape9
+            sh:path [
+                sh:alternativePath (
+                    [
+                        sh:inversePath ex:pred1 ;
+                    ]
+                    (
+                        ex:pred1
+                        ex:pred2
+                    )
+                    [
+                        sh:alternativePath (
+                            ex:pred1
+                            ex:pred2
+                            ex:pred3
+                        ) ;
+                    ]
+                ) ;
+            ] ;
+        .
+        ex:TestPropShape10
+            sh:path (
+                [
+                    sh:zeroOrMorePath [
+                        sh:inversePath ex:pred1 ;
+                    ] ;
+                ]
+                [
+                    sh:alternativePath (
+                        [
+                            sh:zeroOrMorePath [
+                                sh:inversePath ex:pred1 ;
+                            ] ;
+                        ]
+                        [
+                            sh:alternativePath (
+                                ex:pred1
+                                [
+                                    sh:oneOrMorePath ex:pred2 ;
+                                ]
+                                [
+                                    sh:zeroOrMorePath ex:pred3 ;
+                                ]
+                            ) ;
+                        ]
+                    ) ;
+                ]
+            ) ;
+        .
+        ex:InvalidTestPropShape1
+            sh:path () ;
+        .
+        ex:InvalidTestPropShape2
+            sh:path (
+                ex:pred1
+            ) ;
+        .
+        ex:InvalidTestPropShape3
+            sh:path [
+                sh:alternativePath () ;
+            ] ;
+        .
+        ex:InvalidTestPropShape4
+            sh:path [
+                sh:alternativePath (
+                    ex:pred1
+                ) ;
+            ] ;
+        .
+        ex:InvalidTestPropShape5
+            sh:path [
+                ex:invalidShaclPathProperty ex:pred1
+            ] ;
+        .
+        ex:InvalidTestPropShape6
+            sh:path "This can't be a literal!";
+        .
+        """
+    g = Graph()
+    g.parse(data=data, format="turtle")
+    yield g
+
+
+@pytest.mark.parametrize(
+    ("resource", "expected"),
+    (
+        # Single SHACL Path
+        (EX.TestPropShape1, EX.pred1),
+        (EX.TestPropShape2a, EX.pred1 / EX.pred2 / EX.pred3),
+        (EX.TestPropShape2b, EX.pred1 / EX.pred2 / EX.pred3),
+        (EX.TestPropShape3, ~EX.pred1),
+        (EX.TestPropShape4a, EX.pred1 | EX.pred2 | EX.pred3),
+        (EX.TestPropShape4b, EX.pred1 | EX.pred2 | EX.pred3),
+        (EX.TestPropShape5, EX.pred1 * "*"),  # type: ignore[operator]
+        (EX.TestPropShape6, EX.pred1 * "+"),  # type: ignore[operator]
+        (EX.TestPropShape7, EX.pred1 * "?"),  # type: ignore[operator]
+        # SHACL Path Combinations
+        (EX.TestPropShape8, ~EX.pred1 * "*"),
+        (
+            EX.TestPropShape9,
+            ~EX.pred1 | EX.pred1 / EX.pred2 | EX.pred1 | EX.pred2 | EX.pred3,
+        ),
+        (
+            EX.TestPropShape10,
+            ~EX.pred1
+            * "*"
+            / (~EX.pred1 * "*" | EX.pred1 | EX.pred2 * "+" | EX.pred3 * "*"),  # type: ignore[operator]
+        ),
+        # Invalid Operations
+        (EX.InvalidTestPropShape1, SHACLPathError),
+        (EX.InvalidTestPropShape2, SHACLPathError),
+        (EX.InvalidTestPropShape3, SHACLPathError),
+        (EX.InvalidTestPropShape4, SHACLPathError),
+        (EX.InvalidTestPropShape5, SHACLPathError),
+        (EX.InvalidTestPropShape6, TypeError),
+    ),
+)
+def test_parse_shacl_path(
+    path_source_data: Graph, resource: URIRef, expected: Union[URIRef, Path]
+):
+    path_root = path_source_data.value(resource, SH.path)
+
+    if isinstance(expected, type):
+        with pytest.raises(expected):  # type: ignore[arg-type]
+            parse_shacl_path(path_source_data, path_root)  # type: ignore[arg-type]
+    else:
+        assert parse_shacl_path(path_source_data, path_root) == expected  # type: ignore[arg-type]


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->
This adds a utility to parse valid SHACL Paths (e.g. the objects of triples with predicate `sh:path`) into an RDFLib-friendly object. The resulting object could either be:
 - A `URIRef`, when the path is simply a predicate
 - A `Path`, when the path is complex (e.g. `[sh:inversePath skos:broader]`)

This enables easy evaluation and manipulation of SHACL paths using RDFLib. For example:
- The output can be passed to any of several methods (`Graph.triples`, `Graph.value`, etc.) as a predicate to get value(s) at that path
- The `n3` method can be used to get a SPARQL property path representation of the path

Note that `pyshacl` does not have a utility to do this- rather, it only evaluates SHACL paths.
# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

