### PR TITLE
Ruff fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.9
+    rev: v0.5.4
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 # https://beta.ruff.rs/docs/configuration/
 target-version = "py38"
+# Same as Black.
+line-length = 88
+
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle errors
     "W", # pycodestyle warnings
@@ -124,10 +128,7 @@ ignore = [
     "E231", # missing whitespace after ','
 ]
 
-# Same as Black.
-line-length = 88
-
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "rdflib/plugins/sparql/*" = [
     "N801", # Class name should be UpperCamelCase
     "N802", # Function name should be lowercase
@@ -158,7 +159,6 @@ line-length = 88
 "{test/conftest.py,rdflib/namespace/__init__.py,rdflib/__init__.py,rdflib/plugins/sparql/__init__.py}" = [
     "E402", # Module level import not at top of file
 ]
-
 
 [tool.black]
 line-length = "88"

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -1871,7 +1871,7 @@ class Graph(Node):
             for s, p, o in self.triples((uri, None, None)):
                 subgraph.add((s, p, o))
                 # recurse 'down' through ll Blank Nodes
-                if type(o) == BNode and not (o, None, None) in subgraph:  # noqa: E713
+                if type(o) is BNode and (o, None, None) not in subgraph:
                     add_to_cbd(o)
 
             # for Rule 3 (reification)

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -670,7 +670,7 @@ class NamespaceManager:
         Raises exception if a namespace is not bound to the prefix.
 
         """
-        if not type(curie) is str:  # noqa: E714, E721
+        if not type(curie) is str:  # noqa: E714
             raise TypeError(f"Argument must be a string, not {type(curie).__name__}.")
         parts = curie.split(":", 1)
         if len(parts) != 2:

--- a/rdflib/plugins/parsers/trix.py
+++ b/rdflib/plugins/parsers/trix.py
@@ -4,7 +4,7 @@ A TriX parser for RDFLib
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Tuple
 from xml.sax import handler, make_parser
 from xml.sax.handler import ErrorHandler
 

--- a/rdflib/plugins/parsers/trix.py
+++ b/rdflib/plugins/parsers/trix.py
@@ -289,7 +289,7 @@ class TriXParser(Parser):
         preserve_bnode_ids = args.get("preserve_bnode_ids", None)
         if preserve_bnode_ids is not None:
             # type error: ContentHandler has no attribute "preserve_bnode_ids"
-            content_handler.preserve_bnode_ids = preserve_bnode_ids # type: ignore[attr-defined, unused-ignore]
+            content_handler.preserve_bnode_ids = preserve_bnode_ids  # type: ignore[attr-defined, unused-ignore]
         # We're only using it once now
         # content_handler.reset()
         # self._parser.reset()

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -58,7 +58,7 @@ class SPARQLConnector:
         self.kwargs = kwargs
         self.method = method
         if auth is not None:
-            if type(auth) != tuple:
+            if type(auth) is not tuple:
                 raise SPARQLConnectorException("auth must be a tuple")
             if len(auth) != 2:
                 raise SPARQLConnectorException("auth must be a tuple (user, password)")
@@ -92,7 +92,7 @@ class SPARQLConnector:
 
         params = {}
         # this test ensures we don't have a useless (BNode) default graph URI, which calls to Graph().query() will add
-        if default_graph is not None and type(default_graph) != BNode:
+        if default_graph is not None and type(default_graph) is not BNode:
             params["default-graph-uri"] = default_graph
 
         headers = {"Accept": _response_mime_types[self.returnFormat]}

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -345,7 +345,7 @@ class SPARQLStore(SPARQLConnector, Store):
         )
 
         if vars:
-            if type(result) == tuple:
+            if type(result) is tuple:
                 if result[0] == 401:
                     raise ValueError(
                         "It looks like you need to authenticate with this SPARQL Store. HTTP unauthorized"

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -187,7 +187,7 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
         False
         """
 
-        if type(self) == type(other):
+        if type(self) is type(other):
             return str(self) == str(other)
         else:
             return False
@@ -205,7 +205,7 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
         """
         if other is None:
             return True  # everything bigger than None
-        elif type(self) == type(other):
+        elif type(self) is type(other):
             return str(self) > str(other)
         elif isinstance(other, Node):
             return _ORDERING[type(self)] > _ORDERING[type(other)]
@@ -215,7 +215,7 @@ class Identifier(Node, str):  # allow Identifiers to be Nodes in the Graph
     def __lt__(self, other: Any) -> bool:
         if other is None:
             return False  # Nothing is less than None
-        elif type(self) == type(other):
+        elif type(self) is type(other):
             return str(self) < str(other)
         elif isinstance(other, Node):
             return _ORDERING[type(self)] < _ORDERING[type(other)]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,9 +10,6 @@ import pytest
 pytest.register_assert_rewrite("test.utils")
 
 from pathlib import Path
-from test.utils.audit import AuditHookDispatcher
-from test.utils.http import ctx_http_server
-from test.utils.httpfileserver import HTTPFileServer
 from typing import (
     Collection,
     Dict,
@@ -24,6 +21,9 @@ from typing import (
 )
 
 from rdflib import Graph
+from test.utils.audit import AuditHookDispatcher
+from test.utils.http import ctx_http_server
+from test.utils.httpfileserver import HTTPFileServer
 
 from .data import TEST_DATA_DIR
 from .utils.earl import EARLReporter

--- a/test/data.py
+++ b/test/data.py
@@ -1,7 +1,7 @@
 from pathlib import Path
-from test.utils.graph import cached_graph
 
 from rdflib import URIRef
+from test.utils.graph import cached_graph
 
 TEST_DIR = Path(__file__).parent
 TEST_DATA_DIR = TEST_DIR / "data"

--- a/test/data/suites/trix/test_trix.py
+++ b/test/data/suites/trix/test_trix.py
@@ -3,9 +3,6 @@ test suite."""
 
 from __future__ import annotations
 
-from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
-from test.utils.namespace import RDFT
 from typing import Callable, Dict
 
 import pytest
@@ -14,6 +11,9 @@ from rdflib import ConjunctiveGraph, logger
 from rdflib.compare import graph_diff, isomorphic
 from rdflib.namespace import split_uri
 from rdflib.term import Node, URIRef
+from test.data import TEST_DATA_DIR
+from test.utils.manifest import RDFTest, read_manifest
+from test.utils.namespace import RDFT
 
 verbose = False
 

--- a/test/data/variants/diverse_quads.py
+++ b/test/data/variants/diverse_quads.py
@@ -1,8 +1,7 @@
-from test.utils.namespace import EGDC, EGSCHEME, EGURN
-
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.namespace import XSD
 from rdflib.term import Literal
+from test.utils.namespace import EGDC, EGSCHEME, EGURN
 
 
 def populate_graph(graph: Graph) -> None:

--- a/test/data/variants/diverse_triples.py
+++ b/test/data/variants/diverse_triples.py
@@ -1,7 +1,6 @@
-from test.utils.namespace import EGDC, EGSCHEME, EGURN
-
 from rdflib.graph import Graph
 from rdflib.term import Literal
+from test.utils.namespace import EGDC, EGSCHEME, EGURN
 
 
 def populate_graph(graph: Graph) -> None:

--- a/test/data/variants/simple_quad.py
+++ b/test/data/variants/simple_quad.py
@@ -1,6 +1,5 @@
-from test.utils.namespace import EGDO
-
 from rdflib.graph import ConjunctiveGraph, Graph
+from test.utils.namespace import EGDO
 
 
 def populate_graph(graph: Graph) -> None:

--- a/test/data/variants/simple_triple.py
+++ b/test/data/variants/simple_triple.py
@@ -1,6 +1,5 @@
-from test.utils.namespace import EGDO
-
 from rdflib.graph import Graph
+from test.utils.namespace import EGDO
 
 
 def populate_graph(graph: Graph) -> None:

--- a/test/jsonld/test_nested_arrays.py
+++ b/test/jsonld/test_nested_arrays.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from test.utils.namespace import EGDC
-
 from rdflib import Graph, Literal
 from rdflib.collection import Collection
+from test.utils.namespace import EGDC
 
 prop = EGDC["props/a"]
 res = EGDC["res"]

--- a/test/test_conjunctivegraph/test_conjunctivegraph_generators.py
+++ b/test/test_conjunctivegraph/test_conjunctivegraph_generators.py
@@ -1,7 +1,7 @@
 import os
-from test.data import TEST_DATA_DIR
 
 from rdflib import ConjunctiveGraph, URIRef
+from test.data import TEST_DATA_DIR
 
 timblcardn3 = open(os.path.join(TEST_DATA_DIR, "timbl-card.n3")).read()
 

--- a/test/test_conjunctivegraph/test_conjunctivegraph_operator_combinations.py
+++ b/test/test_conjunctivegraph/test_conjunctivegraph_operator_combinations.py
@@ -1,7 +1,7 @@
 import os
-from test.data import CHEESE, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 from rdflib import ConjunctiveGraph, Graph
+from test.data import CHEESE, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 sportquadstrig = open(os.path.join(TEST_DATA_DIR, "sportquads.trig")).read()
 

--- a/test/test_dataset/test_dataset.py
+++ b/test/test_dataset/test_dataset.py
@@ -2,14 +2,14 @@ import os
 import shutil
 import tempfile
 import warnings
-from test.data import CONTEXT1, LIKES, PIZZA, TAREK
-from test.utils.namespace import EGSCHEME
 
 import pytest
 
 from rdflib import URIRef, plugin
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Dataset, Graph
 from rdflib.store import Store
+from test.data import CONTEXT1, LIKES, PIZZA, TAREK
+from test.utils.namespace import EGSCHEME
 
 # Will also run SPARQLUpdateStore tests against local SPARQL1.1 endpoint if
 # available. This assumes SPARQL1.1 query/update endpoints running locally at

--- a/test/test_dataset/test_dataset_default_graph.py
+++ b/test/test_dataset/test_dataset_default_graph.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-from test.data import TEST_DATA_DIR
 from typing import Iterable, Type, Union
 
 import pytest
@@ -10,6 +9,7 @@ from _pytest.mark.structures import ParameterSet
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset
 from rdflib.term import BNode, URIRef
+from test.data import TEST_DATA_DIR
 
 
 def make_load_default_and_named() -> Iterable[ParameterSet]:

--- a/test/test_dataset/test_dataset_generators.py
+++ b/test/test_dataset/test_dataset_generators.py
@@ -1,7 +1,7 @@
 import os
-from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 from rdflib import Dataset, URIRef
+from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 timblcardn3 = open(os.path.join(TEST_DATA_DIR, "timbl-card.n3")).read()
 

--- a/test/test_extras/test_infixowl/test_basic.py
+++ b/test/test_extras/test_infixowl/test_basic.py
@@ -1,5 +1,3 @@
-from test.data import CONTEXT0
-
 import pytest
 
 from rdflib import OWL, Graph, Literal, Namespace
@@ -12,6 +10,7 @@ from rdflib.extras.infixowl import (
     max,
     some,
 )
+from test.data import CONTEXT0
 
 EXNS = Namespace("http://example.org/vocab/")
 

--- a/test/test_extras/test_infixowl/test_class.py
+++ b/test/test_extras/test_infixowl/test_class.py
@@ -1,5 +1,3 @@
-from test.data import CONTEXT0, CONTEXT1
-
 import pytest
 
 from rdflib import OWL, RDFS, BNode, Graph, Literal, Namespace, URIRef, Variable
@@ -12,6 +10,7 @@ from rdflib.extras.infixowl import (
     max,
 )
 from rdflib.util import first
+from test.data import CONTEXT0, CONTEXT1
 
 EXNS = Namespace("http://example.org/vocab/")
 PZNS = Namespace(

--- a/test/test_extras/test_infixowl/test_cover.py
+++ b/test/test_extras/test_infixowl/test_cover.py
@@ -1,5 +1,3 @@
-from test.data import CONTEXT0, TEST_DATA_DIR
-
 import pytest
 
 from rdflib import OWL, RDF, RDFS, XSD, Graph, Literal, Namespace, URIRef, logger
@@ -28,6 +26,7 @@ from rdflib.extras.infixowl import (
     some,
     value,
 )
+from test.data import CONTEXT0, TEST_DATA_DIR
 
 EXNS = Namespace("http://example.org/vocab/")
 PZNS = Namespace(

--- a/test/test_extras/test_infixowl/test_individual.py
+++ b/test/test_extras/test_infixowl/test_individual.py
@@ -1,9 +1,8 @@
-from test.data import CONTEXT0, PIZZA
-
 import pytest
 
 from rdflib import OWL, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.extras.infixowl import Class, Individual
+from test.data import CONTEXT0, PIZZA
 
 EXNS = Namespace("http://example.org/vocab/")
 

--- a/test/test_extras/test_infixowl/test_manchester_syntax.py
+++ b/test/test_extras/test_infixowl/test_manchester_syntax.py
@@ -1,9 +1,8 @@
-from test.data import TEST_DATA_DIR
-
 import pytest
 
 from rdflib import OWL, RDFS, Graph, Literal, Namespace
 from rdflib.extras.infixowl import Class, Individual, manchesterSyntax
+from test.data import TEST_DATA_DIR
 
 EXNS = Namespace("http://example.org/vocab/")
 PZNS = Namespace(

--- a/test/test_graph/test_canonicalization.py
+++ b/test/test_graph/test_canonicalization.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from io import StringIO
-from test.utils import GraphHelper
 from typing import TYPE_CHECKING, Set
 
 import pytest
@@ -10,6 +9,7 @@ from rdflib import RDF, BNode, ConjunctiveGraph, Graph, Literal, Namespace, URIR
 from rdflib.compare import to_canonical_graph, to_isomorphic
 from rdflib.namespace import FOAF
 from rdflib.plugins.stores.memory import Memory
+from test.utils import GraphHelper
 
 if TYPE_CHECKING:
     from rdflib.graph import _TripleType

--- a/test/test_graph/test_diff.py
+++ b/test/test_graph/test_diff.py
@@ -1,15 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from test.utils import (
-    COLLAPSED_BNODE,
-    BNodeHandling,
-    GHQuad,
-    GHTriple,
-    GraphHelper,
-    MarksType,
-    MarkType,
-)
 from typing import TYPE_CHECKING, Collection, Set, Tuple, Type, Union, cast
 
 import pytest
@@ -21,6 +12,15 @@ from rdflib.compare import graph_diff
 from rdflib.graph import ConjunctiveGraph, Dataset
 from rdflib.namespace import FOAF, RDF
 from rdflib.term import BNode, Literal
+from test.utils import (
+    COLLAPSED_BNODE,
+    BNodeHandling,
+    GHQuad,
+    GHTriple,
+    GraphHelper,
+    MarksType,
+    MarkType,
+)
 
 if TYPE_CHECKING:
     from rdflib.graph import _TripleType

--- a/test/test_graph/test_graph.py
+++ b/test/test_graph/test_graph.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
-from test.utils import GraphHelper, get_unique_plugin_names
-from test.utils.httpfileserver import HTTPFileServer, ProtoFileResource
-from test.utils.outcome import ExceptionChecker, OutcomeChecker, OutcomePrimitive
 from typing import Callable, Optional, Set, Tuple
 from urllib.error import HTTPError, URLError
 
@@ -18,6 +14,10 @@ from rdflib.namespace import Namespace, NamespaceManager
 from rdflib.plugin import PluginException
 from rdflib.store import Store
 from rdflib.term import BNode
+from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
+from test.utils import GraphHelper, get_unique_plugin_names
+from test.utils.httpfileserver import HTTPFileServer, ProtoFileResource
+from test.utils.outcome import ExceptionChecker, OutcomeChecker, OutcomePrimitive
 
 
 def test_property_store() -> None:

--- a/test/test_graph/test_graph_cbd.py
+++ b/test/test_graph/test_graph_cbd.py
@@ -1,13 +1,12 @@
 """Tests the Graph class' cbd() function"""
 
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper
-
 import pytest
 
 from rdflib import Graph, Namespace
 from rdflib.namespace import RDF, RDFS
 from rdflib.term import Literal, URIRef
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper
 
 EXAMPLE_GRAPH_FILE_PATH = TEST_DATA_DIR / "spec" / "cbd" / "example_graph.rdf"
 EXAMPLE_GRAPH_CBD_FILE_PATH = TEST_DATA_DIR / "spec" / "cbd" / "example_graph_cbd.rdf"

--- a/test/test_graph/test_graph_formula.py
+++ b/test/test_graph/test_graph_formula.py
@@ -41,7 +41,7 @@ def checkFormulaStore(store="default", configString=None):  # noqa: N802, N803
             formulaA = s  # noqa: N806
             formulaB = o  # noqa: N806
 
-        assert type(formulaA) == QuotedGraph and type(formulaB) == QuotedGraph
+        assert type(formulaA) is QuotedGraph and type(formulaB) is QuotedGraph
         # a = URIRef('http://test/a')
         b = URIRef("http://test/b")
         c = URIRef("http://test/c")

--- a/test/test_graph/test_graph_generators.py
+++ b/test/test_graph/test_graph_generators.py
@@ -1,7 +1,7 @@
 import os
-from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 from rdflib import Graph
+from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK, TEST_DATA_DIR
 
 timblcardn3 = open(os.path.join(TEST_DATA_DIR, "timbl-card.n3")).read()
 

--- a/test/test_graph/test_graph_http.py
+++ b/test/test_graph/test_graph_http.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import logging
 import re
 from http.server import BaseHTTPRequestHandler
+from urllib.error import HTTPError
+
+import pytest
+
+from rdflib import Graph
 from test.data import TEST_DATA_DIR
 from test.utils import GraphHelper
 from test.utils.graph import cached_graph
@@ -16,11 +21,6 @@ from test.utils.http import (
 from test.utils.httpservermock import ServedBaseHTTPServerMock
 from test.utils.namespace import EGDO
 from test.utils.wildcard import URL_PARSE_RESULT_WILDCARD
-from urllib.error import HTTPError
-
-import pytest
-
-from rdflib import Graph
 
 """
 Test that correct content negotiation headers are passed

--- a/test/test_graph/test_graph_redirect.py
+++ b/test/test_graph/test_graph_redirect.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from test.data import SIMPLE_TRIPLE_GRAPH, TEST_DATA_DIR
-from test.utils import GraphHelper
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
 from typing import Tuple
 from urllib.parse import urlparse
 
 from rdflib.graph import Graph
+from test.data import SIMPLE_TRIPLE_GRAPH, TEST_DATA_DIR
+from test.utils import GraphHelper
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
 
 
 def test_graph_redirect_new_host(

--- a/test/test_graph/test_graph_store.py
+++ b/test/test_graph/test_graph_store.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-from test.data import SIMPLE_TRIPLE_GRAPH
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -32,6 +31,7 @@ from rdflib.plugins.stores.memory import Memory
 from rdflib.query import Result
 from rdflib.store import Store
 from rdflib.term import Identifier, URIRef, Variable
+from test.data import SIMPLE_TRIPLE_GRAPH
 
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet

--- a/test/test_graph/test_namespace_rebinding.py
+++ b/test/test_graph/test_namespace_rebinding.py
@@ -1,11 +1,10 @@
-from test.data import CONTEXT1, CONTEXT2, TAREK
-
 import pytest
 
 from rdflib import ConjunctiveGraph, Graph, Literal
 from rdflib.namespace import OWL, Namespace, NamespaceManager
 from rdflib.plugins.stores.memory import Memory
 from rdflib.term import URIRef
+from test.data import CONTEXT1, CONTEXT2, TAREK
 
 foaf1_uri = URIRef("http://xmlns.com/foaf/0.1/")
 foaf2_uri = URIRef("http://xmlns.com/foaf/2.0/")

--- a/test/test_graph/test_skolemization.py
+++ b/test/test_graph/test_skolemization.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import logging
 import re
-from test.utils import GraphHelper
-from test.utils.namespace import EGDC
 from typing import Pattern, Union
 
 import pytest
 
 from rdflib import Graph
 from rdflib.term import BNode, Literal, URIRef
+from test.utils import GraphHelper
+from test.utils.namespace import EGDC
 
 base_triples = {
     (EGDC.subject, EGDC.predicate, EGDC.object0),

--- a/test/test_graph/test_slice.py
+++ b/test/test_graph/test_slice.py
@@ -1,6 +1,5 @@
-from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK
-
 from rdflib import Graph
+from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK
 
 
 class TestGraphSlice:

--- a/test/test_graph/test_variants.py
+++ b/test/test_graph/test_variants.py
@@ -9,9 +9,6 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from test.data import TEST_DATA_DIR
-from test.utils import GraphHelper
-from test.utils.graph import GraphSource
 from typing import (
     ClassVar,
     Collection,
@@ -36,6 +33,9 @@ import rdflib.util
 from rdflib.graph import Dataset, _GraphT
 from rdflib.namespace import XSD
 from rdflib.term import URIRef
+from test.data import TEST_DATA_DIR
+from test.utils import GraphHelper
+from test.utils.graph import GraphSource
 
 MODULE_PATH = Path(__file__).parent
 

--- a/test/test_issues/test_issue1043.py
+++ b/test/test_issues/test_issue1043.py
@@ -1,8 +1,8 @@
 import io
 import sys
-from test.utils.namespace import EGDO
 
 from rdflib import RDFS, XSD, Graph, Literal
+from test.utils.namespace import EGDO
 
 
 def test_issue_1043():

--- a/test/test_issues/test_issue1404.py
+++ b/test/test_issues/test_issue1404.py
@@ -31,7 +31,7 @@ def test_skolem_de_skolem_roundtrip():
 
     # Check the BNode is now a URIRef after skolemization.
     skolem_bnode = skolemized_graph.value(**query)
-    assert type(skolem_bnode) == URIRef
+    assert type(skolem_bnode) is URIRef
 
     # Check that the original bnode id exists somewhere in the uri.
     assert bnode_id in skolem_bnode

--- a/test/test_issues/test_issue1484.py
+++ b/test/test_issues/test_issue1484.py
@@ -1,8 +1,8 @@
 import io
 import json
-from test.utils.namespace import EGDO
 
 from rdflib import RDF, RDFS, Graph
+from test.utils.namespace import EGDO
 
 
 def test_issue_1484_json():

--- a/test/test_issues/test_issue274.py
+++ b/test/test_issues/test_issue274.py
@@ -1,5 +1,3 @@
-from test.utils import eq_
-from test.utils.namespace import EGDO
 from unittest import TestCase
 
 import pytest
@@ -9,6 +7,8 @@ from rdflib.plugins.sparql.operators import (
     register_custom_function,
     unregister_custom_function,
 )
+from test.utils import eq_
+from test.utils.namespace import EGDO
 
 G = Graph()
 G.add((BNode(), RDFS.label, Literal("bnode")))

--- a/test/test_issues/test_issue381.py
+++ b/test/test_issues/test_issue381.py
@@ -1,7 +1,6 @@
-from test.utils.namespace import EGDO
-
 from rdflib import BNode, Graph
 from rdflib.compare import isomorphic
+from test.utils.namespace import EGDO
 
 
 def test_no_spurious_semicolon():

--- a/test/test_issues/test_issue733.py
+++ b/test/test_issues/test_issue733.py
@@ -5,9 +5,8 @@ zeroOrMore ('*') property paths and specifying neither the
 subject or the object.
 """
 
-from test.utils.namespace import EGDO
-
 from rdflib import Graph
+from test.utils.namespace import EGDO
 
 
 def test_issue_733():

--- a/test/test_issues/test_issue801.py
+++ b/test/test_issues/test_issue801.py
@@ -2,9 +2,8 @@
 Issue 801 - Problem with prefixes created for URIs containing %20
 """
 
-from test.utils.namespace import EGDO
-
 from rdflib import BNode, Graph, Literal
+from test.utils.namespace import EGDO
 
 
 def test_issue_801():

--- a/test/test_literal/test_literal.py
+++ b/test/test_literal/test_literal.py
@@ -4,11 +4,12 @@ import builtins
 import datetime
 import logging
 from decimal import Decimal
+from typing import Any, Callable, Generator, Optional, Type, Union
+
 from test.utils import affix_tuples
 from test.utils.literal import LiteralChecker, literal_idfn
 from test.utils.namespace import EGDC
 from test.utils.outcome import OutcomeChecker, OutcomePrimitive, OutcomePrimitives
-from typing import Any, Callable, Generator, Optional, Type, Union
 
 # NOTE: The config below enables strict mode for mypy.
 # mypy: no_ignore_errors

--- a/test/test_literal/test_literal_html5lib.py
+++ b/test/test_literal/test_literal_html5lib.py
@@ -1,6 +1,4 @@
 import xml.dom.minidom
-from test.utils.literal import LiteralChecker
-from test.utils.outcome import OutcomeChecker, OutcomePrimitives
 from typing import Callable
 
 import pytest
@@ -8,6 +6,8 @@ import pytest
 import rdflib.term
 from rdflib.namespace import RDF
 from rdflib.term import Literal
+from test.utils.literal import LiteralChecker
+from test.utils.outcome import OutcomeChecker, OutcomePrimitives
 
 try:
     import html5lib as _  # noqa: F401

--- a/test/test_misc/test_input_source.py
+++ b/test/test_misc/test_input_source.py
@@ -8,15 +8,6 @@ import re
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from test.utils import GraphHelper
-from test.utils.httpfileserver import (
-    HTTPFileInfo,
-    HTTPFileServer,
-    LocationType,
-    ProtoFileResource,
-    ProtoRedirectResource,
-)
-from test.utils.outcome import ExceptionChecker
 from typing import (  # Callable,
     IO,
     BinaryIO,
@@ -44,6 +35,15 @@ from rdflib.parser import (
     URLInputSource,
     create_input_source,
 )
+from test.utils import GraphHelper
+from test.utils.httpfileserver import (
+    HTTPFileInfo,
+    HTTPFileServer,
+    LocationType,
+    ProtoFileResource,
+    ProtoRedirectResource,
+)
+from test.utils.outcome import ExceptionChecker
 
 from ..data import TEST_DATA_DIR
 

--- a/test/test_misc/test_networking_redirect.py
+++ b/test/test_misc/test_networking_redirect.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 from copy import deepcopy
-from test.utils.http import headers_as_message as headers_as_message
-from test.utils.outcome import ExceptionChecker
 from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Union
 from urllib.error import HTTPError
 from urllib.request import HTTPRedirectHandler, Request
@@ -12,6 +10,8 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 from rdflib._networking import _make_redirect_request
+from test.utils.http import headers_as_message as headers_as_message
+from test.utils.outcome import ExceptionChecker
 
 AnyT = TypeVar("AnyT")
 

--- a/test/test_misc/test_parse_file_guess_format.py
+++ b/test/test_misc/test_parse_file_guess_format.py
@@ -12,13 +12,13 @@ import os
 from pathlib import Path
 from shutil import copyfile
 from tempfile import TemporaryDirectory
-from test.data import TEST_DATA_DIR
 
 import pytest
 
 from rdflib import Graph
 from rdflib.exceptions import ParserError
 from rdflib.util import guess_format
+from test.data import TEST_DATA_DIR
 
 
 class TestFileParserGuessFormat:

--- a/test/test_misc/test_security.py
+++ b/test/test_misc/test_security.py
@@ -6,10 +6,6 @@ import itertools
 import logging
 from contextlib import ExitStack
 from pathlib import Path
-from test.utils.audit import AuditHookDispatcher
-from test.utils.httpfileserver import HTTPFileServer, ProtoFileResource
-from test.utils.namespace import EGDO
-from test.utils.urlopen import context_urlopener
 from textwrap import dedent
 from typing import Any, Iterable, Tuple
 from urllib.request import HTTPHandler, OpenerDirector, Request
@@ -18,6 +14,10 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 from rdflib import Graph
+from test.utils.audit import AuditHookDispatcher
+from test.utils.httpfileserver import HTTPFileServer, ProtoFileResource
+from test.utils.namespace import EGDO
+from test.utils.urlopen import context_urlopener
 
 from ..utils import GraphHelper
 from ..utils.path import ctx_chdir

--- a/test/test_n3.py
+++ b/test/test_n3.py
@@ -1,6 +1,5 @@
 import itertools
 import os
-from test import TEST_DIR
 from urllib.error import URLError
 
 import pytest
@@ -8,6 +7,7 @@ import pytest
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.plugins.parsers.notation3 import BadSyntax, exponent_syntax
 from rdflib.term import Literal, URIRef
+from test import TEST_DIR
 
 test_data = """
 #  Definitions of terms describing the n3 model

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -8,7 +8,6 @@ import warnings
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
-from test.data import TEST_DATA_DIR
 from typing import Optional, Type
 
 import pytest
@@ -16,6 +15,7 @@ import pytest
 from rdflib import RDF, SKOS
 from rdflib.namespace import DefinedNamespace, Namespace
 from rdflib.term import URIRef
+from test.data import TEST_DATA_DIR
 
 
 def test_definednamespace_creator_qb():

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from test.utils.outcome import OutcomeChecker, OutcomePrimitive
 from typing import Any, Optional
 from warnings import warn
 
@@ -20,6 +19,7 @@ from rdflib.namespace import (
     URIPattern,
 )
 from rdflib.term import BNode, Literal, URIRef
+from test.utils.outcome import OutcomeChecker, OutcomePrimitive
 
 
 class TestNamespace:

--- a/test/test_namespace/test_namespace.py
+++ b/test/test_namespace/test_namespace.py
@@ -240,7 +240,7 @@ class TestNamespacePrefix:
 
         ref = URIRef("http://www.w3.org/ns/shacl#Info")
         assert (
-            type(SH) == DefinedNamespaceMeta
+            type(SH) is DefinedNamespaceMeta
         ), f"SH no longer a DefinedNamespaceMeta (instead it is now {type(SH)}, update test."
         assert ref in SH, "sh:Info not in SH"
 

--- a/test/test_namespace/test_namespacemanager.py
+++ b/test/test_namespace/test_namespacemanager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.utils.outcome import ExceptionChecker, OutcomeChecker, OutcomePrimitive
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Set, Tuple, Type, Union
 
 import pytest
@@ -18,6 +17,7 @@ from rdflib.namespace import (
     NamespaceManager,
 )
 from rdflib.term import URIRef
+from test.utils.outcome import ExceptionChecker, OutcomeChecker, OutcomePrimitive
 
 if TYPE_CHECKING:
     from rdflib._type_checking import _NamespaceSetString

--- a/test/test_nt_misc.py
+++ b/test/test_nt_misc.py
@@ -2,13 +2,13 @@ import logging
 import os
 import re
 from pathlib import Path
-from test.data import TEST_DATA_DIR
 from urllib.request import urlopen
 
 import pytest
 
 from rdflib import Graph, Literal, URIRef
 from rdflib.plugins.parsers import ntriples
+from test.data import TEST_DATA_DIR
 
 log = logging.getLogger(__name__)
 

--- a/test/test_parsers/test_broken_parse_data_from_jena.py
+++ b/test/test_parsers/test_broken_parse_data_from_jena.py
@@ -1,9 +1,9 @@
 import os
-from test.data import TEST_DATA_DIR
 
 import pytest
 
 import rdflib
+from test.data import TEST_DATA_DIR
 
 # Recovered from
 # https://github.com/RDFLib/rdflib/tree/6b4607018ebf589da74aea4c25408999f1acf2e2

--- a/test/test_parsers/test_nquads.py
+++ b/test/test_parsers/test_nquads.py
@@ -1,7 +1,7 @@
 import os
-from test.data import TEST_DATA_DIR
 
 from rdflib import ConjunctiveGraph, Namespace, URIRef
+from test.data import TEST_DATA_DIR
 
 TEST_BASE = os.path.join(TEST_DATA_DIR, "nquads.rdflib")
 

--- a/test/test_parsers/test_parser_hext.py
+++ b/test/test_parsers/test_parser_hext.py
@@ -128,7 +128,7 @@ def test_roundtrip():
                 if cg2.context_aware:
                     for context in cg2.contexts():
                         for triple in context.triples((None, None, None)):
-                            if type(triple[2]) == Literal:
+                            if type(triple[2]) is Literal:
                                 if triple[2].datatype == XSD.string:
                                     context.remove((triple[0], triple[1], triple[2]))
                                     context.add(
@@ -136,7 +136,7 @@ def test_roundtrip():
                                     )
                 else:
                     for triple in cg2.triples((None, None, None)):
-                        if type(triple[2]) == Literal:
+                        if type(triple[2]) is Literal:
                             if triple[2].datatype == XSD.string:
                                 cg2.remove((triple[0], triple[1], triple[2]))
                                 cg2.add((triple[0], triple[1], Literal(str(triple[2]))))

--- a/test/test_parsers/test_parser_turtlelike.py
+++ b/test/test_parsers/test_parser_turtlelike.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import enum
 import itertools
 from dataclasses import dataclass, field
-from test.utils.namespace import EGDC
 from typing import Callable, Dict, Iterator, List, Set, Tuple, Union
 
 import pytest
@@ -17,6 +16,7 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 from rdflib import XSD, Graph, Literal
 from rdflib.term import Identifier
 from rdflib.util import from_n3
+from test.utils.namespace import EGDC
 
 
 class FormatTrait(enum.Enum):

--- a/test/test_parsers/test_swap_n3.py
+++ b/test/test_parsers/test_swap_n3.py
@@ -1,9 +1,9 @@
 import os
-from test.data import TEST_DATA_DIR
 
 import pytest
 
 import rdflib
+from test.data import TEST_DATA_DIR
 
 """
 SWAP N3 parser test suite

--- a/test/test_parsers/test_trix_parse.py
+++ b/test/test_parsers/test_trix_parse.py
@@ -1,7 +1,7 @@
 import os
-from test.data import TEST_DATA_DIR
 
 from rdflib.graph import ConjunctiveGraph
+from test.data import TEST_DATA_DIR
 
 
 class TestTrixParse:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -272,7 +272,7 @@ def roundtrip(
         for c in g2.contexts():
             # type error: Incompatible types in assignment (expression has type "Node", variable has type "str")
             for s, p, o in c.triples((None, None, None)):  # type: ignore[assignment]
-                if type(o) == rdflib.Literal and o.datatype == XSD.string:
+                if type(o) is rdflib.Literal and o.datatype == XSD.string:
                     # type error: Argument 1 to "remove" of "Graph" has incompatible type "Tuple[str, Node, Literal]"; expected "Tuple[Optional[Node], Optional[Node], Optional[Node]]"
                     c.remove((s, p, o))  # type: ignore[arg-type]
                     # type error: Argument 1 to "add" of "Graph" has incompatible type "Tuple[str, Node, Literal]"; expected "Tuple[Node, Node, Node]"

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -26,8 +26,6 @@ import enum
 import logging
 import os.path
 from pathlib import Path
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper
 from typing import Callable, Iterable, List, Optional, Set, Tuple, Type, Union
 from xml.sax import SAXParseException
 
@@ -42,6 +40,8 @@ from rdflib.parser import Parser, create_input_source
 from rdflib.plugins.parsers.notation3 import BadSyntax
 from rdflib.serializer import Serializer
 from rdflib.util import guess_format
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_serializers/test_serializer.py
+++ b/test/test_serializers/test_serializer.py
@@ -9,9 +9,6 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path, PosixPath, PurePath
-from test.utils import GraphHelper, get_unique_plugins
-from test.utils.destination import DestinationType, DestParmType, DestRef
-from test.utils.namespace import EGDC, EGSCHEME, EGURN
 from typing import (
     IO,
     Callable,
@@ -35,6 +32,9 @@ import rdflib.plugin
 from rdflib import RDF, XSD, Graph, Literal, Namespace, URIRef
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset
 from rdflib.serializer import Serializer
+from test.utils import GraphHelper, get_unique_plugins
+from test.utils.destination import DestinationType, DestParmType, DestRef
+from test.utils.namespace import EGDC, EGSCHEME, EGURN
 
 
 @pytest.mark.parametrize(

--- a/test/test_serializers/test_serializer_jsonld.py
+++ b/test/test_serializers/test_serializer_jsonld.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import json
 import logging
 import pprint
-from test.utils.namespace import EGDO
 from typing import Any, Dict, Union
 
 import pytest
 
 from rdflib import Graph
 from rdflib.plugins.shared.jsonld.context import Context
+from test.utils.namespace import EGDO
 
 
 @pytest.mark.parametrize(

--- a/test/test_serializers/test_serializer_n3.py
+++ b/test/test_serializers/test_serializer_n3.py
@@ -1,6 +1,4 @@
 import logging
-from test.utils import GraphHelper
-from test.utils.namespace import EGDC
 
 import rdflib
 import rdflib.term
@@ -8,6 +6,8 @@ from rdflib import Graph
 from rdflib.graph import QuotedGraph
 from rdflib.plugins.parsers.notation3 import LOG_implies_URI
 from rdflib.term import BNode, URIRef
+from test.utils import GraphHelper
+from test.utils.namespace import EGDC
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_sparql/test_datetime_processing.py
+++ b/test/test_sparql/test_datetime_processing.py
@@ -1,8 +1,8 @@
 import io
-from test.utils import eq_
 
 import rdflib
 from rdflib import Graph
+from test.utils import eq_
 
 
 def test_datetime_datetime_subs_issue():

--- a/test/test_sparql/test_expressions.py
+++ b/test/test_sparql/test_expressions.py
@@ -1,11 +1,11 @@
 from functools import partial
-from test.utils import eq_ as eq
 
 import rdflib.plugins.sparql.parser as p
 from rdflib import Literal, Variable
 from rdflib.plugins.sparql.algebra import translatePName, traverse
 from rdflib.plugins.sparql.operators import simplify
 from rdflib.plugins.sparql.sparql import Prologue, QueryContext, SPARQLError
+from test.utils import eq_ as eq
 
 
 def _eval(e, ctx=None):

--- a/test/test_sparql/test_forward_slash_escapes.py
+++ b/test/test_sparql/test_forward_slash_escapes.py
@@ -18,8 +18,6 @@ prefixed concepts, e.g. "application/json" somehow being
 """
 from __future__ import annotations
 
-from test.data import TEST_DATA_DIR
-from test.utils.graph import cached_graph
 from typing import Set
 
 import pytest
@@ -28,6 +26,8 @@ from rdflib import Graph
 from rdflib.plugins.sparql.processor import prepareQuery
 from rdflib.plugins.sparql.sparql import Query
 from rdflib.query import ResultRow
+from test.data import TEST_DATA_DIR
+from test.utils.graph import cached_graph
 
 query_string_expanded = r"""
 SELECT ?nIndividual

--- a/test/test_sparql/test_initbindings.py
+++ b/test/test_sparql/test_initbindings.py
@@ -1,7 +1,6 @@
-from test.utils.namespace import EGDC
-
 from rdflib import ConjunctiveGraph, Literal, URIRef, Variable
 from rdflib.plugins.sparql import prepareQuery
+from test.utils.namespace import EGDC
 
 g = ConjunctiveGraph()
 

--- a/test/test_sparql/test_prefixed_name.py
+++ b/test/test_sparql/test_prefixed_name.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-from test.utils.outcome import OutcomeChecker, OutcomePrimitive
 
 import pyparsing
 import pytest
@@ -11,6 +10,7 @@ import rdflib
 from rdflib import Graph
 from rdflib.namespace import Namespace
 from rdflib.term import Node, URIRef
+from test.utils.outcome import OutcomeChecker, OutcomePrimitive
 
 RESERVED_PCHARS = [
     "%20",

--- a/test/test_sparql/test_result.py
+++ b/test/test_sparql/test_result.py
@@ -9,13 +9,6 @@ import socket
 from contextlib import ExitStack
 from io import BytesIO, StringIO
 from pathlib import Path, PosixPath, PurePath
-from test.utils.destination import DestinationType, DestParmType
-from test.utils.result import (
-    ResultFormat,
-    ResultFormatInfo,
-    ResultFormatTrait,
-    ResultType,
-)
 from typing import (
     IO,
     BinaryIO,
@@ -41,6 +34,13 @@ from rdflib.graph import Graph
 from rdflib.namespace import Namespace
 from rdflib.query import Result, ResultRow
 from rdflib.term import BNode, Identifier, Literal, Node, Variable
+from test.utils.destination import DestinationType, DestParmType
+from test.utils.result import (
+    ResultFormat,
+    ResultFormatInfo,
+    ResultFormatTrait,
+    ResultType,
+)
 
 BindingsType = Sequence[Mapping[Variable, Identifier]]
 ParseOutcomeType = Union[BindingsType, Type[Exception]]

--- a/test/test_sparql/test_service.py
+++ b/test/test_sparql/test_service.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 import json
 from http.client import IncompleteRead, RemoteDisconnected
-from test.utils import helper
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
-from test.utils.outcome import OutcomeChecker
 from typing import Dict, FrozenSet, List, Mapping, Sequence, Tuple, Type, Union
 
 import pytest
@@ -13,6 +9,10 @@ import pytest
 from rdflib import Graph, Literal, URIRef, Variable
 from rdflib.namespace import XSD
 from rdflib.term import BNode, Identifier
+from test.utils import helper
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
+from test.utils.outcome import OutcomeChecker
 
 
 @pytest.mark.webtest

--- a/test/test_sparql/test_sparql.py
+++ b/test/test_sparql/test_sparql.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import logging
-from test.utils import eq_
-from test.utils.namespace import EGDC
-from test.utils.result import assert_bindings_collections_equal
 from typing import Any, Callable, Mapping, Sequence, Type
 
 import pytest
@@ -24,6 +21,9 @@ from rdflib.plugins.sparql.parserutils import prettify_parsetree
 from rdflib.plugins.sparql.sparql import SPARQLError
 from rdflib.query import Result, ResultRow
 from rdflib.term import Identifier, Variable
+from test.utils import eq_
+from test.utils.namespace import EGDC
+from test.utils.result import assert_bindings_collections_equal
 
 
 def test_graph_prefix():

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -5,7 +5,6 @@ import os
 from dataclasses import dataclass, field
 from io import StringIO
 from pathlib import Path
-from test.data import TEST_DATA_DIR
 from typing import Collection, Tuple, Union, cast
 
 import pytest
@@ -15,6 +14,7 @@ import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
 from rdflib import Graph, Literal, URIRef
 from rdflib.plugins.sparql.algebra import translateAlgebra
+from test.data import TEST_DATA_DIR
 
 
 @pytest.fixture

--- a/test/test_sparql/test_update.py
+++ b/test/test_sparql/test_update.py
@@ -1,14 +1,14 @@
 import itertools
 import logging
-from test.data import TEST_DATA_DIR
-from test.utils import GraphHelper
-from test.utils.graph import GraphSource
-from test.utils.namespace import EGDO
 from typing import Callable
 
 import pytest
 
 from rdflib.graph import ConjunctiveGraph, Dataset, Graph
+from test.data import TEST_DATA_DIR
+from test.utils import GraphHelper
+from test.utils.graph import GraphSource
+from test.utils.namespace import EGDO
 
 
 @pytest.mark.parametrize(

--- a/test/test_store/test_namespace_binding.py
+++ b/test/test_store/test_namespace_binding.py
@@ -5,7 +5,6 @@ import itertools
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from test.utils import pytest_mark_filter
 from typing import Any, Callable, Dict, Set, Union
 
 import pytest
@@ -15,6 +14,7 @@ from rdflib.namespace import Namespace
 from rdflib.plugins.stores.berkeleydb import has_bsddb
 from rdflib.store import Store
 from rdflib.term import IdentifiedNode, URIRef
+from test.utils import pytest_mark_filter
 
 
 class StoreTrait(enum.Enum):

--- a/test/test_store/test_store_auditable.py
+++ b/test/test_store/test_store_auditable.py
@@ -1,9 +1,8 @@
-from test.utils.namespace import EGDO
-
 import pytest
 
 from rdflib import Graph
 from rdflib.plugins.stores.auditable import AuditableStore
+from test.utils.namespace import EGDO
 
 
 @pytest.fixture

--- a/test/test_store/test_store_sparqlstore.py
+++ b/test/test_store/test_store_sparqlstore.py
@@ -107,7 +107,7 @@ class TestSPARQLStoreFakeDBPedia:
             count = 0
             for i in res:
                 count += 1
-                assert type(i[0]) == URIRef, i[0].n3()
+                assert type(i[0]) is URIRef, i[0].n3()
             assert count > 0
             mock.assert_called_once()
             args, kwargs = mock.call_args
@@ -177,7 +177,7 @@ class TestSPARQLStoreFakeDBPedia:
             query, initNs={"xyzzy": "http://www.w3.org/2004/02/skos/core#"}
         )
         for i in res:
-            assert type(i[0]) == Literal, i[0].n3()
+            assert type(i[0]) is Literal, i[0].n3()
 
         assert self.httpmock.mocks[MethodName.GET].call_count == 1
         req = self.httpmock.requests[MethodName.GET].pop(0)
@@ -263,7 +263,7 @@ SELECT ?label WHERE { ?s a xyzzy:Concept ; xyzzy:prefLabel ?label . } LIMIT 10""
         )
         res = helper.query_with_retry(self.graph, prologue + query)
         for i in res:
-            assert type(i[0]) == Literal, i[0].n3()
+            assert type(i[0]) is Literal, i[0].n3()
         assert self.httpmock.mocks[MethodName.GET].call_count == 1
         req = self.httpmock.requests[MethodName.GET].pop(0)
         assert re.match(r"^/sparql", req.path)
@@ -325,7 +325,7 @@ SELECT ?label WHERE { ?s a xyzzy:Concept ; xyzzy:prefLabel ?label . } LIMIT 10""
         )
         res = helper.query_with_retry(self.graph, prologue + query)
         for i in res:
-            assert type(i[0]) == Literal, i[0].n3()
+            assert type(i[0]) is Literal, i[0].n3()
         assert self.httpmock.mocks[MethodName.GET].call_count == 1
         req = self.httpmock.requests[MethodName.GET].pop(0)
         assert re.match(r"^/sparql", req.path)

--- a/test/test_store/test_store_sparqlstore.py
+++ b/test/test_store/test_store_sparqlstore.py
@@ -4,9 +4,6 @@ import logging
 import re
 import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from test.utils import helper
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
 from threading import Thread
 from typing import Callable, ClassVar, Type
 from unittest.mock import patch
@@ -16,6 +13,9 @@ import pytest
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import FOAF, RDF, RDFS, XMLNS, XSD
 from rdflib.plugins.stores.sparqlconnector import SPARQLConnector
+from test.utils import helper
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
 
 
 class TestSPARQLStoreGraph:

--- a/test/test_store/test_store_sparqlstore_query.py
+++ b/test/test_store/test_store_sparqlstore_query.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import itertools
 import logging
-from test.utils import GraphHelper
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import pytest
 from _pytest.mark.structures import ParameterSet
 
 from rdflib.graph import Graph
+from test.utils import GraphHelper
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
 
 
 def make_test_query_construct_format_cases() -> Iterable[ParameterSet]:

--- a/test/test_store/test_store_sparqlstore_sparqlconnector.py
+++ b/test/test_store/test_store_sparqlstore_sparqlconnector.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import json
 import logging
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Graph
 from rdflib.plugins.stores.sparqlstore import SPARQLStore
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
 
 
 @pytest.mark.parametrize(

--- a/test/test_store/test_store_sparqlupdatestore.py
+++ b/test/test_store/test_store_sparqlupdatestore.py
@@ -1,10 +1,10 @@
 import re
-from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK
 from urllib.request import urlopen
 
 import pytest
 
 from rdflib import BNode, ConjunctiveGraph, Graph, Literal, URIRef
+from test.data import BOB, CHEESE, HATES, LIKES, MICHEL, PIZZA, TAREK
 
 HOST = "http://localhost:3031"
 DB = "/db/"

--- a/test/test_store/test_store_sparqlupdatestore_mock.py
+++ b/test/test_store/test_store_sparqlupdatestore_mock.py
@@ -1,10 +1,10 @@
-from test.utils.http import MethodName, MockHTTPResponse
-from test.utils.httpservermock import ServedBaseHTTPServerMock
-from test.utils.namespace import EGDO
 from typing import ClassVar
 
 from rdflib.graph import ConjunctiveGraph
 from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
+from test.utils.http import MethodName, MockHTTPResponse
+from test.utils.httpservermock import ServedBaseHTTPServerMock
+from test.utils.namespace import EGDO
 
 
 class TestSPARQLConnector:

--- a/test/test_tools/test_chunk_serializer.py
+++ b/test/test_tools/test_chunk_serializer.py
@@ -4,17 +4,17 @@ import logging
 import os
 from contextlib import ExitStack
 from pathlib import Path
-from test.data import TEST_DATA_DIR
-from test.utils import GraphHelper
-from test.utils.graph import cached_graph
-from test.utils.namespace import MF
-from test.utils.path import ctx_chdir
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import pytest
 
 from rdflib import Graph
 from rdflib.tools.chunk_serializer import serialize_in_chunks
+from test.data import TEST_DATA_DIR
+from test.utils import GraphHelper
+from test.utils.graph import cached_graph
+from test.utils.namespace import MF
+from test.utils.path import ctx_chdir
 
 if TYPE_CHECKING:
     from builtins import ellipsis

--- a/test/test_tools/test_csv2rdf.py
+++ b/test/test_tools/test_csv2rdf.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 from tempfile import mkstemp
+
 from test.data import TEST_DATA_DIR
 
 REALESTATE_FILE_PATH = os.path.join(TEST_DATA_DIR, "csv", "realestate.csv")

--- a/test/test_turtle_quoting.py
+++ b/test/test_turtle_quoting.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import itertools
 import logging
 import re
-from test.utils.namespace import EGDC
 from typing import Callable, Dict, Iterable, List, Tuple
 
 import pytest
@@ -16,6 +15,7 @@ import pytest
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.plugins.parsers import ntriples
 from rdflib.term import Literal, URIRef
+from test.utils.namespace import EGDC
 
 from .utils import GraphHelper
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,9 +4,6 @@ import logging
 import time
 from contextlib import ExitStack
 from pathlib import Path
-from test.data import TEST_DATA_DIR
-from test.utils.graph import cached_graph
-from test.utils.namespace import RDFT
 from typing import Any, Collection, List, Optional, Set, Tuple, Type, Union
 
 import pytest
@@ -16,6 +13,9 @@ from rdflib.graph import ConjunctiveGraph, Graph, QuotedGraph
 from rdflib.namespace import RDF, RDFS
 from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef
 from rdflib.util import _coalesce, _iri2uri, find_roots, get_tree
+from test.data import TEST_DATA_DIR
+from test.utils.graph import cached_graph
+from test.utils.namespace import RDFT
 
 n3source = """\
 @prefix : <http://www.w3.org/2000/10/swap/Primer#>.

--- a/test/test_w3c_spec/test_n3_w3c.py
+++ b/test/test_w3c_spec/test_n3_w3c.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 
 import itertools
 import os
-from test.data import TEST_DATA_DIR
-from test.utils.manifest import RDFTest, read_manifest
-from test.utils.namespace import RDFT
 from typing import Callable, Dict
 
 import pytest
@@ -16,6 +13,9 @@ from rdflib import Graph
 from rdflib.compare import graph_diff, isomorphic
 from rdflib.namespace import split_uri
 from rdflib.term import Node, URIRef
+from test.data import TEST_DATA_DIR
+from test.utils.manifest import RDFTest, read_manifest
+from test.utils.namespace import RDFT
 
 verbose = False
 

--- a/test/test_w3c_spec/test_nquads_w3c.py
+++ b/test/test_w3c_spec/test_nquads_w3c.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper, ensure_suffix
-from test.utils.dawg_manifest import ManifestEntry, params_from_sources
-from test.utils.iri import URIMapper
-from test.utils.namespace import RDFT
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Dataset
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
+from test.utils.namespace import RDFT
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_w3c_spec/test_nt_w3c.py
+++ b/test/test_w3c_spec/test_nt_w3c.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper, ensure_suffix
-from test.utils.dawg_manifest import ManifestEntry, params_from_sources
-from test.utils.iri import URIMapper
-from test.utils.namespace import RDFT
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Graph
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
+from test.utils.namespace import RDFT
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_w3c_spec/test_rdfxml_w3c.py
+++ b/test/test_w3c_spec/test_rdfxml_w3c.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper, ensure_suffix
-from test.utils.dawg_manifest import ManifestEntry, params_from_sources
-from test.utils.iri import URIMapper
-from test.utils.namespace import RDFT
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Graph
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
+from test.utils.namespace import RDFT
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_w3c_spec/test_sparql10_w3c.py
+++ b/test/test_w3c_spec/test_sparql10_w3c.py
@@ -3,6 +3,11 @@ Runs the SPARQL 1.0 test suite from.
 """
 
 from contextlib import ExitStack
+from typing import Generator
+
+import pytest
+from pytest import MonkeyPatch
+
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -13,10 +18,6 @@ from test.utils.sparql_checker import (
     check_entry,
     ctx_configure_rdflib,
 )
-from typing import Generator
-
-import pytest
-from pytest import MonkeyPatch
 
 REMOTE_BASE_IRI = "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/"
 LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/dawg-data-r2/"

--- a/test/test_w3c_spec/test_sparql11_w3c.py
+++ b/test/test_w3c_spec/test_sparql11_w3c.py
@@ -3,6 +3,11 @@ Runs the SPARQL 1.1 test suite from.
 """
 
 from contextlib import ExitStack
+from typing import Generator
+
+import pytest
+from pytest import MonkeyPatch
+
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -13,10 +18,6 @@ from test.utils.sparql_checker import (
     check_entry,
     ctx_configure_rdflib,
 )
-from typing import Generator
-
-import pytest
-from pytest import MonkeyPatch
 
 REMOTE_BASE_IRI = "http://www.w3.org/2009/sparql/docs/tests/data-sparql11/"
 LOCAL_BASE_DIR = TEST_DATA_DIR / "suites/w3c/sparql11/"

--- a/test/test_w3c_spec/test_sparql_rdflib.py
+++ b/test/test_w3c_spec/test_sparql_rdflib.py
@@ -3,6 +3,11 @@ Runs the RDFLib SPARQL test suite.
 """
 
 from contextlib import ExitStack
+from typing import Generator
+
+import pytest
+from pytest import MonkeyPatch
+
 from test.data import TEST_DATA_DIR
 from test.utils import ensure_suffix
 from test.utils.dawg_manifest import MarksDictType, params_from_sources
@@ -13,10 +18,6 @@ from test.utils.sparql_checker import (
     check_entry,
     ctx_configure_rdflib,
 )
-from typing import Generator
-
-import pytest
-from pytest import MonkeyPatch
 
 REMOTE_BASE_IRI = (
     "http://raw.github.com/RDFLib/rdflib/main/test/data/suites/rdflib/sparql/"

--- a/test/test_w3c_spec/test_trig_w3c.py
+++ b/test/test_w3c_spec/test_trig_w3c.py
@@ -6,16 +6,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper, ensure_suffix
-from test.utils.dawg_manifest import ManifestEntry, params_from_sources
-from test.utils.iri import URIMapper
-from test.utils.namespace import RDFT
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Dataset
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
+from test.utils.namespace import RDFT
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_w3c_spec/test_turtle_w3c.py
+++ b/test/test_w3c_spec/test_turtle_w3c.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from test.data import TEST_DATA_DIR
-from test.utils import BNodeHandling, GraphHelper, ensure_suffix
-from test.utils.dawg_manifest import ManifestEntry, params_from_sources
-from test.utils.iri import URIMapper
-from test.utils.namespace import RDFT
 from typing import Optional
 
 import pytest
 
 from rdflib.graph import Graph
+from test.data import TEST_DATA_DIR
+from test.utils import BNodeHandling, GraphHelper, ensure_suffix
+from test.utils.dawg_manifest import ManifestEntry, params_from_sources
+from test.utils.iri import URIMapper
+from test.utils.namespace import RDFT
 
 logger = logging.getLogger(__name__)
 

--- a/test/utils/dawg_manifest.py
+++ b/test/utils/dawg_manifest.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from test.utils import MarkListType, marks_to_list
-from test.utils.graph import GraphSource, GraphSourceType
-from test.utils.iri import URIMapper
-from test.utils.namespace import MF
 from typing import (
     Callable,
     Collection,
@@ -26,6 +22,10 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 from rdflib.graph import Graph
 from rdflib.namespace import RDF
 from rdflib.term import IdentifiedNode, Identifier, URIRef
+from test.utils import MarkListType, marks_to_list
+from test.utils.graph import GraphSource, GraphSourceType
+from test.utils.iri import URIMapper
+from test.utils.namespace import MF
 
 POFilterType = Tuple[Optional[URIRef], Optional[URIRef]]
 POFiltersType = Iterable[POFilterType]

--- a/test/utils/earl.py
+++ b/test/utils/earl.py
@@ -9,9 +9,6 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from test.utils import GraphHelper
-from test.utils.dawg_manifest import ManifestEntry
-from test.utils.namespace import EARL, MF, RDFT
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -33,6 +30,9 @@ from pytest import Item
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 from rdflib.namespace import DC, DOAP, FOAF
 from rdflib.plugins.stores.memory import Memory
+from test.utils import GraphHelper
+from test.utils.dawg_manifest import ManifestEntry
+from test.utils.namespace import EARL, MF, RDFT
 
 if TYPE_CHECKING:
     from _pytest.main import Session

--- a/test/utils/graph.py
+++ b/test/utils/graph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import test.data
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -9,6 +8,7 @@ from runpy import run_path
 from typing import Any, Optional, Tuple, Type, Union
 
 import rdflib.util
+import test.data
 from rdflib.graph import Graph, _GraphT
 from rdflib.util import guess_format
 

--- a/test/utils/http.py
+++ b/test/utils/http.py
@@ -6,7 +6,6 @@ import enum
 import random
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from test.utils.wildcard import EQ_WILDCARD
 from threading import Thread
 from typing import (
     Dict,
@@ -21,6 +20,8 @@ from typing import (
     Union,
 )
 from urllib.parse import ParseResult
+
+from test.utils.wildcard import EQ_WILDCARD
 
 __all__: List[str] = []
 

--- a/test/utils/httpfileserver.py
+++ b/test/utils/httpfileserver.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from test.utils.http import HeadersT, MethodName, MockHTTPRequest, apply_headers_to
 from typing import Dict, List, Optional, Sequence, Type
 from urllib.parse import parse_qs, urljoin, urlparse
 from uuid import uuid4
+
+from test.utils.http import HeadersT, MethodName, MockHTTPRequest, apply_headers_to
 
 __all__: List[str] = [
     "LocationType",

--- a/test/utils/httpservermock.py
+++ b/test/utils/httpservermock.py
@@ -3,13 +3,6 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from test.utils.http import (
-    MethodName,
-    MockHTTPRequest,
-    MockHTTPResponse,
-    apply_headers_to,
-    get_random_ip,
-)
 from threading import Thread
 from types import TracebackType
 from typing import (
@@ -27,6 +20,14 @@ from typing import (
 )
 from unittest.mock import MagicMock, Mock
 from urllib.parse import parse_qs, urlparse
+
+from test.utils.http import (
+    MethodName,
+    MockHTTPRequest,
+    MockHTTPResponse,
+    apply_headers_to,
+    get_random_ip,
+)
 
 __all__: List[str] = ["make_spypair", "BaseHTTPServerMock", "ServedBaseHTTPServerMock"]
 

--- a/test/utils/iri.py
+++ b/test/utils/iri.py
@@ -9,14 +9,14 @@ import http.client
 import logging
 import mimetypes
 from dataclasses import dataclass
+from nturl2path import url2pathname as nt_url2pathname
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
-from test.utils import ensure_suffix
 from typing import Callable, Optional, Set, Tuple, Type, TypeVar, Union
 from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunsplit
 from urllib.request import BaseHandler, OpenerDirector, Request
 from urllib.response import addinfourl
 
-from nturl2path import url2pathname as nt_url2pathname
+from test.utils import ensure_suffix
 
 PurePathT = TypeVar("PurePathT", bound=PurePath)
 

--- a/test/utils/literal.py
+++ b/test/utils/literal.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import builtins
 import logging
 from dataclasses import dataclass
-from test.utils.outcome import NoExceptionChecker
 from typing import Any, Optional, Union
 from xml.dom.minidom import DocumentFragment
 
 from rdflib.term import Literal, URIRef
+from test.utils.outcome import NoExceptionChecker
 
 
 @dataclass(frozen=True)

--- a/test/utils/manifest.py
+++ b/test/utils/manifest.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
-from test.utils.namespace import DAWGT, MF, QT, RDFT, UT
 from typing import Iterable, List, NamedTuple, Optional, Tuple, Union, cast
 
 from rdflib import RDF, RDFS, Graph
 from rdflib.term import Identifier, Node, URIRef
+from test.utils.namespace import DAWGT, MF, QT, RDFT, UT
 
 logger = logging.getLogger(__name__)
 

--- a/test/utils/sparql_checker.py
+++ b/test/utils/sparql_checker.py
@@ -9,12 +9,6 @@ import pprint
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from io import BytesIO, StringIO
-from test.utils import BNodeHandling, GraphHelper
-from test.utils.dawg_manifest import Manifest, ManifestEntry
-from test.utils.iri import URIMapper
-from test.utils.namespace import MF, QT, UT
-from test.utils.result import ResultType, assert_bindings_collections_equal
-from test.utils.urlopen import context_urlopener
 from typing import Dict, Generator, Optional, Set, Tuple, Type, Union, cast
 from urllib.parse import urljoin
 
@@ -31,6 +25,12 @@ from rdflib.plugins.sparql.results.rdfresults import RDFResultParser
 from rdflib.query import Result
 from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, Node, URIRef
 from rdflib.util import guess_format
+from test.utils import BNodeHandling, GraphHelper
+from test.utils.dawg_manifest import Manifest, ManifestEntry
+from test.utils.iri import URIMapper
+from test.utils.namespace import MF, QT, UT
+from test.utils.result import ResultType, assert_bindings_collections_equal
+from test.utils.urlopen import context_urlopener
 
 logger = logging.getLogger(__name__)
 

--- a/test/utils/test/test_httpservermock.py
+++ b/test/utils/test/test_httpservermock.py
@@ -1,9 +1,10 @@
-from test.utils.http import MethodName, MockHTTPResponse, ctx_http_handler
-from test.utils.httpservermock import BaseHTTPServerMock, ServedBaseHTTPServerMock
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 import pytest
+
+from test.utils.http import MethodName, MockHTTPResponse, ctx_http_handler
+from test.utils.httpservermock import BaseHTTPServerMock, ServedBaseHTTPServerMock
 
 
 def test_base() -> None:

--- a/test/utils/test/test_iri.py
+++ b/test/utils/test/test_iri.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 from contextlib import ExitStack
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
-from test.utils.iri import file_uri_to_path, rebase_url
 from typing import Optional, Type, Union
 
 import pytest
+
+from test.utils.iri import file_uri_to_path, rebase_url
 
 
 @pytest.mark.parametrize(

--- a/test/utils/test/test_outcome.py
+++ b/test/utils/test/test_outcome.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
-from test.utils.outcome import ExceptionChecker, OutcomeChecker
 from typing import Any, Callable, NoReturn, Optional, Type, Union
 
 import pytest
+
+from test.utils.outcome import ExceptionChecker, OutcomeChecker
 
 
 def _raise(

--- a/test/utils/test/test_result.py
+++ b/test/utils/test/test_result.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
-from test.utils.result import BindingsCollectionType, assert_bindings_collections_equal
 from typing import Optional, Type, Union
 
 import pytest
 
 from rdflib.namespace import XSD
 from rdflib.term import BNode, Literal, URIRef, Variable
+from test.utils.result import BindingsCollectionType, assert_bindings_collections_equal
 
 
 @pytest.mark.parametrize(

--- a/test/utils/test/test_testutils.py
+++ b/test/utils/test/test_testutils.py
@@ -4,6 +4,12 @@ import os
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any, List, Optional, Tuple, Type, Union
+
+import pytest
+
+from rdflib.graph import ConjunctiveGraph, Dataset, Graph
+from rdflib.term import URIRef
 from test.utils import (
     COLLAPSED_BNODE,
     BNodeHandling,
@@ -11,12 +17,6 @@ from test.utils import (
     affix_tuples,
     file_uri_to_path,
 )
-from typing import Any, List, Optional, Tuple, Type, Union
-
-import pytest
-
-from rdflib.graph import ConjunctiveGraph, Dataset, Graph
-from rdflib.term import URIRef
 
 
 def check(


### PR DESCRIPTION
Last week saw Dependabot bump Ruff from 0.4.1 to 0.5.2, thats 12 releases, then yesterday bumped it from 0.5.2 to 0.5.4, another two releases.
In that jump of 14 releases, there were a bunch of fixes to Ruff, that caused some of RDFLib's files to need to be fixed.

The biggest change is now Ruff doesn't think "test" is a system module (which is correct) so now the isort feature sorts test in with the rest of the user's local modules.

There was also an update to the settings names in the pyproject.toml to stop Ruff from complaining about using the wrong settings names.