### PR TITLE
Bovlb patch 1

### DIFF
--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -342,8 +342,8 @@ def test_sparql_blank_node_comma():
     } LIMIT 10
     """
 
-    parseResults = parser.parseQuery(query)
-    triples = parseResults[1]['where'].part[0].triples[0]
+    parse_results = parser.parseQuery(query)
+    triples = parse_results[1]['where'].part[0].triples[0]
     s_count = sum(1 for i in range(0, len(triples), 3)
                   if triples[i] == Variable('s'))
     assert s_count == 2, f"Found ?s as subject {s_count} times, expected 2"

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -329,3 +329,21 @@ def test_sparql_group_concat():
     g = Graph()
     q = dict(g.query(query))
     assert q[URIRef("http://example.org/pred")] == Literal("abc")
+
+
+def test_sparql_blank_node_comma():
+    """Tests if blank nodes separated by commas are correctly parsed"""
+
+    query = """
+    PREFIX : <http://example.org/>
+
+    SELECT ?s WHERE {
+    ?s :hasIngredient [:name "chicken"], [:name "butter"] .
+    } LIMIT 10
+    """
+
+    parseResults = parseQuery(query)
+    triples = parseResults[1]['where'].part[0].triples[0]
+    s_count = sum(1 for i in range(0, len(triples), 3)
+                  if triples[i] == Variable('s'))
+    assert s_count == 2, f"Found ?s as subject {s_count} times, expected 2"

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -12,7 +12,7 @@ from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
 
 import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
-from rdflib import Graph, Literal, URIRef
+from rdflib import Graph, Literal, URIRef, Variable
 from rdflib.plugins.sparql.algebra import translateAlgebra
 from test.data import TEST_DATA_DIR
 
@@ -342,7 +342,7 @@ def test_sparql_blank_node_comma():
     } LIMIT 10
     """
 
-    parseResults = parseQuery(query)
+    parseResults = parser.parseQuery(query)
     triples = parseResults[1]['where'].part[0].triples[0]
     s_count = sum(1 for i in range(0, len(triples), 3)
                   if triples[i] == Variable('s'))

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -343,7 +343,6 @@ def test_sparql_blank_node_comma():
     """
 
     parse_results = parser.parseQuery(query)
-    triples = parse_results[1]['where'].part[0].triples[0]
-    s_count = sum(1 for i in range(0, len(triples), 3)
-                  if triples[i] == Variable('s'))
+    triples = parse_results[1]["where"].part[0].triples[0]
+    s_count = sum(1 for i in range(0, len(triples), 3) if triples[i] == Variable("s"))
     assert s_count == 2, f"Found ?s as subject {s_count} times, expected 2"


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

The following SPARLQ where clause:
```
?s :hasIngredient [:name "chicken"], [:name "butter"] .
```

should be parsed as:

```
_:1 :name "butter" .
_:2 :name "chicken" .
?s :hasIngredient _:1 .
?s :hasIngredient _:2
```

but was instead being parsed as:

```
_:1 :name "chicken" .
_:1 :name _:2 .
_:2 :name "butter" .
?s :hasIngredient _:1
```

I fixed the bug and added a new test.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

