### PR TITLE
Prevent crash when comparing ill-typed numeric types.

### DIFF
--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1107,9 +1107,15 @@ class Literal(Identifier):
         if other is None:
             return True  # Everything is greater than None
         if isinstance(other, Literal):
+            # Fast path for comapring numeric literals
+            # that are not ill-typed and don't have a None value
             if (
-                self.datatype in _NUMERIC_LITERAL_TYPES
-                and other.datatype in _NUMERIC_LITERAL_TYPES
+                (
+                    self.datatype in _NUMERIC_LITERAL_TYPES
+                    and other.datatype in _NUMERIC_LITERAL_TYPES
+                )
+                and ((not self.ill_typed) and (not other.ill_typed))
+                and (self.value is not None and other.value is not None)
             ):
                 return self.value > other.value
 


### PR DESCRIPTION
This fixes comparisons that look like:
```
if Literal("1234", datatype="xsd:integer") > Literal("hello", datatype="xsd:integer")
```
Both of the dataypes are in the `_NUMERIC_LITERAL_TYPES` list, so they enter the fast-path comparison.
The problem is the second literal is not a valid integer, so it has the value `None`.
That throws a comparison error that is uncaught by RDFLib, causing the application to crash.

If this seems like something that is pretty common and should be picked up sooner, I think its because this error only occurs when `rdflib.NORMALIZE_LITERALS` is False. When rdflib normalizes the literals, it fixes the value, so this does not happen. I found this when testing some PySHACL code sections which run with `rdflib.NORMALIZE_LITERALS=False`.

Luckily since rdflib introduced the concept of `ill_typed` literals, we can use that to restrict the fast-path to only those numeric literals that are _not_ ill-typed.

