### PR TITLE
Add initial implementation of RDF Patch parser.

### DIFF
--- a/docs/plugin_parsers.rst
+++ b/docs/plugin_parsers.rst
@@ -24,7 +24,7 @@ json-ld   :class:`~rdflib.plugins.parsers.jsonld.JsonLDParser`
 hext      :class:`~rdflib.plugins.parsers.hext.HextuplesParser`
 n3        :class:`~rdflib.plugins.parsers.notation3.N3Parser`
 nquads    :class:`~rdflib.plugins.parsers.nquads.NQuadsParser`
-patch     :class:`~rdflib.plugins.parsers.patch.PatchParser`
+patch     :class:`~rdflib.plugins.parsers.patch.RDFPatchParser`
 nt        :class:`~rdflib.plugins.parsers.ntriples.NTParser`
 trix      :class:`~rdflib.plugins.parsers.trix.TriXParser`
 turtle    :class:`~rdflib.plugins.parsers.notation3.TurtleParser`

--- a/docs/plugin_parsers.rst
+++ b/docs/plugin_parsers.rst
@@ -24,6 +24,7 @@ json-ld   :class:`~rdflib.plugins.parsers.jsonld.JsonLDParser`
 hext      :class:`~rdflib.plugins.parsers.hext.HextuplesParser`
 n3        :class:`~rdflib.plugins.parsers.notation3.N3Parser`
 nquads    :class:`~rdflib.plugins.parsers.nquads.NQuadsParser`
+patch     :class:`~rdflib.plugins.parsers.patch.PatchParser`
 nt        :class:`~rdflib.plugins.parsers.ntriples.NTParser`
 trix      :class:`~rdflib.plugins.parsers.trix.TriXParser`
 turtle    :class:`~rdflib.plugins.parsers.notation3.TurtleParser`

--- a/examples/parse_patch.py
+++ b/examples/parse_patch.py
@@ -19,11 +19,11 @@ ds = Dataset()
 # Apply add patch
 ds.parse(data=add_patch, format="patch")
 print("After add patch:")
-for triple in ds.de_skolemize():
+for triple in ds:
     print(triple)
 
 # Apply delete patch
 ds.parse(data=delete_patch, format="patch")
 print("After delete patch:")
-for triple in ds.de_skolemize():
+for triple in ds:
     print(triple)

--- a/examples/parse_patch.py
+++ b/examples/parse_patch.py
@@ -1,0 +1,29 @@
+from rdflib import Dataset
+
+# RDF patch data
+add_patch = """
+TX .
+A _:bn1 <http://example.org/predicate1> "object1" .
+A _:bn1 <http://example.org/predicate2> "object2" .
+TC .
+"""
+
+delete_patch = """
+TX .
+D _:bn1 <http://example.org/predicate1> "object1" .
+TC .
+"""
+
+ds = Dataset()
+
+# Apply add patch
+ds.parse(data=add_patch, format="patch")
+print("After add patch:")
+for triple in ds.de_skolemize():
+    print(triple)
+
+# Apply delete patch
+ds.parse(data=delete_patch, format="patch")
+print("After delete patch:")
+for triple in ds.de_skolemize():
+    print(triple)

--- a/examples/parse_patch.py
+++ b/examples/parse_patch.py
@@ -1,29 +1,35 @@
 from rdflib import Dataset
 
-# RDF patch data
-add_patch = """
-TX .
-A _:bn1 <http://example.org/predicate1> "object1" .
-A _:bn1 <http://example.org/predicate2> "object2" .
-TC .
-"""
 
-delete_patch = """
-TX .
-D _:bn1 <http://example.org/predicate1> "object1" .
-TC .
-"""
+def main():
+    # RDF patch data
+    add_patch = """
+    TX .
+    A _:bn1 <http://example.org/predicate1> "object1" .
+    A _:bn1 <http://example.org/predicate2> "object2" .
+    TC .
+    """
 
-ds = Dataset()
+    delete_patch = """
+    TX .
+    D _:bn1 <http://example.org/predicate1> "object1" .
+    TC .
+    """
 
-# Apply add patch
-ds.parse(data=add_patch, format="patch")
-print("After add patch:")
-for triple in ds:
-    print(triple)
+    ds = Dataset()
 
-# Apply delete patch
-ds.parse(data=delete_patch, format="patch")
-print("After delete patch:")
-for triple in ds:
-    print(triple)
+    # Apply add patch
+    ds.parse(data=add_patch, format="patch")
+    print("After add patch:")
+    for triple in ds:
+        print(triple)
+
+    # Apply delete patch
+    ds.parse(data=delete_patch, format="patch")
+    print("After delete patch:")
+    for triple in ds:
+        print(triple)
+
+
+if __name__ == "__main__":
+    main()

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -488,6 +488,14 @@ register(
     "HextuplesParser",
 )
 
+# Register RDF Patch Parsers
+register(
+    "patch",
+    Parser,
+    "rdflib.plugins.parsers.patch",
+    "RDFPatchParser",
+)
+
 # Register SPARQL Processors
 register(
     "sparql",

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -13,12 +13,25 @@ from rdflib.plugins.parsers.nquads import NQuadsParser
 from rdflib.plugins.parsers.ntriples import r_wspace
 from rdflib.term import BNode
 
-__all__ = ["RDFPatchParser"]
+__all__ = ["RDFPatchParser", "Operation"]
 
 _BNodeContextType = MutableMapping[str, BNode]
 
 
 class Operation(Enum):
+    """
+    Enum of RDF Patch operations.
+
+    Operations:
+    - `AddTripleOrQuad` (A): Adds a triple or quad.
+    - `DeleteTripleOrQuad` (D): Deletes a triple or quad.
+    - `AddPrefix` (PA): Adds a prefix.
+    - `DeletePrefix` (PD): Deletes a prefix.
+    - `TransactionStart` (TX): Starts a transaction.
+    - `TransactionCommit` (TC): Commits a transaction.
+    - `TransactionAbort` (TA): Aborts a transaction.
+    - `Header` (H): Specifies a header.
+    """
     AddTripleOrQuad = "A"
     DeleteTripleOrQuad = "D"
     AddPrefix = "PA"

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -8,6 +8,7 @@ from rdflib.exceptions import ParserError as ParseError
 from rdflib.graph import Dataset
 from rdflib.parser import InputSource
 from rdflib.plugins.parsers.nquads import NQuadsParser
+
 # Build up from the NTriples parser:
 from rdflib.plugins.parsers.ntriples import r_wspace
 from rdflib.term import BNode
@@ -18,14 +19,14 @@ _BNodeContextType = MutableMapping[str, BNode]
 
 
 class Operation(Enum):
-    AddTripleOrQuad = 'A'
-    DeleteTripleOrQuad = 'D'
-    AddPrefix = 'PA'
-    DeletePrefix = 'PD'
-    TransactionStart = 'TX'
-    TransactionCommit = 'TC'
-    TransactionAbort = 'TA'
-    Header = 'H'
+    AddTripleOrQuad = "A"
+    DeleteTripleOrQuad = "D"
+    AddPrefix = "PA"
+    DeletePrefix = "PD"
+    TransactionStart = "TX"
+    TransactionCommit = "TC"
+    TransactionAbort = "TA"
+    Header = "H"
 
 
 class RDFPatchParser(NQuadsParser):
@@ -42,7 +43,7 @@ class RDFPatchParser(NQuadsParser):
 
         :type inputsource: `rdflib.parser.InputSource`
         :param inputsource: the source of RDF Patch formatted data
-        :type sink: `rdflib.graph.Graph`
+        :type sink: `rdflib.graph.Dataset`
         :param sink: where to send parsed data
         :type bnode_context: `dict`, optional
         :param bnode_context: a dict mapping blank node identifiers to `~rdflib.term.BNode` instances.
@@ -52,9 +53,7 @@ class RDFPatchParser(NQuadsParser):
             "RDFPatchParser must be given" " a context aware store."
         )
         # type error: Incompatible types in assignment (expression has type "ConjunctiveGraph", base class "W3CNTriplesParser" defined the type as "Union[DummySink, NTGraphSink]")
-        self.sink: Dataset = Dataset(  # type: ignore[assignment]
-            store=sink.store
-        )
+        self.sink: Dataset = Dataset(store=sink.store)  # type: ignore[assignment]
         self.skolemize = skolemize
 
         source = inputsource.getCharacterStream()
@@ -105,11 +104,11 @@ class RDFPatchParser(NQuadsParser):
             self.delete_prefix()
 
     def add_triple_or_quad(self):
-        self.sink.parse(data=self.line, format='nquads', skolemize=True)
+        self.sink.parse(data=self.line, format="nquads", skolemize=True)
 
     def delete_triple_or_quad(self):
         removal_ds = Dataset()
-        removal_ds.parse(data=self.line, format='nquads', skolemize=True)
+        removal_ds.parse(data=self.line, format="nquads", skolemize=True)
         triple_or_quad = next(iter(removal_ds))
         self.sink.remove(triple_or_quad)
 
@@ -129,8 +128,9 @@ class RDFPatchParser(NQuadsParser):
                 self.eat_op(op.value)
                 return op
         raise ValueError(
-            f"Invalid or no Operation found in line: \"{self.line}\". Valid Operations "
-            f"codes are {', '.join([op.value for op in Operation])}")
+            f'Invalid or no Operation found in line: "{self.line}". Valid Operations '
+            f"codes are {', '.join([op.value for op in Operation])}"
+        )
 
     def eat_op(self, op: str) -> None:
         self.line = self.line.lstrip(op)

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -178,6 +178,6 @@ class RDFPatchParser(NQuadsParser):
     def labeled_bnode(self):
         if self.peek("<_"):
             plain_uri = self.eat(r_uriref).group(1)
-            bnode_id = r_nodeid.match(plain_uri).group(1)
+            bnode_id = r_nodeid.match(plain_uri).group(1)  # type: ignore[union-attr]
             return BNode(bnode_id)
         return False

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -70,7 +70,7 @@ class RDFPatchParser(NQuadsParser):
             "RDFPatchParser must be given" " a context aware store."
         )
         # type error: Incompatible types in assignment (expression has type "ConjunctiveGraph", base class "W3CNTriplesParser" defined the type as "Union[DummySink, NTGraphSink]")
-        self.sink: Dataset = Dataset(store=sink.store)  # type: ignore[assignment]
+        self.sink: Dataset = Dataset(store=sink.store)
         self.skolemize = skolemize
 
         source = inputsource.getCharacterStream()

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from codecs import getreader
+from enum import Enum
+from typing import Any, MutableMapping, Optional
+
+from rdflib.exceptions import ParserError as ParseError
+from rdflib.graph import Dataset
+from rdflib.parser import InputSource
+from rdflib.plugins.parsers.nquads import NQuadsParser
+# Build up from the NTriples parser:
+from rdflib.plugins.parsers.ntriples import r_wspace
+from rdflib.term import BNode
+
+__all__ = ["RDFPatchParser"]
+
+_BNodeContextType = MutableMapping[str, BNode]
+
+
+class Operation(Enum):
+    AddTripleOrQuad = 'A'
+    DeleteTripleOrQuad = 'D'
+    AddPrefix = 'PA'
+    DeletePrefix = 'PD'
+    TransactionStart = 'TX'
+    TransactionCommit = 'TC'
+    TransactionAbort = 'TA'
+    Header = 'H'
+
+
+class RDFPatchParser(NQuadsParser):
+    def parse(  # type: ignore[override]
+        self,
+        inputsource: InputSource,
+        sink: Dataset,
+        bnode_context: Optional[_BNodeContextType] = None,
+        skolemize: bool = False,
+        **kwargs: Any,
+    ) -> Dataset:
+        """
+        Parse inputsource as an RDF Patch file.
+
+        :type inputsource: `rdflib.parser.InputSource`
+        :param inputsource: the source of RDF Patch formatted data
+        :type sink: `rdflib.graph.Graph`
+        :param sink: where to send parsed data
+        :type bnode_context: `dict`, optional
+        :param bnode_context: a dict mapping blank node identifiers to `~rdflib.term.BNode` instances.
+                              See `.W3CNTriplesParser.parse`
+        """
+        assert sink.store.context_aware, (
+            "RDFPatchParser must be given" " a context aware store."
+        )
+        # type error: Incompatible types in assignment (expression has type "ConjunctiveGraph", base class "W3CNTriplesParser" defined the type as "Union[DummySink, NTGraphSink]")
+        self.sink: Dataset = Dataset(  # type: ignore[assignment]
+            store=sink.store
+        )
+        self.skolemize = skolemize
+
+        source = inputsource.getCharacterStream()
+        if not source:
+            source = inputsource.getByteStream()
+            source = getreader("utf-8")(source)
+
+        if not hasattr(source, "read"):
+            raise ParseError("Item to parse must be a file-like object.")
+
+        self.file = source
+        self.buffer = ""
+        while True:
+            self.line = __line = self.readline()
+            if self.line is None:
+                break
+            try:
+                self.parsepatch(bnode_context)
+            except ParseError as msg:
+                raise ParseError("Invalid line (%s):\n%r" % (msg, __line))
+
+        if self.skolemize:
+            return self.sink
+        else:
+            self.sink = self.sink.de_skolemize()
+            return self.sink  # Dataset is skolemized as part of adding/removing triples
+            # , so de skolemize before returning. NB this is broken by the parent class
+            # (ConjunctiveGraph) which re-skolemizes the dataset.
+
+    def parsepatch(self, bnode_context: Optional[_BNodeContextType] = None) -> None:
+        self.eat(r_wspace)
+        #  From spec: "No comments should be included (comments start # and run to end
+        #  of line)."
+        if (not self.line) or self.line.startswith("#"):
+            return  # The line is empty or a comment
+
+        # if header, transaction, skip
+        operation = self.operation()
+        self.eat(r_wspace)
+
+        if operation == Operation.AddTripleOrQuad:
+            self.add_triple_or_quad()
+        elif operation == Operation.DeleteTripleOrQuad:
+            self.delete_triple_or_quad()
+        elif operation == Operation.AddPrefix:
+            self.add_prefix()
+        elif operation == Operation.DeletePrefix:
+            self.delete_prefix()
+
+    def add_triple_or_quad(self):
+        self.sink.parse(data=self.line, format='nquads', skolemize=True)
+
+    def delete_triple_or_quad(self):
+        removal_ds = Dataset()
+        removal_ds.parse(data=self.line, format='nquads', skolemize=True)
+        triple_or_quad = next(iter(removal_ds))
+        self.sink.remove(triple_or_quad)
+
+    def add_prefix(self):
+        # Extract prefix and URI from the line
+        prefix, ns, _ = self.line.replace('"', "").replace("'", "").split(" ")
+        ns_stripped = ns.strip("<>")
+        self.sink.bind(prefix, ns_stripped)
+
+    def delete_prefix(self):
+        prefix, _, _ = self.line.replace('"', "").replace("'", "").split(" ")
+        self.sink.namespace_manager.bind(prefix, None, replace=True)
+
+    def operation(self) -> Operation:
+        for op in Operation:
+            if self.line.startswith(op.value):
+                self.eat_op(op.value)
+                return op
+        raise ValueError(
+            f"Invalid or no Operation found in line: \"{self.line}\". Valid Operations "
+            f"codes are {', '.join([op.value for op in Operation])}")
+
+    def eat_op(self, op: str) -> None:
+        self.line = self.line.lstrip(op)

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -177,6 +177,7 @@ class RDFPatchParser(NQuadsParser):
 
     def labeled_bnode(self):
         if self.peek("<_"):
-            plain_uri = self.eat(r_uriref).group(1)  # type: ignore[union-attr]
+            plain_uri = self.eat(r_uriref).group(1)
             bnode_id = r_nodeid.match(plain_uri).group(1)
             return BNode(bnode_id)
+        return False

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -147,17 +147,17 @@ class RDFPatchParser(NQuadsParser):
 
     def add_prefix(self):
         # Extract prefix and URI from the line
-        prefix, ns, _ = self.line.replace('"', "").replace("'", "").split(" ")
+        prefix, ns, _ = self.line.replace('"', "").replace("'", "").split(" ")  # type: ignore[union-attr]
         ns_stripped = ns.strip("<>")
         self.sink.bind(prefix, ns_stripped)
 
     def delete_prefix(self):
-        prefix, _, _ = self.line.replace('"', "").replace("'", "").split(" ")
+        prefix, _, _ = self.line.replace('"', "").replace("'", "").split(" ")  # type: ignore[union-attr]
         self.sink.namespace_manager.bind(prefix, None, replace=True)
 
     def operation(self) -> Operation:
         for op in Operation:
-            if self.line.startswith(op.value):
+            if self.line.startswith(op.value):  # type: ignore[union-attr]
                 self.eat_op(op.value)
                 return op
         raise ValueError(
@@ -166,16 +166,17 @@ class RDFPatchParser(NQuadsParser):
         )
 
     def eat_op(self, op: str) -> None:
-        self.line = self.line.lstrip(op)
+        self.line = self.line.lstrip(op)  # type: ignore[union-attr]
 
     def nodeid(
         self, bnode_context: Optional[_BNodeContextType] = None
     ) -> Union[te.Literal[False], BNode, URIRef]:
         if self.peek("_"):
             return BNode(self.eat(r_nodeid).group(1))
+        return False
 
     def labeled_bnode(self):
         if self.peek("<_"):
-            plain_uri = self.eat(r_uriref).group(1)
+            plain_uri = self.eat(r_uriref).group(1)  # type: ignore[union-attr]
             bnode_id = r_nodeid.match(plain_uri).group(1)
             return BNode(bnode_id)

--- a/rdflib/plugins/parsers/patch.py
+++ b/rdflib/plugins/parsers/patch.py
@@ -32,6 +32,7 @@ class Operation(Enum):
     - `TransactionAbort` (TA): Aborts a transaction.
     - `Header` (H): Specifies a header.
     """
+
     AddTripleOrQuad = "A"
     DeleteTripleOrQuad = "D"
     AddPrefix = "PA"

--- a/test/data/patch/add_and_delete_bnode_triples.rdp
+++ b/test/data/patch/add_and_delete_bnode_triples.rdp
@@ -1,0 +1,6 @@
+TX .
+A _:bn1 <http://example.org/predicate1> "object1" <http://example.org/graph1> .
+A _:bn1 <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+A _:bn1 <http://example.org/predicate3> "object3" <http://example.org/graph1> .
+D _:bn1 <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+TC .

--- a/test/data/patch/add_and_delete_labeled_bnode_quads.rdp
+++ b/test/data/patch/add_and_delete_labeled_bnode_quads.rdp
@@ -1,0 +1,6 @@
+TX .
+A <_:bn1> <http://example.org/predicate1> "object1" <http://example.org/graph1> .
+A <_:bn1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+A <_:bn1> <http://example.org/predicate3> "object3" <http://example.org/graph1> .
+D <_:bn1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+TC .

--- a/test/data/patch/add_and_delete_prefix.rdp
+++ b/test/data/patch/add_and_delete_prefix.rdp
@@ -1,0 +1,6 @@
+TX .
+PA present <http://some-other-ns#> .
+PA removed <http://ns-for-prefix-to-remove#> .
+PD removed <http://ns-for-prefix-to-remove#> .
+A <http://ns-for-prefix-to-remove#test-subj> <http://ns-for-prefix-to-remove#test-pred> "object1" .
+TC .

--- a/test/data/patch/add_and_delete_triples.rdp
+++ b/test/data/patch/add_and_delete_triples.rdp
@@ -1,0 +1,6 @@
+TX .
+A <http://example.org/subject1> <http://example.org/predicate1> "object1" .
+A <http://example.org/subject1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+D <http://example.org/subject1> <http://example.org/predicate1> "object1" .
+D <http://example.org/subject1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+TC .

--- a/test/data/patch/add_bnode_graph.rdp
+++ b/test/data/patch/add_bnode_graph.rdp
@@ -1,0 +1,3 @@
+TX .
+A _:bn1 <http://example.org/predicate1> "object1" _:bn1 .
+TC .

--- a/test/data/patch/add_bnode_quad.rdp
+++ b/test/data/patch/add_bnode_quad.rdp
@@ -1,0 +1,3 @@
+TX .
+A _:bn1 <http://example.org/predicate1> "object1" <https://graph-1> .
+TC .

--- a/test/data/patch/add_bnode_triple.rdp
+++ b/test/data/patch/add_bnode_triple.rdp
@@ -1,0 +1,3 @@
+TX .
+A _:bn1 <http://example.org/predicate1> "object1" .
+TC .

--- a/test/data/patch/add_bnode_uri.rdp
+++ b/test/data/patch/add_bnode_uri.rdp
@@ -1,0 +1,3 @@
+TX .
+A <_:bn1> <http://example.org/predicate1> "object1" .
+TC .

--- a/test/data/patch/add_delete_bnode.rdp
+++ b/test/data/patch/add_delete_bnode.rdp
@@ -1,0 +1,4 @@
+TX .
+A _:bn2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/object2> .
+D _:bn2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/object2> .
+TC .

--- a/test/data/patch/add_prefix.rdp
+++ b/test/data/patch/add_prefix.rdp
@@ -1,0 +1,3 @@
+TX .
+PA testing <http://example.org/> .
+TC .

--- a/test/data/patch/add_triple_and_quad.rdp
+++ b/test/data/patch/add_triple_and_quad.rdp
@@ -1,0 +1,4 @@
+TX .
+A <http://example.org/subject1> <http://example.org/predicate1> "object1" .
+A <http://example.org/subject1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+TC .

--- a/test/data/patch/delete_bnode_graph.rdp
+++ b/test/data/patch/delete_bnode_graph.rdp
@@ -1,0 +1,3 @@
+TX .
+D _:bn1 <http://example.org/predicate1> "object1" _:bn1 .
+TC .

--- a/test/data/patch/delete_bnode_quad.rdp
+++ b/test/data/patch/delete_bnode_quad.rdp
@@ -1,0 +1,3 @@
+TX .
+D _:bn1 <http://example.org/predicate1> "object1" <https://graph-1> .
+TC .

--- a/test/data/patch/delete_bnode_triple.rdp
+++ b/test/data/patch/delete_bnode_triple.rdp
@@ -1,0 +1,3 @@
+TX .
+D _:bn1 <http://example.org/predicate1> "object1" .
+TC .

--- a/test/data/patch/delete_bnode_uri.rdp
+++ b/test/data/patch/delete_bnode_uri.rdp
@@ -1,0 +1,3 @@
+TX .
+D <_:bn1> <http://example.org/predicate1> "object1" .
+TC .

--- a/test/test_parsers/test_parser_patch.py
+++ b/test/test_parsers/test_parser_patch.py
@@ -23,7 +23,7 @@ class TestPatchParser:
         ds = Dataset()
         nq_path = os.path.relpath(
             os.path.join(TEST_DATA_DIR, "patch/add_and_delete_bnode_triples.rdp"),
-            os.curdir
+            os.curdir,
         )
         with open(nq_path, "rb") as data:
             ds.parse(data, format="patch")
@@ -59,7 +59,9 @@ class TestPatchParser:
             ds.parse(data, format="patch")
         namespaces = [tup[0] for tup in (ds.namespaces())]
         assert "present" in namespaces
-        assert "@prefix removed: <http://ns-for-prefix-to-remove#> ." not in ds.serialize()
+        assert (
+            "@prefix removed: <http://ns-for-prefix-to-remove#> ." not in ds.serialize()
+        )
 
     def test_06(self):
         ds = Dataset()
@@ -87,8 +89,9 @@ class TestPatchParser:
         # test will pass if changed to `for t in ds.de_skolemize():`:
         for t in ds:
             assert BNode("bn1") in t
-            assert URIRef(
-                'https://rdflib.github.io/.well-known/genid/rdflib/bn1') not in t
+            assert (
+                URIRef("https://rdflib.github.io/.well-known/genid/rdflib/bn1") not in t
+            )
 
     def test_08(self):
         ds = Dataset()

--- a/test/test_parsers/test_parser_patch.py
+++ b/test/test_parsers/test_parser_patch.py
@@ -17,7 +17,6 @@ class TestPatchParser:
         with open(nq_path, "rb") as data:
             ds.parse(data, format="patch")
         assert len(ds) == 2
-        return ds
 
     def test_02(self):
         ds = Dataset()
@@ -28,7 +27,6 @@ class TestPatchParser:
         with open(nq_path, "rb") as data:
             ds.parse(data, format="patch")
         assert len(ds) == 2
-        return ds
 
     def test_03(self):
         ds = Dataset()
@@ -38,7 +36,6 @@ class TestPatchParser:
         with open(nq_path, "rb") as data:
             ds.parse(data, format="patch")
         assert len(ds) == 0
-        return ds
 
     def test_04(self):
         ds = Dataset()
@@ -147,4 +144,3 @@ class TestPatchParser:
         with open(nq_path, "rb") as data:
             ds.parse(data, format="patch")
         assert len(ds) == 2
-        return ds

--- a/test/test_parsers/test_parser_patch.py
+++ b/test/test_parsers/test_parser_patch.py
@@ -1,0 +1,136 @@
+import os
+
+import pytest
+
+from rdflib import Dataset, BNode, URIRef
+from test.data import TEST_DATA_DIR
+
+TEST_BASE = os.path.join(TEST_DATA_DIR, "patch")
+
+
+class TestPatchParser:
+    def test_01(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_triple_and_quad.rdp"), os.curdir
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 2
+        return ds
+
+    def test_02(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_and_delete_bnode_triples.rdp"),
+            os.curdir
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 2
+        return ds
+
+    def test_03(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_and_delete_triples.rdp"), os.curdir
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 0
+        return ds
+
+    def test_04(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_prefix.rdp"), os.curdir
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        namespaces = [tup[0] for tup in (ds.namespaces())]
+        assert "testing" in namespaces
+
+    def test_05(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_and_delete_prefix.rdp"), os.curdir
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        namespaces = [tup[0] for tup in (ds.namespaces())]
+        assert "present" in namespaces
+        assert "@prefix removed: <http://ns-for-prefix-to-remove#> ." not in ds.serialize()
+
+    def test_06(self):
+        ds = Dataset()
+        add_bnode_triple_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_bnode_triple.rdp"), os.curdir
+        )
+        with open(add_bnode_triple_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 1
+        delete_bnode_triple_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/delete_bnode_triple.rdp"), os.curdir
+        )
+        with open(delete_bnode_triple_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 0
+
+    @pytest.mark.xfail(reason="De skolemization is undone by ConjunctiveGraph")
+    def test_07(self):
+        ds = Dataset()
+        add_bnode_triple_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_bnode_triple.rdp"), os.curdir
+        )
+        with open(add_bnode_triple_path, "rb") as data:
+            ds.parse(data, format="patch")
+        # test will pass if changed to `for t in ds.de_skolemize():`:
+        for t in ds:
+            assert BNode("bn1") in t
+            assert URIRef(
+                'https://rdflib.github.io/.well-known/genid/rdflib/bn1') not in t
+
+    def test_08(self):
+        ds = Dataset()
+        add_bnode_quad_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_bnode_quad.rdp"), os.curdir
+        )
+        with open(add_bnode_quad_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 1
+        delete_bnode_quad_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/delete_bnode_quad.rdp"), os.curdir
+        )
+        with open(delete_bnode_quad_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 0
+
+    def test_09(self):
+        ds = Dataset()
+        add_bnode_graph_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_bnode_graph.rdp"), os.curdir
+        )
+        with open(add_bnode_graph_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 1
+        delete_bnode_graph_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/delete_bnode_graph.rdp"), os.curdir
+        )
+        with open(delete_bnode_graph_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 0
+
+    def test_10(self):
+        ds = Dataset()
+        add_bnode_uri_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_bnode_uri.rdp"), os.curdir
+        )
+        with open(add_bnode_uri_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 1
+        delete_bnode_uri_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/delete_bnode_uri.rdp"), os.curdir
+        )
+        with open(delete_bnode_uri_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 0

--- a/test/test_parsers/test_parser_patch.py
+++ b/test/test_parsers/test_parser_patch.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from rdflib import Dataset, BNode, URIRef
+from rdflib import BNode, Dataset, URIRef
 from test.data import TEST_DATA_DIR
 
 TEST_BASE = os.path.join(TEST_DATA_DIR, "patch")

--- a/test/test_parsers/test_parser_patch.py
+++ b/test/test_parsers/test_parser_patch.py
@@ -137,3 +137,14 @@ class TestPatchParser:
         with open(delete_bnode_uri_path, "rb") as data:
             ds.parse(data, format="patch")
         assert len(ds) == 0
+
+    def test_11(self):
+        ds = Dataset()
+        nq_path = os.path.relpath(
+            os.path.join(TEST_DATA_DIR, "patch/add_and_delete_labeled_bnode_quads.rdp"),
+            os.curdir,
+        )
+        with open(nq_path, "rb") as data:
+            ds.parse(data, format="patch")
+        assert len(ds) == 2
+        return ds


### PR DESCRIPTION
# Summary of changes

Introduces support for parsing RDF Patch files, aligned to the specification here: https://afs.github.io/rdf-delta/rdf-patch.html

Supports:
- Adding and Deleting triples and quads from a Dataset.
- Adding and Deleting prefixes from a Dataset.
- blank node ID preservation from input documents. That is, blank nodes are NOT document scoped when parsing patches.
blank nodes can be specified either using the format:
  - `_:identifier`
  - `<_:identifier>`
both will be parsed as blank nodes and their identifier from the document they are parsed from preserved.

Known limitations:
- No support yet for Patch logs (a series of Patch files)

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  - [x] ~Created an issue to discuss the change and get in-principle agreement.~ Discussed with a number of maintainers
TODO:
  - [x] Considered adding an example in `./examples`.
  - [x] Considered adding additional documentation.

