### PR TITLE
Fix test logic for datetime

### DIFF
--- a/test/test_literal/test_datetime.py
+++ b/test/test_literal/test_datetime.py
@@ -44,8 +44,9 @@ class TestRelativeBase:
 
         assert isinstance(l.toPython(), datetime)
         assert datetime_isoformat(
-            l.toPython() == DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT, dt
-        )
+            l.toPython(),
+            DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT
+         ) == dt
         assert l.toPython().isoformat() == "2008-12-01T18:02:00.522630+00:00"
 
     def test_timezone_offset(self):

--- a/test/test_literal/test_datetime.py
+++ b/test/test_literal/test_datetime.py
@@ -43,10 +43,12 @@ class TestRelativeBase:
         )
 
         assert isinstance(l.toPython(), datetime)
-        assert datetime_isoformat(
-            l.toPython(),
-            DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT
-         ) == dt
+        assert (
+            datetime_isoformat(
+                l.toPython(), DATE_EXT_COMPLETE + "T" + "%H:%M:%S.%f" + TZ_EXT
+            )
+            == dt
+        )
         assert l.toPython().isoformat() == "2008-12-01T18:02:00.522630+00:00"
 
     def test_timezone_offset(self):


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes
One of the assertions in `test_datetime_z` seems to be performing operations in the wrong order. This also means it's passing trivially, as it's essentially recreating the expected result string and asserting it's not empty.

This PR changes the test to what I think was the intended order of operations:
- format the parsed datetime value (`l.toPython()`) according to the given format string
- compare against the expected result string
- assert they're equal

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

