### PR TITLE
More typing fixes for mypy update

### DIFF
--- a/rdflib/extras/infixowl.py
+++ b/rdflib/extras/infixowl.py
@@ -1329,7 +1329,10 @@ class Class(AnnotatableTerms):
     #        predicate=RDFS.subClassOf,object=self.identifier):
     #         yield Class(s,skipOWLClassMembership=True)
 
-    def __repr__(self, full=False, normalization=True):
+    def __repr__(self):
+        return self.manchesterClass(full=False, normalization=True)
+
+    def manchesterClass(self, full=False, normalization=True):  # noqa: N802
         """
         Returns the Manchester Syntax equivalent for this class
         """

--- a/test/test_extras/test_infixowl/test_class.py
+++ b/test/test_extras/test_infixowl/test_class.py
@@ -153,7 +153,7 @@ def test_class_getparents(graph):
 
     assert list(sibling.subSumpteeIds()) == []
 
-    assert str(brother.__repr__(full=True)) == "Class: ex:Brother "
+    assert str(brother.manchesterClass(full=True)) == "Class: ex:Brother "
 
     assert graph.serialize(format="ttl") == (
         "@prefix ex: <http://example.org/vocab/> .\n"
@@ -251,7 +251,7 @@ def test_class_serialize(graph):
 
     assert str(owlc.__invert__()) == "Some Class DisjointWith ( NOT ex:Sister )\n"
 
-    assert owlc.__repr__(full=True) == (
+    assert owlc.manchesterClass(full=True) == (
         "Class: ex:test \n"
         "    ## A Defined Class (Man) ##\n"
         "    This is a Man\n"

--- a/test/test_serializers/test_serializer.py
+++ b/test/test_serializers/test_serializer.py
@@ -717,4 +717,5 @@ def test_serialize_to_fileuri_with_authortiy(
             format=format.info.serializer,
         )
         assert False  # this should never happen as serialize should always fail
-    assert catcher.value is not None
+    # type error, mypy thinks this line is unreachable, but it works fine
+    assert catcher.value is not None  # type: ignore[unreachable, unused-ignore]

--- a/test/test_sparql/test_result.py
+++ b/test/test_sparql/test_result.py
@@ -441,4 +441,5 @@ def test_serialize_to_fileuri_with_authortiy(
             encoding=encoding,
         )
         assert False  # this should never happen as serialize should always fail
-    assert catcher.value is not None
+    # type error, mypy thinks this line is unreachable, but it works fine
+    assert catcher.value is not None  # type: ignore[unreachable, unused-ignore]

--- a/test/utils/test/test_outcome.py
+++ b/test/utils/test/test_outcome.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
-from typing import Any, Callable, NoReturn, Optional, Type, Union
+from typing import Any, Callable, NoReturn, Optional, Type, Union, cast
 
 import pytest
 
@@ -16,7 +16,8 @@ def _raise(
     if isinstance(what, type) and issubclass(what, Exception):
         raise what(*args, **kwargs)
     elif callable(what):
-        raise what(*args, **kwargs)
+        what_fn: Callable[..., Exception] = cast(Callable[..., Exception], what)
+        raise what_fn(*args, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
These are some typing and function-signature fixes that are required due to the new mypy 1.11.0 update that dependabot has pushed today.
