### PR TITLE
Revert "build(deps): bump library/python from 3.12.7-slim to 3.13.0-slim in /docker/unstable"

### DIFF
--- a/docker/unstable/Dockerfile
+++ b/docker/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.13.0-slim@sha256:2ec5a4a5c3e919570f57675471f081d6299668d909feabd8d4803c6c61af666c
+FROM docker.io/library/python:3.12.7-slim@sha256:af4e85f1cac90dd3771e47292ea7c8a9830abfabbe4faa5c53f158854c2e819d
 
 # This file is generated from docker:unstable in Taskfile.yml
 COPY var/requirements.txt /var/tmp/build/


### PR DESCRIPTION
Reverts RDFLib/rdflib#2926