### PR TITLE
Implement RDF Patch serializer

### DIFF
--- a/docs/plugin_serializers.rst
+++ b/docs/plugin_serializers.rst
@@ -21,6 +21,7 @@ n3         :class:`~rdflib.plugins.serializers.n3.N3Serializer`
 nquads     :class:`~rdflib.plugins.serializers.nquads.NQuadsSerializer`
 nt         :class:`~rdflib.plugins.serializers.nt.NTSerializer`
 hext       :class:`~rdflib.plugins.serializers.hext.HextuplesSerializer`
+patch      :class:`~rdflib.plugins.serializers.patch.PatchSerializer`
 pretty-xml :class:`~rdflib.plugins.serializers.rdfxml.PrettyXMLSerializer`
 trig       :class:`~rdflib.plugins.serializers.trig.TrigSerializer`
 trix       :class:`~rdflib.plugins.serializers.trix.TriXSerializer`
@@ -33,6 +34,11 @@ xml        :class:`~rdflib.plugins.serializers.rdfxml.XMLSerializer`
 JSON-LD
 -------
 JSON-LD - 'json-ld' - has been incorporated into RDFLib since v6.0.0.
+
+RDF Patch
+---------
+
+The RDF Patch Serializer - 'patch' - uses the RDF Patch format defined at https://afs.github.io/rdf-patch/. It supports serializing context aware stores as either addition or deletion patches; and also supports serializing the difference between two context aware stores as a Patch of additions and deletions.
 
 HexTuples
 ---------

--- a/examples/patch_serializer_example.py
+++ b/examples/patch_serializer_example.py
@@ -1,60 +1,64 @@
 from rdflib import Dataset, Graph, Literal, URIRef
 
-# example for adding a quad
-ds = Dataset()
-g = Graph(identifier=URIRef("http://graph-a"))
-ds.add_graph(g)
-triple = (URIRef("http://subj-a"), URIRef("http://pred-a"), Literal("obj-a"))
-ds.get_context(g.identifier).add(triple)
-result = ds.serialize(format="patch", operation="add")
-print("Add Quad Patch:")
-print(result)
 
-# alternate example for adding a quad
-ds = Dataset()
-quad = (
-    URIRef("http://subj-a"),
-    URIRef("http://pred-a"),
-    Literal("obj-a"),
-    Graph(identifier=URIRef("http://graph-a")),
-)
-ds.add(quad)
-result = ds.serialize(format="patch", operation="add")
-print("Add Quad Patch:")
-print(result)
+def main():
+    # example for adding a quad
+    ds = Dataset()
+    g = Graph(identifier=URIRef("http://graph-a"))
+    ds.add_graph(g)
+    triple = (URIRef("http://subj-a"), URIRef("http://pred-a"), Literal("obj-a"))
+    ds.get_context(g.identifier).add(triple)
+    result = ds.serialize(format="patch", operation="add")
+    print("Add Quad Patch:")
+    print(result)
+
+    # alternate example for adding a quad
+    ds = Dataset()
+    quad = (
+        URIRef("http://subj-a"),
+        URIRef("http://pred-a"),
+        Literal("obj-a"),
+        Graph(identifier=URIRef("http://graph-a")),
+    )
+    ds.add(quad)
+    result = ds.serialize(format="patch", operation="add")
+    print("Add Quad Patch:")
+    print(result)
+
+    # example for adding a triple
+    ds = Dataset()
+    ds.add(triple)
+    result = ds.serialize(format="patch", operation="add")
+    print("\nAdd Triple Patch:")
+    print(result)
+
+    # Example for diff quads
+    quad_1 = (
+        URIRef("http://subj-a"),
+        URIRef("http://pred-a"),
+        Literal("obj-a"),
+        Graph(identifier=URIRef("http://graph-a")),
+    )
+    quad_2 = (
+        URIRef("http://subj-b"),
+        URIRef("http://pred-b"),
+        Literal("obj-b"),
+        Graph(identifier=URIRef("http://graph-b")),
+    )
+    quad_3 = (
+        URIRef("http://subj-c"),
+        URIRef("http://pred-c"),
+        Literal("obj-c"),
+        Graph(identifier=URIRef("http://graph-c")),
+    )
+    ds1 = Dataset()
+    ds2 = Dataset()
+    ds1.addN([quad_1, quad_2])
+    ds2.addN([quad_2, quad_3])
+    result = ds1.serialize(format="patch", target=ds2)
+    print("Diff Quad Patch:")
+    print(result)
 
 
-# example for adding a triple
-ds = Dataset()
-ds.add(triple)
-result = ds.serialize(format="patch", operation="add")
-print("\nAdd Triple Patch:")
-print(result)
-
-
-# Example for diff quads
-quad_1 = (
-    URIRef("http://subj-a"),
-    URIRef("http://pred-a"),
-    Literal("obj-a"),
-    Graph(identifier=URIRef("http://graph-a")),
-)
-quad_2 = (
-    URIRef("http://subj-b"),
-    URIRef("http://pred-b"),
-    Literal("obj-b"),
-    Graph(identifier=URIRef("http://graph-b")),
-)
-quad_3 = (
-    URIRef("http://subj-c"),
-    URIRef("http://pred-c"),
-    Literal("obj-c"),
-    Graph(identifier=URIRef("http://graph-c")),
-)
-ds1 = Dataset()
-ds2 = Dataset()
-ds1.addN([quad_1, quad_2])
-ds2.addN([quad_2, quad_3])
-result = ds1.serialize(format="patch", target=ds2)
-print("Diff Quad Patch:")
-print(result)
+if __name__ == "__main__":
+    main()

--- a/examples/patch_serializer_example.py
+++ b/examples/patch_serializer_example.py
@@ -1,0 +1,55 @@
+from rdflib import Dataset, Literal, URIRef
+
+# Example for adding a quad
+ds = Dataset()
+ds.addN([
+    (
+        URIRef("http://subj-a"),
+        URIRef("http://pred-a"),
+        Literal("obj-a"),
+        URIRef("http://graph-a"),
+    )
+])
+result = ds.serialize(format="patch", operation="add")
+print("Add Quad Patch:")
+print(result)
+
+# Example for removing a triple
+ds = Dataset()
+ds.add(
+    (
+        URIRef("http://subj-a"),
+        URIRef("http://pred-a"),
+        Literal("obj-a"),
+    )
+)
+result = ds.serialize(format="patch", operation="remove")
+print("Delete Triple Patch:")
+print(result)
+
+# Example for diff quads
+quad_1 = (
+    URIRef("http://subj-a"),
+    URIRef("http://pred-a"),
+    Literal("obj-a"),
+    URIRef("http://graph-a"),
+)
+quad_2 = (
+    URIRef("http://subj-b"),
+    URIRef("http://pred-b"),
+    Literal("obj-b"),
+    URIRef("http://graph-b"),
+)
+quad_3 = (
+    URIRef("http://subj-c"),
+    URIRef("http://pred-c"),
+    Literal("obj-c"),
+    URIRef("http://graph-c"),
+)
+ds1 = Dataset()
+ds2 = Dataset()
+ds1.addN([quad_1, quad_2])
+ds2.addN([quad_2, quad_3])
+result = ds1.serialize(format="patch", target=ds2)
+print("Diff Quad Patch:")
+print(result)

--- a/examples/patch_serializer_example.py
+++ b/examples/patch_serializer_example.py
@@ -1,50 +1,55 @@
-from rdflib import Dataset, Literal, URIRef
+from rdflib import Dataset, Graph, Literal, URIRef
 
-# Example for adding a quad
+# example for adding a quad
 ds = Dataset()
-ds.add(
-    (
-        URIRef("http://subj-a"),
-        URIRef("http://pred-a"),
-        Literal("obj-a"),
-        URIRef("http://graph-a"),
-    )
-)
+g = Graph(identifier=URIRef("http://graph-a"))
+ds.add_graph(g)
+triple = (URIRef("http://subj-a"), URIRef("http://pred-a"), Literal("obj-a"))
+ds.get_context(g.identifier).add(triple)
 result = ds.serialize(format="patch", operation="add")
 print("Add Quad Patch:")
 print(result)
 
-# Example for removing a triple
+# alternate example for adding a quad
 ds = Dataset()
-ds.add(
-    (
-        URIRef("http://subj-a"),
-        URIRef("http://pred-a"),
-        Literal("obj-a"),
-    )
+quad = (
+    URIRef("http://subj-a"),
+    URIRef("http://pred-a"),
+    Literal("obj-a"),
+    Graph(identifier=URIRef("http://graph-a")),
 )
-result = ds.serialize(format="patch", operation="remove")
-print("Delete Triple Patch:")
+ds.add(quad)
+result = ds.serialize(format="patch", operation="add")
+print("Add Quad Patch:")
 print(result)
+
+
+# example for adding a triple
+ds = Dataset()
+ds.add(triple)
+result = ds.serialize(format="patch", operation="add")
+print("\nAdd Triple Patch:")
+print(result)
+
 
 # Example for diff quads
 quad_1 = (
     URIRef("http://subj-a"),
     URIRef("http://pred-a"),
     Literal("obj-a"),
-    URIRef("http://graph-a"),
+    Graph(identifier=URIRef("http://graph-a")),
 )
 quad_2 = (
     URIRef("http://subj-b"),
     URIRef("http://pred-b"),
     Literal("obj-b"),
-    URIRef("http://graph-b"),
+    Graph(identifier=URIRef("http://graph-b")),
 )
 quad_3 = (
     URIRef("http://subj-c"),
     URIRef("http://pred-c"),
     Literal("obj-c"),
-    URIRef("http://graph-c"),
+    Graph(identifier=URIRef("http://graph-c")),
 )
 ds1 = Dataset()
 ds2 = Dataset()

--- a/examples/patch_serializer_example.py
+++ b/examples/patch_serializer_example.py
@@ -2,14 +2,14 @@ from rdflib import Dataset, Literal, URIRef
 
 # Example for adding a quad
 ds = Dataset()
-ds.addN([
+ds.add(
     (
         URIRef("http://subj-a"),
         URIRef("http://pred-a"),
         Literal("obj-a"),
         URIRef("http://graph-a"),
     )
-])
+)
 result = ds.serialize(format="patch", operation="add")
 print("Add Quad Patch:")
 print(result)

--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -363,6 +363,12 @@ register(
     "rdflib.plugins.serializers.hext",
     "HextuplesSerializer",
 )
+register(
+    "patch",
+    Serializer,
+    "rdflib.plugins.serializers.patch",
+    "PatchSerializer",
+)
 
 # Register Triple Parsers
 register(

--- a/rdflib/plugins/serializers/patch.py
+++ b/rdflib/plugins/serializers/patch.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import warnings
+from typing import IO, Optional
+from uuid import uuid4
+
+from rdflib import Dataset, Graph
+from rdflib.plugins.serializers.nquads import _nq_row
+from rdflib.plugins.serializers.nt import _nt_row
+from rdflib.serializer import Serializer
+
+add_remove_methods = {"add": "A", "remove": "D"}
+
+
+class PatchSerializer(Serializer):
+    """
+    Creates an RDF patch file to add and remove triples/quads.
+    Can either:
+    - Create an add or delete patch for a single Dataset.
+    - Create a patch to represent the difference between two Datasets.
+    """
+
+    def __init__(
+        self,
+        store: Dataset,
+    ):
+        self.store = store
+        super().__init__(store)
+
+    def serialize(
+        self,
+        stream: IO[bytes],
+        base: Optional[str] = None,
+        encoding: Optional[str] = None,
+        operation: Optional[str] = None,
+        target: Optional[Graph] = None,
+        header_id: Optional[str] = None,
+        header_prev: Optional[str] = None,
+    ):
+        if not header_id:
+            header_id = f"uuid:{uuid4()}"
+        encoding = self.encoding
+        if base is not None:
+            warnings.warn("PatchSerializer does not support base.")
+        if encoding is not None and encoding.lower() != self.encoding.lower():
+            warnings.warn(
+                "PatchSerializer does not use custom encoding. "
+                f"Given encoding was: {encoding}"
+            )
+
+        def write_header():
+            stream.write(f"H id <{header_id}> .\n".encode(encoding, "replace"))
+            if header_prev:
+                stream.write(f"H prev <{header_prev}>\n".encode(encoding, "replace"))
+            stream.write("TX .\n".encode(encoding, "replace"))
+
+        def write_triples(contexts, op_code):
+            for context in contexts:
+                context_id = (
+                    None
+                    if context == self.store.default_context
+                    else context.identifier
+                )
+                for triple in context:
+                    stream.write(
+                        _patch_row(triple, context_id, op_code).encode(
+                            encoding, "replace"
+                        )
+                    )
+
+        if operation:
+            assert operation in add_remove_methods, f"Invalid operation: {operation}"
+
+        write_header()
+        if operation:
+            operation_code = add_remove_methods.get(operation)
+            write_triples(self.store.contexts(), operation_code)
+        elif target:
+            to_add, to_remove = self._diff(target)
+            write_triples(to_add.contexts(), "A")
+            write_triples(to_remove.contexts(), "D")
+
+        stream.write("TC .\n".encode(encoding, "replace"))
+
+    def _diff(self, target):
+        rows_to_add = target - self.store
+        rows_to_remove = self.store - target
+        return rows_to_add, rows_to_remove
+
+
+def _patch_row(triple, context_id, operation):
+    if context_id:
+        return f"{operation} {_nq_row(triple, context_id)}"
+    else:
+        return f"{operation} {_nt_row(triple)}"

--- a/rdflib/plugins/serializers/patch.py
+++ b/rdflib/plugins/serializers/patch.py
@@ -34,6 +34,19 @@ class PatchSerializer(Serializer):
         encoding: Optional[str] = None,
         **kwargs,
     ):
+        """
+        Serialize the store to the given stream.
+        :param stream: The stream to serialize to.
+        :param base: The base URI to use for the serialization.
+        :param encoding: The encoding to use for the serialization.
+        :param kwargs: Additional keyword arguments.
+        Supported keyword arguments:
+        - operation: The operation to perform. Either 'add' or 'remove'.
+        - target: The target Dataset to compare against.
+        NB: Only one of 'operation' or 'target' should be provided.
+        - header_id: The header ID to use.
+        - header_prev: The previous header ID to use.
+        """
         operation = kwargs.get("operation")
         target = kwargs.get("target")
         header_id = kwargs.get("header_id")

--- a/rdflib/plugins/serializers/patch.py
+++ b/rdflib/plugins/serializers/patch.py
@@ -4,7 +4,7 @@ import warnings
 from typing import IO, Optional
 from uuid import uuid4
 
-from rdflib import Dataset, Graph
+from rdflib import Dataset
 from rdflib.plugins.serializers.nquads import _nq_row
 from rdflib.plugins.serializers.nt import _nt_row
 from rdflib.serializer import Serializer
@@ -24,7 +24,7 @@ class PatchSerializer(Serializer):
         self,
         store: Dataset,
     ):
-        self.store = store
+        self.store: Dataset = store
         super().__init__(store)
 
     def serialize(
@@ -32,11 +32,12 @@ class PatchSerializer(Serializer):
         stream: IO[bytes],
         base: Optional[str] = None,
         encoding: Optional[str] = None,
-        operation: Optional[str] = None,
-        target: Optional[Graph] = None,
-        header_id: Optional[str] = None,
-        header_prev: Optional[str] = None,
+        **kwargs,
     ):
+        operation = kwargs.get("operation")
+        target = kwargs.get("target")
+        header_id = kwargs.get("header_id")
+        header_prev = kwargs.get("header_prev")
         if not header_id:
             header_id = f"uuid:{uuid4()}"
         encoding = self.encoding

--- a/test/test_serializers/test_serializer_patch.py
+++ b/test/test_serializers/test_serializer_patch.py
@@ -1,0 +1,182 @@
+from rdflib import Dataset, Literal, URIRef
+
+
+def test_add_quad():
+    ds = Dataset()
+    ds.addN(
+        [
+            (
+                URIRef("http://example.org/subject1"),
+                URIRef("http://example.org/predicate2"),
+                Literal("object2"),
+                URIRef("http://example.org/graph1"),
+            )
+        ]
+    )
+    result = ds.serialize(format="patch", operation="add")
+    assert (
+        """A <http://example.org/subject1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+"""
+        in result
+    )
+
+
+def test_delete_quad():
+    ds = Dataset()
+    ds.addN(
+        [
+            (
+                URIRef("http://example.org/subject1"),
+                URIRef("http://example.org/predicate2"),
+                Literal("object2"),
+                URIRef("http://example.org/graph1"),
+            )
+        ]
+    )
+    result = ds.serialize(format="patch", operation="remove")
+    assert (
+        """D <http://example.org/subject1> <http://example.org/predicate2> "object2" <http://example.org/graph1> .
+"""
+        in result
+    )
+
+
+def test_diff_quad():
+    quad_1 = (
+        URIRef("http://example.org/subject1"),
+        URIRef("http://example.org/predicate2"),
+        Literal("object2"),
+        URIRef("http://example.org/graph1"),
+    )
+    quad_2 = (
+        URIRef("http://example.org/subject2"),
+        URIRef("http://example.org/predicate3"),
+        Literal("object3"),
+        URIRef("http://example.org/graph2"),
+    )
+    ds1 = Dataset()
+    ds2 = Dataset()
+    ds1.addN([quad_1])
+    ds2.addN([quad_1, quad_2])
+    result = ds1.serialize(format="patch", target=ds2)
+    assert (
+        """A <http://example.org/subject2> <http://example.org/predicate3> "object3" <http://example.org/graph2> ."""
+        in result
+    )
+
+
+def test_add_triple():
+    ds = Dataset()
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+        )
+    )
+    result = ds.serialize(format="patch", operation="add")
+    assert (
+        """A <http://example.org/subject1> <http://example.org/predicate2> "object2" ."""
+        in result
+    )
+
+
+def test_delete_triple():
+    ds = Dataset()
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+        )
+    )
+    result = ds.serialize(format="patch", operation="remove")
+    assert (
+        """D <http://example.org/subject1> <http://example.org/predicate2> "object2" ."""
+        in result
+    )
+
+
+def test_diff_triple():
+    triple_1 = (
+        URIRef("http://example.org/subject1"),
+        URIRef("http://example.org/predicate2"),
+        Literal("object2"),
+    )
+    triple_2 = (
+        URIRef("http://example.org/subject2"),
+        URIRef("http://example.org/predicate3"),
+        Literal("object3"),
+    )
+    ds1 = Dataset()
+    ds2 = Dataset()
+    ds1.add(triple_1)
+    ds2.add(triple_1)
+    ds2.add(triple_2)
+    result = ds1.serialize(format="patch", target=ds2)
+    assert (
+        """A <http://example.org/subject2> <http://example.org/predicate3> "object3" ."""
+        in result
+    )
+
+
+def test_diff_quad_overlap():
+    quad_1 = (
+        URIRef("http://example.org/subject1"),
+        URIRef("http://example.org/predicate1"),
+        Literal("object1"),
+        URIRef("http://example.org/graph1"),
+    )
+    quad_2 = (
+        URIRef("http://example.org/subject2"),
+        URIRef("http://example.org/predicate2"),
+        Literal("object2"),
+        URIRef("http://example.org/graph2"),
+    )
+    quad_3 = (
+        URIRef("http://example.org/subject3"),
+        URIRef("http://example.org/predicate3"),
+        Literal("object3"),
+        URIRef("http://example.org/graph3"),
+    )
+    ds1 = Dataset()
+    ds2 = Dataset()
+    ds1.addN([quad_1, quad_2])
+    ds2.addN([quad_2, quad_3])
+    result = ds1.serialize(format="patch", target=ds2)
+    # first quad needs to be removed
+    assert (
+        """D <http://example.org/subject1> <http://example.org/predicate1> "object1" <http://example.org/graph1> ."""
+        in result
+    )
+    # third quad needs to be added
+    assert (
+        """A <http://example.org/subject3> <http://example.org/predicate3> "object3" <http://example.org/graph3> ."""
+        in result
+    )
+
+
+def test_header_id():
+    ds = Dataset()
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+        )
+    )
+    result = ds.serialize(format="patch", operation="add", header_id="uuid:123")
+    assert """H id <uuid:123>""" in result
+
+
+def test_prev_header():
+    ds = Dataset()
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+        )
+    )
+    result = ds.serialize(format="patch", operation="add", header_prev="uuid:123")
+    assert """H prev <uuid:123>""" in result

--- a/test/test_serializers/test_serializer_patch.py
+++ b/test/test_serializers/test_serializer_patch.py
@@ -1,4 +1,4 @@
-from rdflib import Dataset, Literal, URIRef
+from rdflib import Dataset, Graph, Literal, URIRef
 
 
 def test_add_quad():
@@ -8,7 +8,7 @@ def test_add_quad():
             URIRef("http://example.org/subject1"),
             URIRef("http://example.org/predicate2"),
             Literal("object2"),
-            URIRef("http://example.org/graph1"),
+            Graph(identifier=URIRef("http://example.org/graph1")),
         )
     )
     result = ds.serialize(format="patch", operation="add")
@@ -26,7 +26,7 @@ def test_delete_quad():
             URIRef("http://example.org/subject1"),
             URIRef("http://example.org/predicate2"),
             Literal("object2"),
-            URIRef("http://example.org/graph1"),
+            Graph(identifier=URIRef("http://example.org/graph1")),
         )
     )
     result = ds.serialize(format="patch", operation="remove")
@@ -42,13 +42,13 @@ def test_diff_quad():
         URIRef("http://example.org/subject1"),
         URIRef("http://example.org/predicate2"),
         Literal("object2"),
-        URIRef("http://example.org/graph1"),
+        Graph(identifier=URIRef("http://example.org/graph1")),
     )
     quad_2 = (
         URIRef("http://example.org/subject2"),
         URIRef("http://example.org/predicate3"),
         Literal("object3"),
-        URIRef("http://example.org/graph2"),
+        Graph(identifier=URIRef("http://example.org/graph2")),
     )
     ds1 = Dataset()
     ds2 = Dataset()
@@ -121,19 +121,19 @@ def test_diff_quad_overlap():
         URIRef("http://example.org/subject1"),
         URIRef("http://example.org/predicate1"),
         Literal("object1"),
-        URIRef("http://example.org/graph1"),
+        Graph(identifier=URIRef("http://example.org/graph1")),
     )
     quad_2 = (
         URIRef("http://example.org/subject2"),
         URIRef("http://example.org/predicate2"),
         Literal("object2"),
-        URIRef("http://example.org/graph2"),
+        Graph(identifier=URIRef("http://example.org/graph2")),
     )
     quad_3 = (
         URIRef("http://example.org/subject3"),
         URIRef("http://example.org/predicate3"),
         Literal("object3"),
-        URIRef("http://example.org/graph3"),
+        Graph(identifier=URIRef("http://example.org/graph3")),
     )
     ds1 = Dataset()
     ds2 = Dataset()

--- a/test/test_serializers/test_serializer_patch.py
+++ b/test/test_serializers/test_serializer_patch.py
@@ -3,15 +3,13 @@ from rdflib import Dataset, Literal, URIRef
 
 def test_add_quad():
     ds = Dataset()
-    ds.addN(
-        [
-            (
-                URIRef("http://example.org/subject1"),
-                URIRef("http://example.org/predicate2"),
-                Literal("object2"),
-                URIRef("http://example.org/graph1"),
-            )
-        ]
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+            URIRef("http://example.org/graph1"),
+        )
     )
     result = ds.serialize(format="patch", operation="add")
     assert (
@@ -23,15 +21,13 @@ def test_add_quad():
 
 def test_delete_quad():
     ds = Dataset()
-    ds.addN(
-        [
-            (
-                URIRef("http://example.org/subject1"),
-                URIRef("http://example.org/predicate2"),
-                Literal("object2"),
-                URIRef("http://example.org/graph1"),
-            )
-        ]
+    ds.add(
+        (
+            URIRef("http://example.org/subject1"),
+            URIRef("http://example.org/predicate2"),
+            Literal("object2"),
+            URIRef("http://example.org/graph1"),
+        )
     )
     result = ds.serialize(format="patch", operation="remove")
     assert (
@@ -56,7 +52,7 @@ def test_diff_quad():
     )
     ds1 = Dataset()
     ds2 = Dataset()
-    ds1.addN([quad_1])
+    ds1.add(quad_1)
     ds2.addN([quad_1, quad_2])
     result = ds1.serialize(format="patch", target=ds2)
     assert (


### PR DESCRIPTION
Supports serialization from Dataset instances only; triples and quads within a Dataset are supported.

# Summary of changes

Three methods to create RDF Patches from RDFLib Datasets:
1. Serialize a Dataset as an addition patch
2. Serialize a Dataset as a delete patch
3. Create a patch representing the difference between a Dataset instance and a target Dataset instance

Basic usage:
1. `ds.serialize(format="patch", operation="add")`
2. `ds.serialize(format="patch", operation="remove")`
3. `ds1.serialize(format="patch", target=ds2)`

Complete examples are provided in an example script.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  - [x] ~Created an issue to discuss the change and get in-principle agreement.~ Discussed w/ maintainers
  - [x] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

