### PR TITLE
fix: use guess_format when plugin for format not found

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1475,7 +1475,19 @@ class Graph(Node):
             if format is None:
                 format = "turtle"
                 could_not_guess_format = True
-        parser = plugin.get(format, Parser)()
+        try:
+            parser = plugin.get(format, Parser)()
+        except plugin.PluginException:
+            # Handle the case when a URLInputSource returns RDF but with the headers
+            # as a format that does not exist in the plugin system.
+            # Use guess_format to guess the format based on the input's file suffix.
+            format = rdflib.util.guess_format(
+                source if not isinstance(source, InputSource) else str(source)
+            )
+            if format is not None:
+                parser = plugin.get(format, Parser)()
+            else:
+                raise
         try:
             # TODO FIXME: Parser.parse should have **kwargs argument.
             parser.parse(source, self, **args)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1484,10 +1484,9 @@ class Graph(Node):
             format = rdflib.util.guess_format(
                 source if not isinstance(source, InputSource) else str(source)
             )
-            if format is not None:
-                parser = plugin.get(format, Parser)()
-            else:
+            if format is None:
                 raise
+            parser = plugin.get(format, Parser)()
         try:
             # TODO FIXME: Parser.parse should have **kwargs argument.
             parser.parse(source, self, **args)

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -391,6 +391,7 @@ def test_guess_format_for_parse_http(
         checker.check(len(graph))
 
 
+@pytest.mark.webtest
 def test_guess_format_for_parse_http_text_plain():
     # Any raw url of a file from GitHub will return the content-type with text/plain.
     url = "https://raw.githubusercontent.com/AGLDWG/vocpub-profile/master/validators/validator.ttl"

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -391,6 +391,18 @@ def test_guess_format_for_parse_http(
         checker.check(len(graph))
 
 
+def test_guess_format_for_parse_http_text_plain():
+    # Any raw url of a file from GitHub will return the content-type with text/plain.
+    url = "https://raw.githubusercontent.com/AGLDWG/vocpub-profile/master/validators/validator.ttl"
+    graph = Graph().parse(url)
+    assert len(graph) > 0
+
+    # A url that returns content-type text/html.
+    url = "https://github.com/RDFLib/rdflib/issues/2734"
+    with pytest.raises(PluginException):
+        graph = Graph().parse(url)
+
+
 def test_parse_file_uri(make_graph: GraphFactory):
     EG = Namespace("http://example.org/#")  # noqa: N806
     g = make_graph()


### PR DESCRIPTION
# Summary of changes

Fixes https://github.com/RDFLib/rdflib/issues/2734
- add fallback to use `rdflib.util.guess_format` when `PluginException` occurs
- ensure `PluginException` still occurs when `guess_format` fails

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

