### PR TITLE
Fix doc build with sphinx8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -300,7 +300,7 @@ def autodoc_skip_member_handler(
     """
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member
     if (
-        app.env.docname == "apidocs/rdflib"
+        app.env.docname in ["apidocs/rdflib", "apidocs/rdflib.namespace"]
         and what == "module"
         and type(obj).__name__.endswith("DefinedNamespaceMeta")
     ):


### PR DESCRIPTION
Fix https://github.com/RDFLib/rdflib/issues/2936

# Summary of changes

Adds `apidocs/rdflib.namespace` to the list of `autodoc_skip_member_handler` to avoid issues when generating docs because sphinx tries to `str(obj)` to check if the class `.startswith('typing.Annotated')`.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

