### PR TITLE
Fix testing for warnings with pytest 8 (#2748)

### DIFF
--- a/test/test_misc/test_parse_file_guess_format.py
+++ b/test/test_misc/test_parse_file_guess_format.py
@@ -61,7 +61,7 @@ class TestFileParserGuessFormat:
             g.parse(os.path.join(TEST_DATA_DIR, "example-lots_of_graphs.n3")), Graph
         )
 
-    def test_warning(self) -> None:
+    def test_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         g = Graph()
         graph_logger = logging.getLogger("rdflib")  # noqa: F841
 
@@ -78,9 +78,16 @@ class TestFileParserGuessFormat:
                 ),
                 str(newpath),
             )
-            with pytest.raises(ParserError, match=r"Could not guess RDF format"):
-                with pytest.warns(
-                    UserWarning,
-                    match="does not look like a valid URI, trying to serialize this will break.",
-                ) as logwarning:  # noqa: F841
-                    g.parse(str(newpath))
+            with pytest.raises(
+                ParserError, match=r"Could not guess RDF format"
+            ), caplog.at_level("WARNING"):
+                g.parse(str(newpath))
+
+            assert any(
+                rec.levelno == logging.WARNING
+                and (
+                    "does not look like a valid URI, trying to serialize this will break."
+                    in rec.message
+                )
+                for rec in caplog.records
+            )


### PR DESCRIPTION
New versions of pytest don’t catch log.warning() as a UserWarning. Use the caplog fixture instead.

Related: #2727
Fixes: #2748

# Summary of changes

Use the `caplog` fixture instead of `pytest.warns()` to check for warnings emitted with `log.warning()`, as outlined in https://github.com/RDFLib/rdflib/pull/2727#issuecomment-1994503300

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

