### PR TITLE
Add optional orjson support for faster json reading and writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The stable release of RDFLib may be installed with Python's package management t
 
 Some features of RDFLib require optional dependencies which may be installed using *pip* extras:
 
-    $ pip install rdflib[berkeleydb,networkx,html,lxml]
+    $ pip install rdflib[berkeleydb,networkx,html,lxml,orjson]
 
 Alternatively manually download the package from the Python Package
 Index (PyPI) at https://pypi.python.org/pypi/rdflib

--- a/devtools/constraints.min
+++ b/devtools/constraints.min
@@ -8,3 +8,4 @@ berkeleydb==18.1.2
 networkx==2.0
 html5lib==1.0.1
 lxml==4.3.0
+orjson==3.9.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ berkeleydb = {version = "^18.1.0", optional = true}
 networkx = {version = ">=2,<4", optional = true}
 html5lib = {version = "^1.0", optional = true}
 lxml = {version = ">=4.3,<6.0", optional = true}
+orjson = {version = ">=3.9.14,<4", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "24.4.2"
@@ -74,6 +75,7 @@ berkeleydb = ["berkeleydb"]
 networkx = ["networkx"]
 html = ["html5lib"]
 lxml = ["lxml"]
+orjson = ["orjson"]
 
 [build-system]
 requires = ["poetry-core>=1.4.0"]

--- a/rdflib/plugins/parsers/hext.py
+++ b/rdflib/plugins/parsers/hext.py
@@ -20,7 +20,7 @@ try:
 
     _HAS_ORJSON = True
 except ImportError:
-    orjson = None
+    orjson = None  # type: ignore[assignment]
     _HAS_ORJSON = False
 
 if TYPE_CHECKING:

--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -62,9 +62,11 @@ from ..shared.jsonld.keys import (
     VOCAB,
 )
 from ..shared.jsonld.util import (
+    _HAS_ORJSON,
     VOCAB_DELIMS,
     context_from_urlinputsource,
     json,
+    orjson,
     source_to_json,
 )
 
@@ -605,11 +607,18 @@ class Parser:
 
     @staticmethod
     def _to_typed_json_value(value: Any) -> Dict[str, str]:
-        return {
-            TYPE: URIRef("%sJSON" % str(RDF)),
-            VALUE: json.dumps(
+        if _HAS_ORJSON:
+            val_string: str = orjson.dumps(
+                value,
+                option=orjson.OPT_SORT_KEYS | orjson.OPT_NON_STR_KEYS,
+            ).decode("utf-8")
+        else:
+            val_string = json.dumps(
                 value, separators=(",", ":"), sort_keys=True, ensure_ascii=False
-            ),
+            )
+        return {
+            TYPE: RDF.JSON,
+            VALUE: val_string,
         }
 
     @classmethod

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -7,12 +7,20 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import IO, Optional, Type, Union
+from typing import IO, Callable, List, Optional, Type, Union
 
-from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Graph
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset, Graph
 from rdflib.namespace import RDF, XSD
 from rdflib.serializer import Serializer
-from rdflib.term import BNode, Literal, Node, URIRef
+from rdflib.term import BNode, IdentifiedNode, Literal, URIRef
+
+try:
+    import orjson
+
+    _HAS_ORJSON = True
+except ImportError:
+    orjson = None
+    _HAS_ORJSON = False
 
 __all__ = ["HextuplesSerializer"]
 
@@ -22,11 +30,37 @@ class HextuplesSerializer(Serializer):
     Serializes RDF graphs to NTriples format.
     """
 
-    def __init__(self, store: Union[Graph, ConjunctiveGraph]):
-        self.default_context: Optional[Node]
-        self.graph_type: Type[Graph]
-        if isinstance(store, ConjunctiveGraph):
-            self.graph_type = ConjunctiveGraph
+    contexts: List[Union[Graph, IdentifiedNode]]
+    dumps: Callable
+
+    def __new__(cls, store: Union[Graph, Dataset, ConjunctiveGraph]):
+        if _HAS_ORJSON:
+            cls.str_local_id = orjson.Fragment(b'"localId"')
+            cls.str_global_id = orjson.Fragment(b'"globalId"')
+            cls.empty = orjson.Fragment(b'""')
+            cls.newline: Union[bytes, str] = b"\n"
+            cls.lang_str = orjson.Fragment(b'"' + RDF.langString.encode("utf-8") + b'"')
+            cls.xsd_string = orjson.Fragment(b'"' + XSD.string.encode("utf-8") + b'"')
+            dumps = orjson.dumps
+        else:
+            cls.str_local_id = "localId"
+            cls.str_global_id = "globalId"
+            cls.empty = ""
+            cls.newline = "\n"
+            cls.lang_str = f"{RDF.langString}"
+            cls.xsd_string = f"{XSD.string}"
+            dumps = json.dumps
+        self = super(cls, cls).__new__(cls)
+        self.dumps = dumps
+        return self
+
+    def __init__(self, store: Union[Graph, Dataset, ConjunctiveGraph]):
+        self.default_context: Optional[Union[Graph, IdentifiedNode]]
+        self.graph_type: Union[Type[Graph], Type[Dataset], Type[ConjunctiveGraph]]
+        if isinstance(store, (Dataset, ConjunctiveGraph)):
+            self.graph_type = (
+                Dataset if isinstance(store, Dataset) else ConjunctiveGraph
+            )
             self.contexts = list(store.contexts())
             if store.default_context:
                 self.default_context = store.default_context
@@ -64,14 +98,26 @@ class HextuplesSerializer(Serializer):
             raise Exception(
                 "Hextuple serialization can't (yet) handle formula-aware stores"
             )
-
+        context: Union[Graph, IdentifiedNode]
+        context_str: Union[bytes, str]
         for context in self.contexts:
             for triple in context:
-                hl = self._hex_line(triple, context)
+                # Generate context string just once, because it doesn't change
+                # for every triple in this context
+                context_str = (
+                    self.empty
+                    if self.graph_type is Graph
+                    else (
+                        orjson.Fragment('"' + self._context_str(context) + '"')
+                        if _HAS_ORJSON
+                        else self._context_str(context)
+                    )
+                )
+                hl = self._hex_line(triple, context_str)
                 if hl is not None:
-                    stream.write(hl.encode())
+                    stream.write(hl if _HAS_ORJSON else hl.encode())
 
-    def _hex_line(self, triple, context):
+    def _hex_line(self, triple, context_str: Union[bytes, str]):
         if isinstance(
             triple[0], (URIRef, BNode)
         ):  # exclude QuotedGraph and other objects
@@ -85,18 +131,18 @@ class HextuplesSerializer(Serializer):
             # datatype
             if isinstance(triple[2], URIRef):
                 # datatype = "http://www.w3.org/1999/02/22-rdf-syntax-ns#namedNode"
-                datatype = "globalId"
+                datatype = self.str_global_id
             elif isinstance(triple[2], BNode):
                 # datatype = "http://www.w3.org/1999/02/22-rdf-syntax-ns#blankNode"
-                datatype = "localId"
+                datatype = self.str_local_id
             elif isinstance(triple[2], Literal):
                 if triple[2].datatype is not None:
                     datatype = f"{triple[2].datatype}"
                 else:
                     if triple[2].language is not None:  # language
-                        datatype = RDF.langString
+                        datatype = self.lang_str
                     else:
-                        datatype = XSD.string
+                        datatype = self.xsd_string
             else:
                 return None  # can't handle non URI, BN or Literal Object (QuotedGraph)
 
@@ -105,22 +151,22 @@ class HextuplesSerializer(Serializer):
                 if triple[2].language is not None:
                     language = f"{triple[2].language}"
                 else:
-                    language = ""
+                    language = self.empty
             else:
-                language = ""
+                language = self.empty
 
             return (
-                json.dumps(
+                self.dumps(
                     [
                         self._iri_or_bn(triple[0]),
                         triple[1],
                         value,
                         datatype,
                         language,
-                        self._context(context),
+                        context_str,
                     ]
                 )
-                + "\n"
+                + self.newline
             )
         else:  # do not return anything for non-IRIs or BNs, e.g. QuotedGraph, Subjects
             return None
@@ -133,17 +179,28 @@ class HextuplesSerializer(Serializer):
         else:
             return None
 
-    def _context(self, context):
-        if self.graph_type == Graph:
+    def _context_str(self, context: Union[Graph, IdentifiedNode]) -> str:
+        context_identifier: IdentifiedNode = (
+            context.identifier if isinstance(context, Graph) else context
+        )
+        if context_identifier == DATASET_DEFAULT_GRAPH_ID:
             return ""
-        if context.identifier == DATASET_DEFAULT_GRAPH_ID:
-            return ""
-        elif context is not None and self.default_context is not None:
-            # type error: "Node" has no attribute "identifier"
-            if context.identifier == self.default_context.identifier:  # type: ignore[attr-defined]
+        if self.default_context is not None:
+            if (
+                isinstance(self.default_context, IdentifiedNode)
+                and context_identifier == self.default_context
+            ):
                 return ""
+            elif (
+                isinstance(self.default_context, Graph)
+                and context_identifier == self.default_context.identifier
+            ):
+                return ""
+        if self.graph_type is Graph:
+            # Only emit a context name when serializing a Dataset or ConjunctiveGraph
+            return ""
         return (
-            context.identifier
-            if isinstance(context.identifier, URIRef)
-            else context.identifier.n3()
+            f"{context_identifier}"
+            if isinstance(context_identifier, URIRef)
+            else context_identifier.n3()
         )

--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -47,7 +47,7 @@ from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, URIRef
 
 from ..shared.jsonld.context import UNDEF, Context
 from ..shared.jsonld.keys import CONTEXT, GRAPH, ID, LANG, LIST, SET, VOCAB
-from ..shared.jsonld.util import json
+from ..shared.jsonld.util import _HAS_ORJSON, json, orjson
 
 __all__ = ["JsonLDSerializer", "from_rdf"]
 
@@ -91,16 +91,25 @@ class JsonLDSerializer(Serializer):
             use_rdf_type,
             auto_compact=auto_compact,
         )
-
-        data = json.dumps(
-            obj,
-            indent=indent,
-            separators=separators,
-            sort_keys=sort_keys,
-            ensure_ascii=ensure_ascii,
-        )
-
-        stream.write(data.encode(encoding, "replace"))
+        if _HAS_ORJSON:
+            option: int = orjson.OPT_NON_STR_KEYS
+            if indent is not None:
+                option |= orjson.OPT_INDENT_2
+            if sort_keys:
+                option |= orjson.OPT_SORT_KEYS
+            if ensure_ascii:
+                warnings.warn("Cannot use ensure_ascii with orjson")
+            data_bytes = orjson.dumps(obj, option=option)
+            stream.write(data_bytes)
+        else:
+            data = json.dumps(
+                obj,
+                indent=indent,
+                separators=separators,
+                sort_keys=sort_keys,
+                ensure_ascii=ensure_ascii,
+            )
+            stream.write(data.encode(encoding, "replace"))
 
 
 def from_rdf(

--- a/rdflib/plugins/shared/jsonld/util.py
+++ b/rdflib/plugins/shared/jsonld/util.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import json
 import pathlib
-from io import StringIO, TextIOWrapper
+from io import StringIO, TextIOBase, TextIOWrapper
 from posixpath import normpath, sep
-from typing import IO, TYPE_CHECKING, Any, Optional, TextIO, Tuple, Union
+from typing import IO, TYPE_CHECKING, Any, Optional, TextIO, Tuple, Union, cast
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 try:
@@ -13,7 +13,7 @@ try:
 
     _HAS_ORJSON = True
 except ImportError:
-    orjson = None
+    orjson = None  # type: ignore[assignment]
     _HAS_ORJSON = False
 
 
@@ -41,7 +41,7 @@ def source_to_json(
         b_stream = source.getByteStream()
         original_string: Optional[str] = None
         if isinstance(b_stream, BytesIOWrapper):
-            wrapped_inner = b_stream.wrapped
+            wrapped_inner = cast(Union[str, StringIO, TextIOBase], b_stream.wrapped)
             if isinstance(wrapped_inner, str):
                 original_string = wrapped_inner
             elif isinstance(wrapped_inner, StringIO):
@@ -193,4 +193,6 @@ __all__ = [
     "split_iri",
     "norm_url",
     "context_from_urlinputsource",
+    "orjson",
+    "_HAS_ORJSON",
 ]

--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import collections
 import itertools
-import json as j
 import re
 from typing import (
     TYPE_CHECKING,
@@ -63,6 +62,15 @@ from rdflib.term import BNode, Identifier, Literal, URIRef, Variable
 if TYPE_CHECKING:
     from rdflib.paths import Path
 
+import json
+
+try:
+    import orjson
+
+    _HAS_ORJSON = True
+except ImportError:
+    orjson = None  # type: ignore[assignment]
+    _HAS_ORJSON = False
 
 _Triple = Tuple[Identifier, Identifier, Identifier]
 
@@ -365,10 +373,13 @@ def evalServiceQuery(ctx: QueryContext, part: CompValue):
                 )
             )
         if response.status == 200:
-            json = j.loads(response.read())
-            variables = res["vars_"] = json["head"]["vars"]
+            if _HAS_ORJSON:
+                json_dict = orjson.loads(response.read())
+            else:
+                json_dict = json.loads(response.read())
+            variables = res["vars_"] = json_dict["head"]["vars"]
             # or just return the bindings?
-            res = json["results"]["bindings"]
+            res = json_dict["results"]["bindings"]
             if len(res) > 0:
                 for r in res:
                     # type error: Argument 2 to "_yieldBindingsFromServiceCallResult" has incompatible type "str"; expected "Dict[str, Dict[str, str]]"

--- a/rdflib/plugins/sparql/results/csvresults.py
+++ b/rdflib/plugins/sparql/results/csvresults.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import codecs
 import csv
-from typing import IO, Dict, List, Optional, Union
+from io import BufferedIOBase, TextIOBase
+from typing import IO, Dict, List, Optional, Union, cast
 
 from rdflib.plugins.sparql.processor import SPARQLResult
 from rdflib.query import Result, ResultParser, ResultSerializer
@@ -71,13 +72,19 @@ class CSVResultSerializer(ResultSerializer):
     def serialize(self, stream: IO, encoding: str = "utf-8", **kwargs) -> None:
         # the serialiser writes bytes in the given encoding
         # in py3 csv.writer is unicode aware and writes STRINGS,
-        # so we encode afterwards
+        # so we encode afterward
 
         import codecs
 
-        stream = codecs.getwriter(encoding)(stream)  # type: ignore[assignment]
+        # TODO: Find a better solution for all this casting
+        writable_stream = cast(Union[TextIOBase, BufferedIOBase], stream)
+        if isinstance(writable_stream, TextIOBase):
+            string_stream: TextIOBase = writable_stream
+        else:
+            byte_stream = cast(BufferedIOBase, writable_stream)
+            string_stream = cast(TextIOBase, codecs.getwriter(encoding)(byte_stream))
 
-        out = csv.writer(stream, delimiter=self.delim)
+        out = csv.writer(string_stream, delimiter=self.delim)
 
         vs = [self.serializeTerm(v, encoding) for v in self.result.vars]  # type: ignore[union-attr]
         out.writerow(vs)

--- a/rdflib/plugins/sparql/results/jsonresults.py
+++ b/rdflib/plugins/sparql/results/jsonresults.py
@@ -17,14 +17,29 @@ from typing import IO, Any, Dict, Mapping, MutableSequence, Optional
 from rdflib.query import Result, ResultException, ResultParser, ResultSerializer
 from rdflib.term import BNode, Identifier, Literal, URIRef, Variable
 
+try:
+    import orjson
+
+    _HAS_ORJSON = True
+except ImportError:
+    orjson = None  # type: ignore[assignment]
+    _HAS_ORJSON = False
+
 
 class JSONResultParser(ResultParser):
     # type error: Signature of "parse" incompatible with supertype "ResultParser"
     def parse(self, source: IO, content_type: Optional[str] = None) -> Result:  # type: ignore[override]
         inp = source.read()
-        if isinstance(inp, bytes):
-            inp = inp.decode("utf-8")
-        return JSONResult(json.loads(inp))
+        if _HAS_ORJSON:
+            try:
+                loaded = orjson.loads(inp)
+            except Exception as e:
+                raise ResultException(f"Failed to parse result: {e}")
+        else:
+            if isinstance(inp, bytes):
+                inp = inp.decode("utf-8")
+            loaded = json.loads(inp)
+        return JSONResult(loaded)
 
 
 class JSONResultSerializer(ResultSerializer):
@@ -45,12 +60,29 @@ class JSONResultSerializer(ResultSerializer):
             res["results"]["bindings"] = [
                 self._bindingToJSON(x) for x in self.result.bindings
             ]
-
-        r = json.dumps(res, allow_nan=False, ensure_ascii=False)
-        if encoding is not None:
-            stream.write(r.encode(encoding))
+        if _HAS_ORJSON:
+            try:
+                r_bytes = orjson.dumps(res, option=orjson.OPT_NON_STR_KEYS)
+            except Exception as e:
+                raise ResultException(f"Failed to serialize result: {e}")
+            if encoding is not None:
+                # Note, orjson will always write utf-8 even if
+                # encoding is specified as something else.
+                try:
+                    stream.write(r_bytes)
+                except (TypeError, ValueError):
+                    stream.write(r_bytes.decode("utf-8"))
+            else:
+                stream.write(r_bytes.decode("utf-8"))
         else:
-            stream.write(r)
+            r_str = json.dumps(res, allow_nan=False, ensure_ascii=False)
+            if encoding is not None:
+                try:
+                    stream.write(r_str.encode(encoding))
+                except (TypeError, ValueError):
+                    stream.write(r_str)
+            else:
+                stream.write(r_str)
 
     def _bindingToJSON(self, b: Mapping[Variable, Identifier]) -> Dict[Variable, Any]:
         res = {}

--- a/rdflib/plugins/sparql/results/txtresults.py
+++ b/rdflib/plugins/sparql/results/txtresults.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import StringIO
 from typing import IO, List, Optional, Union
 
 from rdflib.namespace import NamespaceManager
@@ -26,16 +27,16 @@ def _termString(
 
 class TXTResultSerializer(ResultSerializer):
     """
-    A write only QueryResult serializer for text/ascii tables
+    A write-only QueryResult serializer for text/ascii tables
     """
 
-    # TODO FIXME: class specific args should be keyword only.
-    # type error: Signature of "serialize" incompatible with supertype "ResultSerializer"
-    def serialize(  # type: ignore[override]
+    def serialize(
         self,
         stream: IO,
-        encoding: str,
+        encoding: str = "utf-8",
+        *,
         namespace_manager: Optional[NamespaceManager] = None,
+        **kwargs,
     ) -> None:
         """
         return a text table of query results
@@ -53,10 +54,9 @@ class TXTResultSerializer(ResultSerializer):
 
         if self.result.type != "SELECT":
             raise Exception("Can only pretty print SELECT results!")
-
+        string_stream = StringIO()
         if not self.result:
-            # type error: No return value expected
-            return "(no results)\n"  # type: ignore[return-value]
+            string_stream.write("(no results)\n")
         else:
             keys: List[Variable] = self.result.vars  # type: ignore[assignment]
             maxlen = [0] * len(keys)
@@ -71,10 +71,16 @@ class TXTResultSerializer(ResultSerializer):
             for r in b:
                 for i in range(len(keys)):
                     maxlen[i] = max(maxlen[i], len(r[i]))
-
-            stream.write("|".join([c(k, maxlen[i]) for i, k in enumerate(keys)]) + "\n")
-            stream.write("-" * (len(maxlen) + sum(maxlen)) + "\n")
+            string_stream.write(
+                "|".join([c(k, maxlen[i]) for i, k in enumerate(keys)]) + "\n"
+            )
+            string_stream.write("-" * (len(maxlen) + sum(maxlen)) + "\n")
             for r in sorted(b):
-                stream.write(
+                string_stream.write(
                     "|".join([t + " " * (i - len(t)) for i, t in zip(maxlen, r)]) + "\n"
                 )
+        text_val = string_stream.getvalue()
+        try:
+            stream.write(text_val.encode(encoding))
+        except (TypeError, ValueError):
+            stream.write(text_val)

--- a/rdflib/query.py
+++ b/rdflib/query.py
@@ -316,7 +316,8 @@ class Result:
         serializer = plugin.get(format, ResultSerializer)(self)
         if destination is None:
             streamb: BytesIO = BytesIO()
-            stream2 = EncodeOnlyUnicode(streamb)
+            stream2 = EncodeOnlyUnicode(streamb)  # TODO: Remove the need for this
+            # TODO: All QueryResult serializers should write to a Bytes Stream.
             # type error: Argument 1 to "serialize" of "ResultSerializer" has incompatible type "EncodeOnlyUnicode"; expected "IO[Any]"
             serializer.serialize(stream2, encoding=encoding, **args)  # type: ignore[arg-type]
             return streamb.getvalue()

--- a/test/test_parsers/test_parser_hext.py
+++ b/test/test_parsers/test_parser_hext.py
@@ -57,6 +57,33 @@ def test_small_string():
     assert len(d) == 10
 
 
+def test_small_bytes_string():
+    s = b"""\
+        ["http://example.com/s01", "http://example.com/a", "http://example.com/Type1", "globalId", "", "https://example.com/graph/1"]
+        ["http://example.com/s01", "http://example.com/label", "This is a Label", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "en", "_:graph-2"]
+        ["http://example.com/s01", "http://example.com/comment", "This is a comment", "http://www.w3.org/2001/XMLSchema#string", "", ""]
+        ["http://example.com/s01", "http://example.com/creationDate", "2021-12-01", "http://www.w3.org/2001/XMLSchema#date", "", ""]
+        ["http://example.com/s01", "http://example.com/creationTime", "2021-12-01T12:13:00", "http://www.w3.org/2001/XMLSchema#dateTime", "", ""]
+        ["http://example.com/s01", "http://example.com/age", "42", "http://www.w3.org/2001/XMLSchema#integer", "", ""]
+        ["http://example.com/s01", "http://example.com/trueFalse", "false", ",http://www.w3.org/2001/XMLSchema#boolean", "", ""]
+        ["http://example.com/s01", "http://example.com/op1", "http://example.com/o1", "globalId", "", ""]
+        ["http://example.com/s01", "http://example.com/op1", "http://example.com/o2", "globalId", "", ""]
+        ["http://example.com/s01", "http://example.com/op2", "http://example.com/o3", "globalId", "", ""]
+        """
+    d = Dataset()
+    d.parse(data=s, format="hext")
+
+    expected_graph_names = (
+        URIRef(DATASET_DEFAULT_GRAPH_ID),
+        URIRef("https://example.com/graph/1"),
+        BNode("graph-2"),
+    )
+    for graph in d.contexts():
+        assert graph.identifier in expected_graph_names
+
+    assert len(d) == 10
+
+
 def test_small_string_cg():
     s = """
         ["http://example.com/s01", "http://example.com/a", "http://example.com/Type1", "globalId", "", "https://example.com/graph/1"]

--- a/test/test_serializers/test_serializer_hext.py
+++ b/test/test_serializers/test_serializer_hext.py
@@ -79,8 +79,10 @@ def test_hext_graph():
         ],
     ]
     for line in out.splitlines():
+        normalized_line = line.replace(", ", ",").strip()
         for test in testing_lines:
-            if test[1] in line:
+            normalized_test = test[1].replace(", ", ",").strip()
+            if normalized_test in normalized_line:
                 test[0] = True
 
     assert all([x[0] for x in testing_lines])
@@ -127,7 +129,7 @@ def test_hext_cg():
            """
     d.parse(data=trig_data, format="trig", publicID=d.default_context.identifier)
     out = d.serialize(format="hext")
-    # note: cant' test for BNs in result as they will be different ever time
+    # note: cant' test for BNs in result as they will be different every time
     testing_lines = [
         [
             False,
@@ -200,8 +202,10 @@ def test_hext_cg():
         ],
     ]
     for line in out.splitlines():
+        normalized_line = line.replace(", ", ",").strip()
         for test in testing_lines:
-            if test[1] in line:
+            normalized_test = test[1].replace(", ", ",").strip()
+            if normalized_test in normalized_line:
                 test[0] = True
 
     assert all([x[0] for x in testing_lines])
@@ -316,8 +320,10 @@ def test_hext_dataset():
         ],
     ]
     for line in out.splitlines():
+        normalized_line = line.replace(", ", ",").strip()
         for test in testing_lines:
-            if test[1] in line:
+            normalized_test = test[1].replace(", ", ",").strip()
+            if normalized_test in normalized_line:
                 test[0] = True
 
     assert all([x[0] for x in testing_lines])
@@ -396,10 +402,12 @@ def test_roundtrip():
         str(Path(__file__).parent.parent / "data/test_parser_hext_multigraph.ndjson")
     ) as i:
         ordered_input = "".join(sorted(i.readlines())).strip()
+        normalized_ordered_input = ordered_input.replace(", ", ",")
 
     ordered_output = "\n".join(sorted(d.serialize(format="hext").split("\n"))).strip()
+    normalized_ordered_output = ordered_output.replace(", ", ",")
 
-    assert ordered_output == ordered_input
+    assert normalized_ordered_output == normalized_ordered_input
 
 
 # def _make_large_graph():

--- a/test/test_sparql/test_result.py
+++ b/test/test_sparql/test_result.py
@@ -182,17 +182,6 @@ def narrow_dest_param(param: DestParmType) -> ResultDestParamType:
 
 def make_select_result_serialize_parse_tests() -> Iterator[ParameterSet]:
     xfails: Dict[Tuple[str, DestinationType, str], Union[MarkDecorator, Mark]] = {
-        ("csv", DestinationType.TEXT_IO, "utf-8"): pytest.mark.xfail(raises=TypeError),
-        ("csv", DestinationType.TEXT_IO, "utf-16"): pytest.mark.xfail(raises=TypeError),
-        ("json", DestinationType.TEXT_IO, "utf-8"): pytest.mark.xfail(raises=TypeError),
-        ("json", DestinationType.TEXT_IO, "utf-16"): pytest.mark.xfail(
-            raises=TypeError
-        ),
-        ("txt", DestinationType.BINARY_IO, "utf-8"): pytest.mark.xfail(
-            raises=TypeError
-        ),
-        ("txt", DestinationType.STR_PATH, "utf-8"): pytest.mark.xfail(raises=TypeError),
-        ("txt", DestinationType.FILE_URI, "utf-8"): pytest.mark.xfail(raises=TypeError),
     }
     format_infos = [
         format_info

--- a/test/utils/result.py
+++ b/test/utils/result.py
@@ -11,6 +11,12 @@ from rdflib.term import BNode, Identifier, Literal, Variable
 
 logger = logging.getLogger(__name__)
 
+try:
+    import orjson
+    _HAS_ORJSON = True
+except ImportError:
+    orjson = None  # type: ignore[assignment]
+    _HAS_ORJSON = False
 
 ResultTypeInfoDict = Dict["ResultType", "ResultTypeInfo"]
 
@@ -222,7 +228,7 @@ class ResultFormat(str, enum.Enum):
                         ResultFormatTrait.HAS_SERIALIZER,
                     }
                 ),
-                frozenset({"utf-8", "utf-16"}),
+                frozenset({"utf-8"} if _HAS_ORJSON else {"utf-8", "utf-16"}),
             ),
             ResultFormatInfo(
                 ResultFormat.XML,

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage.{envname}}
     MYPY_CACHE_DIR = {envdir}/.mypy_cache
     docs: POETRY_ARGS_docs = --only=docs
-    extensive: POETRY_ARGS_extensive = --extras=berkeleydb --extras=networkx --extras=html
+    extensive: POETRY_ARGS_extensive = --extras=berkeleydb --extras=networkx --extras=html --extras=orjson
     lxml: POETRY_ARGS_lxml = --extras=lxml
 commands_pre =
     py3{8,9,10,11}: python -c 'import os; print("\n".join(f"{key}={value}" for key, value in os.environ.items()))'
@@ -78,6 +78,7 @@ extras =
     networkx
     lxml
     html
+    orjson
 commands =
     {envpython} --version
     pip freeze


### PR DESCRIPTION
This adds _optional_ support for orjson, that can be enabled by installing rdflib with pip extras syntax like `rdflib[orjson]`, or poetry extras syntax like `--extras orjson`, or finally it will be detected and used if you simply install `orjson>=3.9.14` in your python environment.

This PR touches a _lot_ of files, because JSON is surprisingly used in a whole lot of different places in rdflib.

* JSON-LD Graph Serializer
* JSON-LD Graph Parser
* rdf:JSON literal support in JSON-LD documents
* Hextuples Graph Serializer (that uses a special newline-delimited JSON)
* Hextuples Graph Parser (parses JSON line-by line from a ND-JSON file)
* sparql-results-json SPARQLResults Parser
* sparql-results-json SPARQLResults Serializer

There are also some tangential non-JSON related changes to stream handling in a bunch of other SPARQLResult serializers. While implementing the orjson support for sparql-results-json serializer I found some errors in the way all of the different Sparql-Results-Serializers treat TextIO and BinaryIO streams. This was causing 7 errors to be thrown by the rdflib serializer tests, but they were marked as ignored in the test suite.

These additional changes include much better Typing to the Sparql-Results-Serializer subclasses, which exposed where the problems were (hooray for typed Python exposing actual errors). Fixes were made to all of the failing Sparql-Results-Serializer subclasses, and there are no skipped tests now. This also allowed the removal of a bunch of mypy `type: ignore` patches that were in place to silence the complaining type checker.

I know it would be great to move all those additional changes to a different PR, but there are two reasons I didnt:
1) The addition of the orjson feature relies on those typing changes and BinaryIO stream fixes.
2) The sparql-results-serializer fixes for specifically the sparql-results-json (SparqlResultsJson) subclass is too entangled with the orjson feature to be able to be extracted easily.

Fixes #2784

