### PR TITLE
removed unused #ignore comments in algebra.py

### DIFF
--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -1007,8 +1007,8 @@ class _AlgebraTranslator:
                 return node_arg.n3()
         elif isinstance(node_arg, CompValue):
             return "{" + node_arg.name + "}"
-        elif isinstance(node_arg, Expr):  # type: ignore[unreachable]
-            return "{" + node_arg.name + "}"  # type: ignore[unreachable]
+        elif isinstance(node_arg, Expr):
+            return "{" + node_arg.name + "}"
         elif isinstance(node_arg, str):
             return node_arg
         else:


### PR DESCRIPTION
Got an 
```
error: Unused "type: ignore" comment  [unused-ignore]
```
when running mypy. Removed those comments.



# Summary of changes

removed two `# type: ignore[unreachable]` comments in sparql/algebra.py

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

