### PR TITLE
Fix defined namespace warnings

### DIFF
--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -74,10 +74,9 @@ from __future__ import annotations
 
 import logging
 import warnings
-from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 from unicodedata import category
 from urllib.parse import urldefrag, urljoin
 
@@ -145,7 +144,7 @@ class Namespace(str):
     False
     """
 
-    def __new__(cls, value: str | bytes) -> Namespace:
+    def __new__(cls, value: Union[str, bytes]) -> Namespace:
         try:
             rt = str.__new__(cls, value)
         except UnicodeDecodeError:
@@ -203,7 +202,7 @@ class URIPattern(str):
 
     """
 
-    def __new__(cls, value: str | bytes) -> URIPattern:
+    def __new__(cls, value: Union[str, bytes]) -> URIPattern:
         try:
             rt = str.__new__(cls, value)
         except UnicodeDecodeError:
@@ -226,7 +225,7 @@ class URIPattern(str):
 # always raise AttributeError if they are not defined and which should not be
 # considered part of __dir__ results. These should be all annotations on
 # `DefinedNamespaceMeta`.
-_DFNS_RESERVED_ATTRS: set[str] = {
+_DFNS_RESERVED_ATTRS: Set[str] = {
     "_NS",
     "_warn",
     "_fail",
@@ -236,7 +235,7 @@ _DFNS_RESERVED_ATTRS: set[str] = {
 
 # Some libraries probe classes for certain attributes or items.
 # This is a list of those attributes and items that should be ignored.
-_IGNORED_ATTR_LOOKUP: set[str] = {
+_IGNORED_ATTR_LOOKUP: Set[str] = {
     "_pytestfixturefunction",  # pytest tries to look this up on Defined namespaces
     "_partialmethod",  # sphinx tries to look this up during autodoc generation
     "__test__",  # pytest checks for this old nose-test style constant
@@ -250,7 +249,7 @@ class DefinedNamespaceMeta(type):
     _NS: Namespace
     _warn: bool = True
     _fail: bool = False  # True means mimic ClosedNamespace
-    _extras: list[str] = []  # List of non-pythonesque items
+    _extras: List[str] = []  # List of non-pythonesque items
     _underscore_num: bool = False  # True means pass "_n" constructs
 
     @lru_cache(maxsize=None)
@@ -349,9 +348,9 @@ class ClosedNamespace(Namespace):
     Trying to create terms not listed is an error
     """
 
-    __uris: dict[str, URIRef]
+    __uris: Dict[str, URIRef]
 
-    def __new__(cls, uri: str, terms: list[str]):
+    def __new__(cls, uri: str, terms: List[str]):
         rt = super().__new__(cls, uri)
         rt.__uris = {t: URIRef(rt + t) for t in terms}  # type: ignore[attr-defined]
         return rt
@@ -381,7 +380,7 @@ class ClosedNamespace(Namespace):
     def __repr__(self) -> str:
         return f"{self.__module__}.{self.__class__.__name__}({str(self)!r})"
 
-    def __dir__(self) -> list[str]:
+    def __dir__(self) -> List[str]:
         return list(self.__uris)
 
     def __contains__(self, ref: str) -> bool:  # type: ignore[override]
@@ -389,7 +388,7 @@ class ClosedNamespace(Namespace):
             ref in self.__uris.values()
         )  # test namespace membership with "ref in ns" syntax
 
-    def _ipython_key_completions_(self) -> list[str]:
+    def _ipython_key_completions_(self) -> List[str]:
         return dir(self)
 
 
@@ -453,11 +452,11 @@ class NamespaceManager:
 
     def __init__(self, graph: Graph, bind_namespaces: _NamespaceSetString = "rdflib"):
         self.graph = graph
-        self.__cache: dict[str, tuple[str, URIRef, str]] = {}
-        self.__cache_strict: dict[str, tuple[str, URIRef, str]] = {}
+        self.__cache: Dict[str, Tuple[str, URIRef, str]] = {}
+        self.__cache_strict: Dict[str, Tuple[str, URIRef, str]] = {}
         self.__log = None
-        self.__strie: dict[str, Any] = {}
-        self.__trie: dict[str, Any] = {}
+        self.__strie: Dict[str, Any] = {}
+        self.__trie: Dict[str, Any] = {}
         # This type declaration is here becuase there is no common base class
         # for all namespaces and without it the inferred type of ns is not
         # compatible with all prefixes.
@@ -574,7 +573,7 @@ class NamespaceManager:
             qNameParts = self.compute_qname(rdfTerm)  # noqa: N806
             return ":".join([qNameParts[0], qNameParts[-1]])
 
-    def compute_qname(self, uri: str, generate: bool = True) -> tuple[str, URIRef, str]:
+    def compute_qname(self, uri: str, generate: bool = True) -> Tuple[str, URIRef, str]:
         prefix: Optional[str]
         if uri not in self.__cache:
             if not _is_valid_uri(uri):
@@ -621,7 +620,7 @@ class NamespaceManager:
 
     def compute_qname_strict(
         self, uri: str, generate: bool = True
-    ) -> tuple[str, str, str]:
+    ) -> Tuple[str, str, str]:
         # code repeated to avoid branching on strict every time
         # if output needs to be strict (e.g. for xml) then
         # only the strict output should bear the overhead
@@ -790,7 +789,7 @@ class NamespaceManager:
 
         insert_trie(self.__trie, str(namespace))
 
-    def namespaces(self) -> Iterable[tuple[str, URIRef]]:
+    def namespaces(self) -> Iterable[Tuple[str, URIRef]]:
         for prefix, namespace in self.store.namespaces():
             namespace = URIRef(namespace)
             yield prefix, namespace
@@ -873,8 +872,8 @@ def is_ncname(name: str) -> int:
 
 
 def split_uri(
-    uri: str, split_start: list[str] = SPLIT_START_CATEGORIES
-) -> tuple[str, str]:
+    uri: str, split_start: List[str] = SPLIT_START_CATEGORIES
+) -> Tuple[str, str]:
     if uri.startswith(XMLNS):
         return (XMLNS, uri.split(XMLNS)[1])
     length = len(uri)
@@ -896,8 +895,8 @@ def split_uri(
 
 
 def insert_trie(
-    trie: dict[str, Any], value: str
-) -> dict[str, Any]:  # aka get_subtrie_or_insert
+    trie: Dict[str, Any], value: str
+) -> Dict[str, Any]:  # aka get_subtrie_or_insert
     """Insert a value into the trie if it is not already contained in the trie.
     Return the subtree for the value regardless of whether it is a new value
     or not."""
@@ -920,12 +919,12 @@ def insert_trie(
     return trie[value]
 
 
-def insert_strie(strie: dict[str, Any], trie: dict[str, Any], value: str) -> None:
+def insert_strie(strie: Dict[str, Any], trie: Dict[str, Any], value: str) -> None:
     if value not in strie:
         strie[value] = insert_trie(trie, value)
 
 
-def get_longest_namespace(trie: dict[str, Any], value: str) -> Optional[str]:
+def get_longest_namespace(trie: Dict[str, Any], value: str) -> Optional[str]:
     for key in trie:
         if value.startswith(key):
             out = get_longest_namespace(trie[key], value)

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -238,13 +238,13 @@ _DFNS_RESERVED_ATTRS: Set[str] = {
 _IGNORED_ATTR_LOOKUP: Set[str] = {
     "_pytestfixturefunction",  # pytest tries to look this up on Defined namespaces
     "_partialmethod",  # sphinx tries to look this up during autodoc generation
-    "__test__",  # pytest checks for this old nose-test style constant
-    "__signature__",  # inspect.signature returns this, it cannot be used
 }
 
 
 class DefinedNamespaceMeta(type):
     """Utility metaclass for generating URIRefs with a common prefix."""
+
+    __slots__: Tuple[str, ...] = tuple()
 
     _NS: Namespace
     _warn: bool = True
@@ -279,6 +279,8 @@ class DefinedNamespaceMeta(type):
             raise AttributeError(
                 f"DefinedNamespace like object has no attribute {name!r}"
             )
+        elif name.startswith("__"):
+            return super(DefinedNamespaceMeta, cls).__getattribute__(name)
         return cls.__getitem__(name)
 
     def __repr__(cls) -> str:
@@ -322,7 +324,7 @@ class DefinedNamespaceMeta(type):
         return values
 
     def as_jsonld_context(self, pfx: str) -> dict:  # noqa: N804
-        """Returns this DefinedNamespace as a a JSON-LD 'context' object"""
+        """Returns this DefinedNamespace as a JSON-LD 'context' object"""
         terms = {pfx: str(self._NS)}
         for key, term in self.__annotations__.items():
             if issubclass(term, URIRef):
@@ -336,6 +338,8 @@ class DefinedNamespace(metaclass=DefinedNamespaceMeta):
     A Namespace with an enumerated list of members.
     Warnings are emitted if unknown members are referenced if _warn is True
     """
+
+    __slots__: Tuple[str, ...] = tuple()
 
     def __init__(self):
         raise TypeError("namespace may not be instantiated")

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -74,9 +74,10 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional
 from unicodedata import category
 from urllib.parse import urldefrag, urljoin
 
@@ -144,7 +145,7 @@ class Namespace(str):
     False
     """
 
-    def __new__(cls, value: Union[str, bytes]) -> Namespace:
+    def __new__(cls, value: str | bytes) -> Namespace:
         try:
             rt = str.__new__(cls, value)
         except UnicodeDecodeError:
@@ -202,7 +203,7 @@ class URIPattern(str):
 
     """
 
-    def __new__(cls, value: Union[str, bytes]) -> URIPattern:
+    def __new__(cls, value: str | bytes) -> URIPattern:
         try:
             rt = str.__new__(cls, value)
         except UnicodeDecodeError:
@@ -225,7 +226,7 @@ class URIPattern(str):
 # always raise AttributeError if they are not defined and which should not be
 # considered part of __dir__ results. These should be all annotations on
 # `DefinedNamespaceMeta`.
-_DFNS_RESERVED_ATTRS: Set[str] = {
+_DFNS_RESERVED_ATTRS: set[str] = {
     "_NS",
     "_warn",
     "_fail",
@@ -235,9 +236,10 @@ _DFNS_RESERVED_ATTRS: Set[str] = {
 
 # Some libraries probe classes for certain attributes or items.
 # This is a list of those attributes and items that should be ignored.
-_IGNORED_ATTR_LOOKUP: Set[str] = {
+_IGNORED_ATTR_LOOKUP: set[str] = {
     "_pytestfixturefunction",  # pytest tries to look this up on Defined namespaces
     "_partialmethod",  # sphinx tries to look this up during autodoc generation
+    "__test__",  # pytest checks for this old nose-test style constant
 }
 
 
@@ -247,7 +249,7 @@ class DefinedNamespaceMeta(type):
     _NS: Namespace
     _warn: bool = True
     _fail: bool = False  # True means mimic ClosedNamespace
-    _extras: List[str] = []  # List of non-pythonesque items
+    _extras: list[str] = []  # List of non-pythonesque items
     _underscore_num: bool = False  # True means pass "_n" constructs
 
     @lru_cache(maxsize=None)
@@ -255,15 +257,11 @@ class DefinedNamespaceMeta(type):
         name = str(name)
 
         if name in _DFNS_RESERVED_ATTRS:
-            raise AttributeError(
-                f"DefinedNamespace like object has no attribute {name!r}"
+            raise KeyError(
+                f"DefinedNamespace like object has no access item named {name!r}"
             )
         elif name in _IGNORED_ATTR_LOOKUP:
             raise KeyError()
-        if str(name).startswith("__"):
-            # NOTE on type ignore: This seems to be a real bug, super() does not
-            # implement this method, it will fail if it is ever reached.
-            return super().__getitem__(name, default)  # type: ignore[misc] # undefined in superclass
         if (cls._warn or cls._fail) and name not in cls:
             if cls._fail:
                 raise AttributeError(f"term '{name}' not in namespace '{cls._NS}'")
@@ -277,26 +275,37 @@ class DefinedNamespaceMeta(type):
     def __getattr__(cls, name: str):
         if name in _IGNORED_ATTR_LOOKUP:
             raise AttributeError()
+        elif name in _DFNS_RESERVED_ATTRS:
+            raise AttributeError(
+                f"DefinedNamespace like object has no attribute {name!r}"
+            )
         return cls.__getitem__(name)
 
     def __repr__(cls) -> str:
-        return f"Namespace({str(cls._NS)!r})"
+        try:
+            ns_repr = repr(cls._NS)
+        except AttributeError:
+            ns_repr = "<DefinedNamespace>"
+        return f"Namespace({ns_repr})"
 
     def __str__(cls) -> str:
-        return str(cls._NS)
+        try:
+            return str(cls._NS)
+        except AttributeError:
+            return "<DefinedNamespace>"
 
     def __add__(cls, other: str) -> URIRef:
         return cls.__getitem__(other)
 
     def __contains__(cls, item: str) -> bool:
         """Determine whether a URI or an individual item belongs to this namespace"""
+        try:
+            this_ns = cls._NS
+        except AttributeError:
+            return False
         item_str = str(item)
-        if item_str.startswith("__"):
-            # NOTE on type ignore: This seems to be a real bug, super() does not
-            # implement this method, it will fail if it is ever reached.
-            return super().__contains__(item)  # type: ignore[misc] # undefined in superclass
-        if item_str.startswith(str(cls._NS)):
-            item_str = item_str[len(str(cls._NS)) :]
+        if item_str.startswith(str(this_ns)):
+            item_str = item_str[len(str(this_ns)) :]
         return any(
             item_str in c.__annotations__
             or item_str in c._extras
@@ -339,9 +348,9 @@ class ClosedNamespace(Namespace):
     Trying to create terms not listed is an error
     """
 
-    __uris: Dict[str, URIRef]
+    __uris: dict[str, URIRef]
 
-    def __new__(cls, uri: str, terms: List[str]):
+    def __new__(cls, uri: str, terms: list[str]):
         rt = super().__new__(cls, uri)
         rt.__uris = {t: URIRef(rt + t) for t in terms}  # type: ignore[attr-defined]
         return rt
@@ -371,7 +380,7 @@ class ClosedNamespace(Namespace):
     def __repr__(self) -> str:
         return f"{self.__module__}.{self.__class__.__name__}({str(self)!r})"
 
-    def __dir__(self) -> List[str]:
+    def __dir__(self) -> list[str]:
         return list(self.__uris)
 
     def __contains__(self, ref: str) -> bool:  # type: ignore[override]
@@ -379,7 +388,7 @@ class ClosedNamespace(Namespace):
             ref in self.__uris.values()
         )  # test namespace membership with "ref in ns" syntax
 
-    def _ipython_key_completions_(self) -> List[str]:
+    def _ipython_key_completions_(self) -> list[str]:
         return dir(self)
 
 
@@ -443,11 +452,11 @@ class NamespaceManager:
 
     def __init__(self, graph: Graph, bind_namespaces: _NamespaceSetString = "rdflib"):
         self.graph = graph
-        self.__cache: Dict[str, Tuple[str, URIRef, str]] = {}
-        self.__cache_strict: Dict[str, Tuple[str, URIRef, str]] = {}
+        self.__cache: dict[str, tuple[str, URIRef, str]] = {}
+        self.__cache_strict: dict[str, tuple[str, URIRef, str]] = {}
         self.__log = None
-        self.__strie: Dict[str, Any] = {}
-        self.__trie: Dict[str, Any] = {}
+        self.__strie: dict[str, Any] = {}
+        self.__trie: dict[str, Any] = {}
         # This type declaration is here becuase there is no common base class
         # for all namespaces and without it the inferred type of ns is not
         # compatible with all prefixes.
@@ -564,7 +573,7 @@ class NamespaceManager:
             qNameParts = self.compute_qname(rdfTerm)  # noqa: N806
             return ":".join([qNameParts[0], qNameParts[-1]])
 
-    def compute_qname(self, uri: str, generate: bool = True) -> Tuple[str, URIRef, str]:
+    def compute_qname(self, uri: str, generate: bool = True) -> tuple[str, URIRef, str]:
         prefix: Optional[str]
         if uri not in self.__cache:
             if not _is_valid_uri(uri):
@@ -611,7 +620,7 @@ class NamespaceManager:
 
     def compute_qname_strict(
         self, uri: str, generate: bool = True
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         # code repeated to avoid branching on strict every time
         # if output needs to be strict (e.g. for xml) then
         # only the strict output should bear the overhead
@@ -780,7 +789,7 @@ class NamespaceManager:
 
         insert_trie(self.__trie, str(namespace))
 
-    def namespaces(self) -> Iterable[Tuple[str, URIRef]]:
+    def namespaces(self) -> Iterable[tuple[str, URIRef]]:
         for prefix, namespace in self.store.namespaces():
             namespace = URIRef(namespace)
             yield prefix, namespace
@@ -863,8 +872,8 @@ def is_ncname(name: str) -> int:
 
 
 def split_uri(
-    uri: str, split_start: List[str] = SPLIT_START_CATEGORIES
-) -> Tuple[str, str]:
+    uri: str, split_start: list[str] = SPLIT_START_CATEGORIES
+) -> tuple[str, str]:
     if uri.startswith(XMLNS):
         return (XMLNS, uri.split(XMLNS)[1])
     length = len(uri)
@@ -886,8 +895,8 @@ def split_uri(
 
 
 def insert_trie(
-    trie: Dict[str, Any], value: str
-) -> Dict[str, Any]:  # aka get_subtrie_or_insert
+    trie: dict[str, Any], value: str
+) -> dict[str, Any]:  # aka get_subtrie_or_insert
     """Insert a value into the trie if it is not already contained in the trie.
     Return the subtree for the value regardless of whether it is a new value
     or not."""
@@ -910,12 +919,12 @@ def insert_trie(
     return trie[value]
 
 
-def insert_strie(strie: Dict[str, Any], trie: Dict[str, Any], value: str) -> None:
+def insert_strie(strie: dict[str, Any], trie: dict[str, Any], value: str) -> None:
     if value not in strie:
         strie[value] = insert_trie(trie, value)
 
 
-def get_longest_namespace(trie: Dict[str, Any], value: str) -> Optional[str]:
+def get_longest_namespace(trie: dict[str, Any], value: str) -> Optional[str]:
     for key in trie:
         if value.startswith(key):
             out = get_longest_namespace(trie[key], value)

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -240,6 +240,7 @@ _IGNORED_ATTR_LOOKUP: set[str] = {
     "_pytestfixturefunction",  # pytest tries to look this up on Defined namespaces
     "_partialmethod",  # sphinx tries to look this up during autodoc generation
     "__test__",  # pytest checks for this old nose-test style constant
+    "__signature__",  # inspect.signature returns this, it cannot be used
 }
 
 

--- a/rdflib/namespace/__init__.py
+++ b/rdflib/namespace/__init__.py
@@ -226,6 +226,7 @@ class URIPattern(str):
 # considered part of __dir__ results. These should be all annotations on
 # `DefinedNamespaceMeta`.
 _DFNS_RESERVED_ATTRS: Set[str] = {
+    "__slots__",
     "_NS",
     "_warn",
     "_fail",

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -299,14 +299,9 @@ def test_repr(dfns: Type[DefinedNamespace]) -> None:
     ns_uri = f"{prefix}{dfns_info.suffix}"
     logging.debug("ns_uri = %s", ns_uri)
 
-    repr_str: Optional[str] = None
-
-    with ExitStack() as xstack:
-        if dfns_info.suffix is None:
-            xstack.enter_context(pytest.raises(AttributeError))
-        repr_str = f"{dfns_info.dfns!r}"
+    repr_str:str = f"{dfns_info.dfns!r}"
     if dfns_info.suffix is None:
-        assert repr_str is None
+        assert "<DefinedNamespace>" in repr_str
     else:
         assert repr_str is not None
         repro = eval(repr_str)
@@ -368,20 +363,15 @@ def test_contains(
     dfns_info = get_dfns_info(dfns)
     if dfns_info.suffix is not None:
         logging.debug("dfns_info = %s", dfns_info)
-    if dfns_info.has_attrs is False:
+    if dfns_info.has_attrs is False or dfns_info.suffix is None:
         is_defined = False
-    does_contain: Optional[bool] = None
-    with ExitStack() as xstack:
-        if dfns_info.suffix is None:
-            xstack.enter_context(pytest.raises(AttributeError))
-        does_contain = attr_name in dfns
-    if dfns_info.suffix is not None:
-        if is_defined:
-            assert does_contain is True
-        else:
-            assert does_contain is False
+
+    does_contain: bool = attr_name in dfns
+
+    if is_defined:
+        assert does_contain is True
     else:
-        assert does_contain is None
+        assert does_contain is False
 
 
 @pytest.mark.parametrize(

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -299,7 +299,7 @@ def test_repr(dfns: Type[DefinedNamespace]) -> None:
     ns_uri = f"{prefix}{dfns_info.suffix}"
     logging.debug("ns_uri = %s", ns_uri)
 
-    repr_str:str = f"{dfns_info.dfns!r}"
+    repr_str: str = f"{dfns_info.dfns!r}"
     if dfns_info.suffix is None:
         assert "<DefinedNamespace>" in repr_str
     else:


### PR DESCRIPTION
Current docs-generation tests are polluted by lots of warnings that occur when Sphinx tries to read various parts of DefinedNamespace.

