### PR TITLE
Change some more internal usages of ConjunctiveGraph to Dataset to silence warnings

### DIFF
--- a/rdflib/plugins/parsers/nquads.py
+++ b/rdflib/plugins/parsers/nquads.py
@@ -29,7 +29,7 @@ from codecs import getreader
 from typing import Any, MutableMapping, Optional
 
 from rdflib.exceptions import ParserError as ParseError
-from rdflib.graph import ConjunctiveGraph
+from rdflib.graph import ConjunctiveGraph, Dataset, Graph
 from rdflib.parser import InputSource
 
 # Build up from the NTriples parser:
@@ -42,15 +42,16 @@ _BNodeContextType = MutableMapping[str, BNode]
 
 
 class NQuadsParser(W3CNTriplesParser):
+
     # type error: Signature of "parse" incompatible with supertype "W3CNTriplesParser"
     def parse(  # type: ignore[override]
         self,
         inputsource: InputSource,
-        sink: ConjunctiveGraph,
+        sink: Graph,
         bnode_context: Optional[_BNodeContextType] = None,
         skolemize: bool = False,
         **kwargs: Any,
-    ) -> ConjunctiveGraph:
+    ):
         """
         Parse inputsource as an N-Quads file.
 
@@ -62,13 +63,26 @@ class NQuadsParser(W3CNTriplesParser):
         :param bnode_context: a dict mapping blank node identifiers to `~rdflib.term.BNode` instances.
                               See `.W3CNTriplesParser.parse`
         """
-        assert sink.store.context_aware, (
-            "NQuadsParser must be given" " a context aware store."
-        )
+        assert (
+            sink.store.context_aware
+        ), "NQuadsParser must be given a context-aware store."
+        # Set default_union to True to mimic ConjunctiveGraph behavior
+        ds = Dataset(store=sink.store, default_union=True)
+        ds_default = ds.default_context  # the DEFAULT_DATASET_GRAPH_ID
+        new_default_context = None
+        if isinstance(sink, (Dataset, ConjunctiveGraph)):
+            new_default_context = sink.default_context
+        elif sink.identifier is not None:
+            if sink.identifier == ds_default.identifier:
+                new_default_context = sink
+            else:
+                new_default_context = ds.get_context(sink.identifier)
+
+        if new_default_context is not None:
+            ds.default_context = new_default_context
+            ds.remove_graph(ds_default)  # remove the original unused default graph
         # type error: Incompatible types in assignment (expression has type "ConjunctiveGraph", base class "W3CNTriplesParser" defined the type as "Union[DummySink, NTGraphSink]")
-        self.sink: ConjunctiveGraph = ConjunctiveGraph(  # type: ignore[assignment]
-            store=sink.store, identifier=sink.identifier
-        )
+        self.sink: Dataset = ds  # type: ignore[assignment]
         self.skolemize = skolemize
 
         source = inputsource.getCharacterStream()
@@ -106,11 +120,14 @@ class NQuadsParser(W3CNTriplesParser):
         obj = self.object(bnode_context)
         self.eat(r_wspace)
 
-        context = self.uriref() or self.nodeid(bnode_context) or self.sink.identifier
+        context = self.uriref() or self.nodeid(bnode_context)
         self.eat(r_tail)
 
         if self.line:
             raise ParseError("Trailing garbage")
         # Must have a context aware store - add on a normal Graph
         # discards anything where the ctx != graph.identifier
-        self.sink.get_context(context).add((subject, predicate, obj))
+        if context:
+            self.sink.get_context(context).add((subject, predicate, obj))
+        else:
+            self.sink.default_context.add((subject, predicate, obj))


### PR DESCRIPTION
This was originally a very simple patch to change the use of `ConjuctiveGraph` to `Dataset` in the hextuples and nquads graph parsers. 

The motivation was to silence the deprecation warnings that are emitted when simply parsing a nquads file or hextuples file, even if you were not personally using a ConjunctiveGraph, the warnings were being emitted for the use of `ConjunctiveGraph` within the parsers.

One of the key differences between ConjuctiveGraph and Dataset is how the `default_graph` works. When creating a new  `ConjunctiveGraph` (`cg`), you can pass an `identifier` that becomes `cg.identifier` and also becomes the identifier of the default_graph. It uses a BNode as the identifier for the default graph if you don't pass one. A named graph with BNode as identifier is actually considered an "unnamed graph".

On the other hand, you cannot pass an `identifier` to a `Dataset`. The Dataset's internal identifier is _always_ a new BNode, (that isn't even used for anything_. The identifier of `ds.default_graph` is the constant `DATASET_DEFAULT_GRAPH_ID` (`"urn:x-rdflib:default"`). So the difference is ConjunctiveGraph by default has an Unnamed graph as its default_graph, and Dataset has a Named Graph (with a URI) as its default_graph.

Changing `ConjunctiveGraph` to `Dataset` in the Hextuples and NQuads parsers inadvertently exposed an underlying existing bug in both parsers. If the destination graph (aka, the "sink") already had a Named default_graph assigned (like in the case of every Dataset), the parser would ignore that and parse into a _new_ default_graph, causing one extra graph in the resulting dataset than you were expecting. That was fixed in this PR.

Another key difference between ConjuctiveGraph and Dataset is that `ConjunctiveGraph` always sets `default_union` to False unless you force it True, but `Dataset` is easily selectable, with the default `False`.
So for compatibility sake, we set `default_union` to True on the usage of Dataset in these two parsers.

Finally, after those changes were made I started getting failing tests in the seemingly unrelated JSON-LD Serializer. This was caused by the change of nquads to use `Dataset` in the parser. Specifically, it was an "Unnamed default-graph" vs "Named default-graph" issue. There was an existing bug in the JSON-LD serializer that treated all named-graphs as "non-default" graphs, where it wraps them in a `@graph{}` wrapper and adds an `@id` with the named-graph identifier. All "Unnamed" graphs were treated as "default-graph" and were added to the top-level context in the JSON-LD file. The problem is it was treating the Dataset named graph with name `DATASET_DEFAULT_GRAPH_ID` as a "non-default" graph because it has a URI as its identifier. This was triggering a lot of JSON-LD serializer tests to fail because the expected output was different.

So this PR fixes that issue in the JSON-LD serializer too, so it now treats Dataset default_graph as an un-named graph.
Note, this is directly related to https://github.com/RDFLib/rdflib/issues/2445 which still needs to be fixed.