### PR TITLE
Let jsonld handle value nodes/Literal for context search

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -158,12 +158,15 @@ class Context:
             if not isinstance(rtype, list):
                 rtype = [rtype] if rtype else []
 
+            typeterm = None
             for rt in rtype:
-                typeterm = self.terms.get(rt)
-                if typeterm:
+                try:
+                    typeterm = self.terms.get(rt)
+                except TypeError:
+                    #extra lenience, triggers if type is set to a literal
+                    pass
+                if typeterm is not None:
                     break
-            else:
-                typeterm = None
 
             if typeterm and typeterm.context:
                 subcontext = self.subcontext(typeterm.context, propagate=False)

--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -163,7 +163,7 @@ class Context:
                 try:
                     typeterm = self.terms.get(rt)
                 except TypeError:
-                    #extra lenience, triggers if type is set to a literal
+                    # extra lenience, triggers if type is set to a literal
                     pass
                 if typeterm is not None:
                     break


### PR DESCRIPTION
If jsonld parser is set from version 1.0 to 1.1 it looses the ability to handle value nodes that are set as `@type` for an object. This change should only make the parser ignore value nodes when searching for an already found context. Thus the ability to handle those is not lost, when setting the parser version to 1.1

This behaviour is not expected of the jsonld parser. Other parsers will fail, when a `@type` is given a literal.
Necessary change to set the default version of the parser to 1.1, because roundtrip test fails otherwise

Background discussion to this change is #2747. (Issue #2606 is the reason for this change.)
 
# Summary of changes

in jsonld-contexts ignore dicts(value nodes), when searching for a context
No changes in tests or documentation, because this is not an expected behaviour.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

