### PR TITLE
SPARQL result parsing

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -580,12 +580,6 @@ register(
     "XMLResultParser",
 )
 register(
-    "application/rdf+xml",
-    ResultParser,
-    "rdflib.plugins.sparql.results.graph",
-    "GraphResultParser",
-)
-register(
     "json",
     ResultParser,
     "rdflib.plugins.sparql.results.jsonresults",
@@ -621,3 +615,10 @@ register(
     "rdflib.plugins.sparql.results.tsvresults",
     "TSVResultParser",
 )
+for parser in list(plugins(kind=Parser)):
+    register(
+        parser.name,
+        ResultParser,
+        "rdflib.plugins.sparql.results.graph",
+        "GraphResultParser",
+    )

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -580,12 +580,6 @@ register(
     "XMLResultParser",
 )
 register(
-    "application/sparql-results+xml; charset=UTF-8",
-    ResultParser,
-    "rdflib.plugins.sparql.results.xmlresults",
-    "XMLResultParser",
-)
-register(
     "application/rdf+xml",
     ResultParser,
     "rdflib.plugins.sparql.results.graph",

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -615,9 +615,13 @@ register(
     "rdflib.plugins.sparql.results.tsvresults",
     "TSVResultParser",
 )
-for parser in list(plugins(kind=Parser)):
+
+graph_parsers = {parser.name for parser in plugins(kind=Parser)}
+result_parsers = {parser.name for parser in plugins(kind=ResultParser)}
+graph_result_parsers = graph_parsers - result_parsers
+for parser_name in graph_result_parsers:
     register(
-        parser.name,
+        parser_name,
         ResultParser,
         "rdflib.plugins.sparql.results.graph",
         "GraphResultParser",

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -9,8 +9,10 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from rdflib.query import Result
+from rdflib.plugin import plugins
+from rdflib.query import Result, ResultParser
 from rdflib.term import BNode
+from rdflib.util import FORMAT_MIMETYPE_MAP, RESPONSE_TABLE_FORMAT_MIMETYPE_MAP
 
 log = logging.getLogger(__name__)
 
@@ -22,16 +24,6 @@ class SPARQLConnectorException(Exception):  # noqa: N818
     pass
 
 
-# TODO: Pull in these from the result implementation plugins?
-_response_mime_types = {
-    "xml": "application/sparql-results+xml, application/rdf+xml",
-    "json": "application/sparql-results+json",
-    "csv": "text/csv",
-    "tsv": "text/tab-separated-values",
-    "application/rdf+xml": "application/rdf+xml",
-}
-
-
 class SPARQLConnector:
     """
     this class deals with nitty gritty details of talking to a SPARQL server
@@ -41,7 +33,7 @@ class SPARQLConnector:
         self,
         query_endpoint: Optional[str] = None,
         update_endpoint: Optional[str] = None,
-        returnFormat: str = "xml",  # noqa: N803
+        returnFormat: Optional[str] = "xml",  # noqa: N803
         method: te.Literal["GET", "POST", "POST_FORM"] = "GET",
         auth: Optional[Tuple[str, str]] = None,
         **kwargs,
@@ -95,7 +87,7 @@ class SPARQLConnector:
         if default_graph is not None and type(default_graph) is not BNode:
             params["default-graph-uri"] = default_graph
 
-        headers = {"Accept": _response_mime_types[self.returnFormat]}
+        headers = {"Accept": self.response_mime_types()}
 
         args = copy.deepcopy(self.kwargs)
 
@@ -170,7 +162,7 @@ class SPARQLConnector:
             params["using-named-graph-uri"] = named_graph
 
         headers = {
-            "Accept": _response_mime_types[self.returnFormat],
+            "Accept": self.response_mime_types(),
             "Content-Type": "application/sparql-update; charset=UTF-8",
         }
 
@@ -187,6 +179,28 @@ class SPARQLConnector:
                 self.update_endpoint + qsa, data=query.encode(), headers=args["headers"]
             )
         )
+
+    def response_mime_types(self) -> str:
+        """Construct a HTTP-Header Accept field to reflect the supported mime types.
+
+        If the return_format parameter is set, the mime types are restricted to these accordingly.
+        """
+        sparql_format_mimetype_map = {
+            k: FORMAT_MIMETYPE_MAP.get(k, [])
+            + RESPONSE_TABLE_FORMAT_MIMETYPE_MAP.get(k, [])
+            for k in list(FORMAT_MIMETYPE_MAP.keys())
+            + list(RESPONSE_TABLE_FORMAT_MIMETYPE_MAP.keys())
+        }
+
+        supported_formats = set()
+        for plugin in plugins(name=self.returnFormat, kind=ResultParser):
+            if "/" not in plugin.name:
+                supported_formats.update(
+                    sparql_format_mimetype_map.get(plugin.name, [])
+                )
+            else:
+                supported_formats.add(plugin.name)
+        return ", ".join(supported_formats)
 
 
 __all__ = ["SPARQLConnector", "SPARQLConnectorException"]

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -129,7 +129,7 @@ class SPARQLStore(SPARQLConnector, Store):
         sparql11: bool = True,
         context_aware: bool = True,
         node_to_sparql: _NodeToSparql = _node_to_sparql,
-        returnFormat: str = "xml",  # noqa: N803
+        returnFormat: Optional[str] = "xml",  # noqa: N803
         auth: Optional[Tuple[str, str]] = None,
         **sparqlconnector_kwargs,
     ):

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -74,6 +74,47 @@ _HashableT = TypeVar("_HashableT", bound=Hashable)
 _AnyT = TypeVar("_AnyT")
 
 
+SUFFIX_FORMAT_MAP = {
+    "xml": "xml",
+    "rdf": "xml",
+    "owl": "xml",
+    "n3": "n3",
+    "ttl": "turtle",
+    "nt": "nt",
+    "trix": "trix",
+    "xhtml": "rdfa",
+    "html": "rdfa",
+    "svg": "rdfa",
+    "nq": "nquads",
+    "nquads": "nquads",
+    "trig": "trig",
+    "json": "json-ld",
+    "jsonld": "json-ld",
+    "json-ld": "json-ld",
+}
+
+
+FORMAT_MIMETYPE_MAP = {
+    "xml": ["application/rdf+xml"],
+    "n3": ["text/n3"],
+    "turtle": ["text/turtle"],
+    "nt": ["application/n-triples"],
+    "trix": ["application/trix"],
+    "rdfa": ["text/html", "application/xhtml+xml"],
+    "nquads": ["application/n-quads"],
+    "trig": ["application/trig"],
+    "json-ld": ["application/ld+json"],
+}
+
+
+RESPONSE_TABLE_FORMAT_MIMETYPE_MAP = {
+    "xml": ["application/sparql-results+xml"],
+    "json": ["application/sparql-results+json"],
+    "csv": ["text/csv"],
+    "tsv": ["text/tab-separated-values"],
+}
+
+
 def list2set(seq: Iterable[_HashableT]) -> List[_HashableT]:
     """
     Return a new list without duplicates.
@@ -329,26 +370,6 @@ def parse_date_time(val: str) -> int:
     )
     t = t + tz_offset
     return t
-
-
-SUFFIX_FORMAT_MAP = {
-    "xml": "xml",
-    "rdf": "xml",
-    "owl": "xml",
-    "n3": "n3",
-    "ttl": "turtle",
-    "nt": "nt",
-    "trix": "trix",
-    "xhtml": "rdfa",
-    "html": "rdfa",
-    "svg": "rdfa",
-    "nq": "nquads",
-    "nquads": "nquads",
-    "trig": "trig",
-    "json": "json-ld",
-    "jsonld": "json-ld",
-    "json-ld": "json-ld",
-}
 
 
 def guess_format(fpath: str, fmap: Optional[Dict[str, str]] = None) -> Optional[str]:


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

- Remove plugin registration for "application/sparql-results+xml; charset=UTF-8"
  - The ResultParser plugin with the name "application/sparql-results+xml; charset=UTF-8" is never called in internal code. The only place where ResultParser plugins are requested is in ["rdflib/query.py:276"](https://github.com/RDFLib/rdflib/blob/53f72d87bbc9c0f193bdc703f030587b359bfb4e/rdflib/query.py#L276). In case of a content-type the charset is split off already.
  - cf. #941
- Resolve TODO: "Pull in these from the result implementation plugins?" for _response_mime_types in sparqlconnector
  - The `_response_mime_types` dict is replaced by a method `response_mime_types` that generates an `Accept` field containing the supported mime types. Per default these are all mime types for which ResultParser plugins are registered.
- Dynamically register the `rdflib.plugins.sparql.results.graph.GraphResultParser` plugin for all names of the Parser plugins since it calls the Parsers internally.

Eventually, these changes could be superseded by a more flexible plugin system, that would distinguish between plugin name, supported format, and supported mime-type.

The changes should maintain backward compatibility.

But this API is now more flexible. The `returnFormat` for `SPARQLConnector` and `SPARQLStore` is now optional and `None` per default. Also, the default Accept header lists all mime-types supported by parsers. Maybe this should be mentioned in the change notes.

~Currently, this PR includes #3240, these commits should be removed, if #3240 is merged.~

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

