### PR TITLE
In .patch serializer, default to "add" operation if no operation

### DIFF
--- a/rdflib/plugins/serializers/patch.py
+++ b/rdflib/plugins/serializers/patch.py
@@ -81,7 +81,10 @@ class PatchSerializer(Serializer):
 
         if operation:
             assert operation in add_remove_methods, f"Invalid operation: {operation}"
-
+        elif not target:
+            # No operation specified and no target specified
+            # Fall back to default operation of "add" to prevent a no-op
+            operation = "add"
         write_header()
         if operation:
             operation_code = add_remove_methods.get(operation)


### PR DESCRIPTION
In RDF `.patch` serializer, default to `"add"` operation if no operation or no `target` (diff) is given in `kwargs`.
This is because not all serializing codepaths allow passing `kwargs`.

This fixes the testsuite integration and allows round-trip tests to complete successfully with the `.patch` serializer.

I believe it is reasonable to expect that a user naively serializing their Graph to `.patch` format would want to default to `add` operation if no operation is given. In current implementation, no `operation` and no `target` results in a `.patch` file with only a header and no contents. This is considered a no-op file, and is likely not what the user wants.

Fixes the issue discussed at the bottom of #2877