### PR TITLE
docs: fix "Build docs" command in developers.rst

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -345,7 +345,7 @@ Some useful commands for working with the task in the taskfile is given below:
     task validate
 
     # Build docs
-    task docs:build
+    task docs
 
     # Run live-preview on the docs
     task docs:live-server


### PR DESCRIPTION
# Summary of changes

Fix the "Build docs" command in docs/developers.rst to, `task docs:build`, to match the actual task
in Taskfile.yml, `task docs` .

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] All tests and type checking are not passing, but I believe this is due to pre-existing issues.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

