### PR TITLE
fix: readthedocs failure with poetry 1.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,10 +21,9 @@ build:
     # the readthedocs environment.
     - pip install -r devtools/requirements-poetry.in
     post_install:
-    - poetry config virtualenvs.create false
-    - poetry install --only=main --only=docs --extras=html
-    - poetry env info
+    - poetry export --only=main --only=docs --extras=html
     - poetry run python -c "from rdflib import Graph; print(Graph)"
+    - pip install --no-cache-dir -r requirements.txt
     - python -c "from rdflib import Graph; print(Graph)"
 
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
     # the readthedocs environment.
     - pip install -r devtools/requirements-poetry.in
     post_install:
-    - poetry export --only=main --only=docs --extras=html
+    - poetry export --only=main --only=docs --extras=html -o requirements.txt
     - pip install --no-cache-dir -r requirements.txt
     - python -c "from rdflib import Graph; print(Graph)"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,6 @@ build:
     - pip install -r devtools/requirements-poetry.in
     post_install:
     - poetry export --only=main --only=docs --extras=html
-    - poetry run python -c "from rdflib import Graph; print(Graph)"
     - pip install --no-cache-dir -r requirements.txt
     - python -c "from rdflib import Graph; print(Graph)"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,8 @@ build:
     - poetry config virtualenvs.create false
     - poetry install --only=main --only=docs --extras=html
     - poetry env info
+    - poetry run python -c "from rdflib import Graph; print(Graph)"
+    - python -c "from rdflib import Graph; print(Graph)"
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,6 +23,7 @@ build:
     post_install:
     - poetry export --only=main --only=docs --extras=html -o requirements.txt
     - pip install --no-cache-dir -r requirements.txt
+    - pip install .
     - python -c "from rdflib import Graph; print(Graph)"
 
 sphinx:

--- a/devtools/requirements-poetry.in
+++ b/devtools/requirements-poetry.in
@@ -1,3 +1,3 @@
 # Fixing this here as readthedocs can't use the compiled requirements-poetry.txt
 # due to conflicts.
-poetry==1.7.1
+poetry==1.8.0


### PR DESCRIPTION
# Summary of changes

There's some changed behaviour in readthedocs CI environment and poetry v1.8.0 and above. Running a `poetry install` does not install into the correct python virtual environment that is set up by readthedocs.

This PR fixes the above issue by performing a poetry export into a `requirements.txt` file and then installing the dependencies and rdflib itself via pip, ensuring everything is installed into readthedocs virtual environment.

This should unblock the Dependabot PR https://github.com/RDFLib/rdflib/pull/2743 that updates poetry to the latest version (1.8.2).

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

