### PR TITLE
Assign consistent bnode identifiers in N3 formulas

### DIFF
--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -905,7 +905,7 @@ class SinkParser:
         term = self._anonymousNodes.get(ln, None)
         if term is not None:
             return term
-        term = self._store.newBlankNode(self._context, why=self._reason2)
+        term = self._store.newBlankNode(self._context, uri='#' + ln, why=self._reason2)
         self._anonymousNodes[ln] = term
         return term
 

--- a/test/test_parsers/test_n3_parse_bnodes_in_formulas.py
+++ b/test/test_parsers/test_n3_parse_bnodes_in_formulas.py
@@ -1,16 +1,21 @@
 from rdflib.graph import Graph
 from rdflib.term import BNode, URIRef
+from rdflib.plugins.parsers.notation3 import LOG_implies_URI
 
 DATA = """
-{ <http://example.org/#a> <http://example.org/#b> _:c } => { <http://example.org/#b> <http://example.org/#c> _:c }.
+@prefix : <http://example.org/#>.
+
+:a :b _:c.
+{ :a :b _:c } => { :b :c _:c }.
 """
 
+LOG = URIRef(LOG_implies_URI)
 
 class TestBlankNodesInFormulas:
     def test_bnodes_in_a_formula_are_the_same(self):
         g = Graph().parse(data=DATA, format="n3")
-        assert len(g) == 1
-        formula = next(iter(g))
+        assert len(g) == 2
+        formula = next(g.triples((None, LOG, None)))
         assert len(formula) == 3
         head, _, body = formula
         assert len(head) == 1
@@ -21,3 +26,17 @@ class TestBlankNodesInFormulas:
         body_clause = next(iter(body))
         assert isinstance(head_clause, tuple)
         assert head_clause[2] == body_clause[2]
+
+    def test_bnodes_in_a_formula_and_parent_graph_are_the_same(self):
+        g = Graph().parse(data=DATA, format="n3")
+        assert len(g) == 2
+        for triples in g:
+            if triples[1] == LOG:
+                formula = triples
+            else:
+                fact = triples
+        head, _, _ = formula
+        assert len(head) == 1
+        head_clause = next(iter(head))
+        assert isinstance(fact[2], BNode)
+        assert fact[2] == head_clause[2]

--- a/test/test_parsers/test_n3_parse_bnodes_in_formulas.py
+++ b/test/test_parsers/test_n3_parse_bnodes_in_formulas.py
@@ -1,0 +1,23 @@
+from rdflib.graph import Graph
+from rdflib.term import BNode, URIRef
+
+DATA = """
+{ <http://example.org/#a> <http://example.org/#b> _:c } => { <http://example.org/#b> <http://example.org/#c> _:c }.
+"""
+
+
+class TestBlankNodesInFormulas:
+    def test_bnodes_in_a_formula_are_the_same(self):
+        g = Graph().parse(data=DATA, format="n3")
+        assert len(g) == 1
+        formula = next(iter(g))
+        assert len(formula) == 3
+        head, _, body = formula
+        assert len(head) == 1
+        head_clause = next(iter(head))
+        assert isinstance(head_clause, tuple)
+        assert isinstance(head_clause[2], BNode)
+        assert len(body) == 1
+        body_clause = next(iter(body))
+        assert isinstance(head_clause, tuple)
+        assert head_clause[2] == body_clause[2]


### PR DESCRIPTION
# Summary of changes

Blank nodes are assigned inconsistent identifiers when they are within different quoted graphs.
I could not find a normative section in the spec that would define the scope of blank nodes, but [section 3.6.1](https://w3c.github.io/N3/spec/#bnodeprplist) says that we "Then, we use this identifier within our [N3 graph](https://w3c.github.io/N3/spec/#dfn-n3-graph)", where "N3 document represents an [N3 graph](https://w3c.github.io/N3/spec/#dfn-n3-graph)".

# Checklist

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the changed does affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

