### PR TITLE
Fix LongTurtle multi-BN object serialization bug

### DIFF
--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.12.0-slim@sha256:43a49c9cc2e614468e3d1a903aabe17a97a4c788c76cf5337b5cdc3535b07d4f
+FROM docker.io/library/python:3.12.0-slim@sha256:babc0d450bf9ed2b369814bc2f466e53a6ea43f1201f6df4e7988751f755c52c
 
 COPY docker/latest/requirements.txt /var/tmp/build/
 

--- a/rdflib/plugins/serializers/longturtle.py
+++ b/rdflib/plugins/serializers/longturtle.py
@@ -292,6 +292,8 @@ class LongTurtleSerializer(RecursiveSerializer):
         if count > 1:
             if not isinstance(objects[0], BNode):
                 self.write("\n" + self.indent(1))
+            else:
+                self.write(" ")
             first_nl = True
         self.path(objects[0], OBJECT, newline=first_nl)
         for obj in objects[1:]:

--- a/test/test_serializers/test_serializer_longturtle.py
+++ b/test/test_serializers/test_serializer_longturtle.py
@@ -181,7 +181,7 @@ def test_longturtle():
     ex:nicholas
         a sdo:Person ;
         sdo:age 41 ;
-        sdo:alternateName
+        sdo:alternateName 
             [
                 sdo:name "Dr N.J. Car" ;
             ] ,
@@ -190,7 +190,7 @@ def test_longturtle():
         sdo:name
             [
                 a cn:CompoundName ;
-                sdo:hasPart
+                sdo:hasPart 
                     [
                         a cn:CompoundName ;
                         rdf:value "Nicholas" ;
@@ -201,7 +201,7 @@ def test_longturtle():
                     ] ,
                     [
                         a cn:CompoundName ;
-                        sdo:hasPart
+                        sdo:hasPart 
                             [
                                 a cn:CompoundName ;
                                 rdf:value "Car" ;


### PR DESCRIPTION
# Summary of changes

Ensure LongTurtle serializer adds a space between the first BN object and a predicate when there are multiple BNs for that predicate.


# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

