### PR TITLE
Replace html5lib with html5rdf, make it an optional dependency

### DIFF
--- a/devtools/constraints.min
+++ b/devtools/constraints.min
@@ -6,6 +6,6 @@ pyparsing==2.1.0
 importlib-metadata==4.0.0
 berkeleydb==18.1.2
 networkx==2.0
-html5lib-modern==1.2.0
+html5rdf==1.2.0
 lxml==4.3.0
 orjson==3.9.14

--- a/docker/latest/requirements.in
+++ b/docker/latest/requirements.in
@@ -1,6 +1,6 @@
 # This file is used for building a docker image of the latest rdflib release. It
 # will be updated by dependabot when new releases are made.
 rdflib==7.1.0
-html5lib-modern==1.2.0
+html5rdf==1.2.0
 # isodate is required to allow the Dockerfile to build on with pre-RDFLib-7.1 releases.
 isodate==0.7.2

--- a/docker/latest/requirements.in
+++ b/docker/latest/requirements.in
@@ -2,5 +2,5 @@
 # will be updated by dependabot when new releases are made.
 rdflib==7.1.0
 html5rdf==1.2.0
-# isodate is required to allow the Dockerfile to build on with pre-RDFLib-7.1 releases.
-isodate==0.7.2
+# html5lib-modern is required to allow the Dockerfile to build on with pre-RDFLib-7.1.1 releases.
+html5lib-modern==1.2.0

--- a/docker/latest/requirements.txt
+++ b/docker/latest/requirements.txt
@@ -8,7 +8,7 @@ html5rdf==1.2
     # via
     #   -r docker/latest/requirements.in
     #   rdflib
-isodate==0.7.2
+html5lib-modern==1.2
     # via -r docker/latest/requirements.in
 pyparsing==3.0.9
     # via rdflib

--- a/docker/latest/requirements.txt
+++ b/docker/latest/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile docker/latest/requirements.in
 #
-html5lib-modern==1.2
+html5rdf==1.2
     # via
     #   -r docker/latest/requirements.in
     #   rdflib

--- a/poetry.lock
+++ b/poetry.lock
@@ -339,14 +339,14 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "html5lib-modern"
+name = "html5rdf"
 version = "1.2"
 description = "HTML parser based on the WHATWG HTML specification"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "html5lib_modern-1.2-py2.py3-none-any.whl", hash = "sha256:3458b6e31525ede4fcaac0ff42d9eeb5efaf755473768103cb56e0275caa8d99"},
-    {file = "html5lib_modern-1.2.tar.gz", hash = "sha256:1fadbfc27ea955431270e4e79a4a4c290ba11c3a3098a95cc22dc73e312a1768"},
+    {file = "html5rdf-1.2-py2.py3-none-any.whl", hash = "sha256:08169aa52a98ee3a6d3456d83feb36211fb5edcbcf3e05f6d19e0136f581638c"},
+    {file = "html5rdf-1.2.tar.gz", hash = "sha256:08378cbbbb63993ba7bb5eb1eac44bf9ca7b1a23dbee3d2afef5376597fb00a5"},
 ]
 
 [package.extras]
@@ -1107,7 +1107,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1456,6 +1455,7 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 berkeleydb = ["berkeleydb"]
+html = ["html5rdf", "lxml"]
 lxml = ["lxml"]
 networkx = ["networkx"]
 orjson = ["orjson"]
@@ -1463,4 +1463,4 @@ orjson = ["orjson"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "b0303e119538a8c1ca41f75206ce1c2fb3016699a00a02039bcafae17da6b03b"
+content-hash = "214d37624612043042464f0e154a4e551ec43177be1aabe4b9aced3ace7182de"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1455,7 +1455,7 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 berkeleydb = ["berkeleydb"]
-html = ["html5rdf", "lxml"]
+html = ["html5rdf"]
 lxml = ["lxml"]
 networkx = ["networkx"]
 orjson = ["orjson"]
@@ -1463,4 +1463,4 @@ orjson = ["orjson"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "214d37624612043042464f0e154a4e551ec43177be1aabe4b9aced3ace7182de"
+content-hash = "71704ba175e33528872fab8121cb609041bd97b6a99f8f04022a26904941b27c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ isodate = {version=">=0.7.2,<1.0.0", python = "<3.11"}
 pyparsing = ">=2.1.0,<4"
 berkeleydb = {version = "^18.1.0", optional = true}
 networkx = {version = ">=2,<4", optional = true}
-html5lib-modern = "^1.2"
+html5rdf = {version = ">=1.2,<2", optional = true}
 lxml = {version = ">=4.3,<6.0", optional = true}
 orjson = {version = ">=3.9.14,<4", optional = true}
 
@@ -74,6 +74,7 @@ ruff = ">=0.0.286,<0.8.0"
 [tool.poetry.extras]
 berkeleydb = ["berkeleydb"]
 networkx = ["networkx"]
+html = ["html5rdf", "lxml"]
 lxml = ["lxml"]
 orjson = ["orjson"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,9 @@ ruff = ">=0.0.286,<0.8.0"
 [tool.poetry.extras]
 berkeleydb = ["berkeleydb"]
 networkx = ["networkx"]
-html = ["html5rdf", "lxml"]
+# html support is optional, it is used only in tokenizing `rdf:HTML` type Literals
+html = ["html5rdf"]
+# lxml support is optional, it is used only for parsing XML-formatted SPARQL results
 lxml = ["lxml"]
 orjson = ["orjson"]
 

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -47,11 +47,11 @@ import logging
 import sys
 from importlib import metadata
 
-#_DISTRIBUTION_METADATA = metadata.metadata("rdflib")
+_DISTRIBUTION_METADATA = metadata.metadata("rdflib")
 
 __docformat__ = "restructuredtext en"
 
-__version__: str = "0.0.0" #_DISTRIBUTION_METADATA["Version"]
+__version__: str = _DISTRIBUTION_METADATA["Version"]
 __date__ = "2024-10-17"
 
 __all__ = [

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -47,11 +47,11 @@ import logging
 import sys
 from importlib import metadata
 
-_DISTRIBUTION_METADATA = metadata.metadata("rdflib")
+#_DISTRIBUTION_METADATA = metadata.metadata("rdflib")
 
 __docformat__ = "restructuredtext en"
 
-__version__: str = _DISTRIBUTION_METADATA["Version"]
+__version__: str = "0.0.0" #_DISTRIBUTION_METADATA["Version"]
 __date__ = "2024-10-17"
 
 __all__ = [

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -1387,10 +1387,13 @@ class Literal(Identifier):
                 return str.__eq__(self, other)
 
             # XML can be compared to HTML, only if html5rdf is enabled
-            if ((dtself in _XML_COMPARABLE and dtother in _XML_COMPARABLE) and
-                # Ill-typed can be none if unknown, but we don't want it to be False.
-                ((self.ill_typed is not False) and (other.ill_typed is not False)) and
-                (self.value is not None and other.value is not None)):
+            if (
+                (dtself in _XML_COMPARABLE and dtother in _XML_COMPARABLE)
+                and
+                # Ill-typed can be None if unknown, but we don't want it to be True.
+                ((self.ill_typed is not True) and (other.ill_typed is not True))
+                and (self.value is not None and other.value is not None)
+            ):
                 return _isEqualXMLNode(self.value, other.value)
 
             if dtself != dtother:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -2099,7 +2099,7 @@ if html5rdf is not None:
     # It is probably best to keep this close to the definition of
     # _GenericPythonToXSDRules so nobody misses it.
     XSDToPython[_RDF_HTMLLITERAL] = _parse_html
-    _XML_COMPARABLE = (_RDF_XMLLITERAL, _RDF_HTMLLITERAL)
+    _XML_COMPARABLE: Tuple[URIRef, ...] = (_RDF_XMLLITERAL, _RDF_HTMLLITERAL)
 else:
     _XML_COMPARABLE = (_RDF_XMLLITERAL,)
 

--- a/test/test_literal/test_literal.py
+++ b/test/test_literal/test_literal.py
@@ -23,11 +23,11 @@ from test.utils.outcome import OutcomeChecker, OutcomePrimitive, OutcomePrimitiv
 
 
 try:
-    import html5lib as _  # noqa: F401
+    import html5rdf as _  # noqa: F401
 
-    _HAVE_HTML5LIB = True
+    _HAVE_HTML5RDF = True
 except ImportError:
-    _HAVE_HTML5LIB = False
+    _HAVE_HTML5RDF = False
 
 import pytest
 
@@ -981,7 +981,7 @@ class _UnknownType:
         (
             lambda: Literal("<body>", datatype=RDF.HTML),
             LiteralChecker(
-                ..., None, RDF.HTML, True if _HAVE_HTML5LIB else None, "<body>"
+                ..., None, RDF.HTML, True if _HAVE_HTML5RDF else None, "<body>"
             ),
         ),
         (
@@ -990,7 +990,7 @@ class _UnknownType:
                 ...,
                 None,
                 RDF.HTML,
-                False if _HAVE_HTML5LIB else None,
+                False if _HAVE_HTML5RDF else None,
                 "<table></table>",
             ),
         ),

--- a/test/test_literal/test_literal_html5lib.py
+++ b/test/test_literal/test_literal_html5lib.py
@@ -1,7 +1,6 @@
 import xml.dom.minidom
 from typing import Callable
 
-import html5lib  # noqa: F401
 import pytest
 
 import rdflib.term
@@ -10,8 +9,13 @@ from rdflib.term import Literal
 from test.utils.literal import LiteralChecker
 from test.utils.outcome import OutcomeChecker, OutcomePrimitives
 
+try:
+    import html5rdf as _  # noqa: F401
+except ImportError:
+    pytest.skip("html5rdf not installed", allow_module_level=True)
 
-def test_has_html5lib() -> None:
+def test_has_html5rdf() -> None:
+    assert rdflib.term._HAS_HTML5RDF is True
     assert RDF.HTML in rdflib.term.XSDToPython
     rule = next(
         (
@@ -29,7 +33,7 @@ def test_has_html5lib() -> None:
     ["factory", "outcome"],
     [
         # Ill-typed literals, these have lexical forms that result in
-        # errors when parsed as HTML by html5lib.
+        # errors when parsed as HTML by html5rdf.
         (
             lambda: Literal("<body><h1>Hello, World!</h1></body>", datatype=RDF.HTML),
             LiteralChecker(

--- a/test/test_literal/test_literal_html5lib.py
+++ b/test/test_literal/test_literal_html5lib.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     pytest.skip("html5rdf not installed", allow_module_level=True)
 
+
 def test_has_html5rdf() -> None:
     assert rdflib.term._HAS_HTML5RDF is True
     assert RDF.HTML in rdflib.term.XSDToPython

--- a/test/test_literal/test_literal_html5lib.py
+++ b/test/test_literal/test_literal_html5lib.py
@@ -52,7 +52,7 @@ def test_has_html5rdf() -> None:
             ),
         ),
         # Well-typed literals, these have lexical forms that parse
-        # without errors with html5lib.
+        # without errors with html5rdf.
         (
             lambda: Literal("<table></table>", datatype=RDF.HTML),
             LiteralChecker(..., None, RDF.HTML, False, "<table></table>"),

--- a/test/test_literal/test_xmlliterals.py
+++ b/test/test_literal/test_xmlliterals.py
@@ -9,11 +9,11 @@ import rdflib
 from rdflib import RDF, Literal
 
 try:
-    import html5lib  # noqa: F401
+    import html5rdf  # noqa: F401
 
-    have_html5lib = True
+    have_html5rdf = True
 except ImportError:
-    have_html5lib = False
+    have_html5rdf = False
 
 
 def testPythonRoundtrip():  # noqa: N802
@@ -90,7 +90,7 @@ def testRoundtrip():  # noqa: N802
     roundtrip("nt")
 
 
-@pytest.mark.skipif(not have_html5lib, reason="requires html5lib")
+@pytest.mark.skipif(not have_html5rdf, reason="requires html5rdf")
 def testHTML():  # noqa: N802
     l1 = Literal("<msg>hello</msg>", datatype=RDF.XMLLiteral)
     assert l1.value is not None, "xml must have been parsed"

--- a/test/test_literal/test_xmlliterals.py
+++ b/test/test_literal/test_xmlliterals.py
@@ -126,7 +126,7 @@ def testHTML():  # noqa: N802
                         textwrap.dedent(
                             """\
                     <!DOCTYPE example>
-                    <something/>
+                    <something2/>
                     """
                         )
                     ),
@@ -137,7 +137,7 @@ def testHTML():  # noqa: N802
                         textwrap.dedent(
                             """\
                     <!DOCTYPE example>
-                    <something />
+                    <something2 />
                     """
                         )
                     ),

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage.{envname}}
     MYPY_CACHE_DIR = {envdir}/.mypy_cache
     docs: POETRY_ARGS_docs = --only=docs
-    extensive: POETRY_ARGS_extensive = --extras=berkeleydb --extras=networkx --extras=orjson
+    extensive: POETRY_ARGS_extensive = --extras=berkeleydb --extras=networkx --extras=html --extras=orjson
     lxml: POETRY_ARGS_lxml = --extras=lxml
 commands_pre =
     py3{8,9,10,11}: python -c 'import os; print("\n".join(f"{key}={value}" for key, value in os.environ.items()))'
@@ -59,7 +59,7 @@ setenv =
     PYTHONHASHSEED = 0
 commands_pre =
     poetry lock --check
-    poetry install --only=main --only=docs
+    poetry install --only=main --only=docs --extras=html
     poetry env info
 commands =
     poetry run sphinx-build -T -W -b html -d {envdir}/doctree docs docs/_build/html


### PR DESCRIPTION
This commit undoes some of what was merged in the v7.1 release that made HTML tokenisation of rdf:HTML literals non-optional.
This makes it an optional extra feature of RDFLib again, and moves away from using the deprecated html5lib (and the alias replacement html5-modern), to using the new html5rdf that lives in the RDFLib org.

This also fixes the tests that comparison code paths that were crashing, that was the reason for making HTML tokenisation non-optional in v7.1. Now that these are fixed, its safe to not have html5rdf installed when using RDFLib.