### PR TITLE
fix: ruff deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 # https://beta.ruff.rs/docs/configuration/
 target-version = "py38"
+
+# Same as Black.
+line-length = 88
+
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle errors
     "W", # pycodestyle warnings
@@ -124,10 +129,7 @@ ignore = [
     "E231", # missing whitespace after ','
 ]
 
-# Same as Black.
-line-length = 88
-
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "rdflib/plugins/sparql/*" = [
     "N801", # Class name should be UpperCamelCase
     "N802", # Function name should be lowercase


### PR DESCRIPTION
# Summary of changes

Fix ruff deprecation warning

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
