### PR TITLE
Fix missing features of IdentifiedNode

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -257,8 +257,13 @@ class IdentifiedNode(Identifier):
     The name "Identified Node" is not explicitly defined in the RDF specification, but can be drawn from this section: https://www.w3.org/TR/rdf-concepts/#section-URI-Vocabulary
     """
 
+    __slots__ = ()
+
     def __getnewargs__(self) -> Tuple[str]:
         return (str(self),)
+
+    def n3(self, namespace_manager: Optional[NamespaceManager] = None) -> str:
+        raise NotImplementedError()
 
     def toPython(self) -> str:  # noqa: N802
         return str(self)

--- a/test/utils/dawg_manifest.py
+++ b/test/utils/dawg_manifest.py
@@ -48,12 +48,12 @@ class ManifestEntry:
     result_cardinality: Optional[URIRef] = field(init=False)
 
     def __post_init__(self) -> None:
-        type = self.value(RDF.type, IdentifiedNode)  # type: ignore[type-abstract]
+        type = self.value(RDF.type, IdentifiedNode)
         assert type is not None
         self.type = type
 
-        self.action = self.value(MF.action, IdentifiedNode)  # type: ignore[type-abstract]
-        self.result = self.value(MF.result, IdentifiedNode)  # type: ignore[type-abstract]
+        self.action = self.value(MF.action, IdentifiedNode)
+        self.result = self.value(MF.result, IdentifiedNode)
         self.result_cardinality = self.value(MF.resultCardinality, URIRef)
         if self.result_cardinality is not None:
             assert self.result_cardinality == MF.LaxCardinality


### PR DESCRIPTION
Fix missing features of IdentifiedNode

When PR #1680 was merged to add the IdentifiedNode intermediate class, it was missing the n3() fn that is required by the parent `Node` abstract base class.
And  it missed the `__slots__` directive that is required for a clean \_\_slots\_\_ chain on all classes in the hierarchy from `Literal` up to `Node`.