### PR TITLE
Don't use quoted forward annotations unless absolutely required, beca…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12,18 +12,32 @@ files = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "0.7.16"
+description = "A light, configurable Sphinx theme"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"},
+    {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"},
+]
+
+[[package]]
 name = "babel"
-version = "2.12.1"
+version = "2.16.0"
 description = "Internationalization utilities"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "Babel-2.12.1-py3-none-any.whl", hash = "sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610"},
-    {file = "Babel-2.12.1.tar.gz", hash = "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"},
+    {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
+    {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
 [package.dependencies]
 pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
+
+[package.extras]
+dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
 name = "berkeleydb"
@@ -989,17 +1003,17 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pygments"
-version = "2.16.1"
+version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
-    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
+    {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
+    {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
 ]
 
 [package.extras]
-plugins = ["importlib-metadata"]
+windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyparsing"
@@ -1248,6 +1262,42 @@ lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy 
 test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
 
 [[package]]
+name = "sphinx"
+version = "7.4.7"
+description = "Python documentation generator"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239"},
+    {file = "sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe"},
+]
+
+[package.dependencies]
+alabaster = ">=0.7.14,<0.8.0"
+babel = ">=2.13"
+colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+docutils = ">=0.20,<0.22"
+imagesize = ">=1.3"
+importlib-metadata = {version = ">=6.0", markers = "python_version < \"3.10\""}
+Jinja2 = ">=3.1"
+packaging = ">=23.0"
+Pygments = ">=2.17"
+requests = ">=2.30.0"
+snowballstemmer = ">=2.2"
+sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
+sphinxcontrib-htmlhelp = ">=2.0.0"
+sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = ">=1.1.9"
+tomli = {version = ">=2", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["flake8 (>=6.0)", "importlib-metadata (>=6.0)", "mypy (==1.10.1)", "pytest (>=6.0)", "ruff (==0.5.2)", "sphinx-lint (>=0.9)", "tomli (>=2)", "types-docutils (==0.21.0.20240711)", "types-requests (>=2.30.0)"]
+test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
+
+[[package]]
 name = "sphinx-autodoc-typehints"
 version = "2.0.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
@@ -1265,6 +1315,25 @@ sphinx = ">=7.1.2"
 docs = ["furo (>=2024.1.29)"]
 numpy = ["nptyping (>=2.5)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.4.2)", "diff-cover (>=8.0.3)", "pytest (>=8.0.1)", "pytest-cov (>=4.1)", "sphobjinv (>=2.3.1)", "typing-extensions (>=4.9)"]
+
+[[package]]
+name = "sphinx-autodoc-typehints"
+version = "2.3.0"
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinx_autodoc_typehints-2.3.0-py3-none-any.whl", hash = "sha256:3098e2c6d0ba99eacd013eb06861acc9b51c6e595be86ab05c08ee5506ac0c67"},
+    {file = "sphinx_autodoc_typehints-2.3.0.tar.gz", hash = "sha256:535c78ed2d6a1bad393ba9f3dfa2602cf424e2631ee207263e07874c38fde084"},
+]
+
+[package.dependencies]
+sphinx = ">=7.3.5"
+
+[package.extras]
+docs = ["furo (>=2024.1.29)"]
+numpy = ["nptyping (>=2.5)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.4.4)", "defusedxml (>=0.7.1)", "diff-cover (>=9)", "pytest (>=8.1.1)", "pytest-cov (>=5)", "sphobjinv (>=2.3.1)", "typing-extensions (>=4.11)"]
 
 [[package]]
 name = "sphinxcontrib-apidoc"
@@ -1371,6 +1440,22 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
+    {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1458,5 +1543,5 @@ orjson = ["orjson"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8.1"
-content-hash = "0718a437065a928b337f8e182e19f39d8a00dcf478d1a6c76c3bfd83bbc46d93"
+python-versions = ">=3.8.1"
+content-hash = "7a3431e370da10f72a2f81a5f31dd1ef7e3771e959a91cfed32b00b1b1285fc5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ rdfs2dot = 'rdflib.tools.rdfs2dot:main'
 rdfgraphisomorphism = 'rdflib.tools.graphisomorphism:main'
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = ">=3.8.1"
 isodate = {version=">=0.7.2,<1.0.0", python = "<3.11"}
 pyparsing = ">=2.1.0,<4"
 berkeleydb = {version = "^18.1.0", optional = true}
@@ -62,10 +62,16 @@ setuptools = ">=68,<72"
 wheel = ">=0.42,<0.45"
 
 [tool.poetry.group.docs.dependencies]
-sphinx = ">=7.1.2,<8"
+sphinx = [
+    {version = ">=7.1.2,<7.4", python = "<3.9"},
+    {version = ">=7.4.0,<8", python = ">=3.9"},
+]
 myst-parser = ">=2,<4"
 sphinxcontrib-apidoc = ">=0.3,<0.6"
-sphinx-autodoc-typehints = ">=1.25.3,<=2.0.1"
+sphinx-autodoc-typehints = [
+    {version = ">=1.25.3,<2.3", python = "<3.9"},
+    {version = ">=2.3.0,<2.4", python = ">=3.9"},
+]
 typing-extensions = "^4.5.0"
 
 [tool.poetry.group.lint.dependencies]

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -309,52 +309,60 @@ if TYPE_CHECKING:
     import rdflib.query
     from rdflib.plugins.sparql.sparql import Query, Update
 
-_SubjectType = Node
-_PredicateType = Node
-_ObjectType = Node
-_ContextIdentifierType = IdentifiedNode
+_SubjectType: te.TypeAlias = Node
+_PredicateType: te.TypeAlias = Node
+_ObjectType: te.TypeAlias = Node
+_ContextIdentifierType: te.TypeAlias = IdentifiedNode
 
-_TripleType = Tuple["_SubjectType", "_PredicateType", "_ObjectType"]
-_QuadType = Tuple["_SubjectType", "_PredicateType", "_ObjectType", "_ContextType"]
-_OptionalQuadType = Tuple[
-    "_SubjectType", "_PredicateType", "_ObjectType", Optional["_ContextType"]
+_TripleType: te.TypeAlias = Tuple[_SubjectType, _PredicateType, _ObjectType]
+_TriplePathType: te.TypeAlias = Tuple[_SubjectType, Path, _ObjectType]
+_TripleOrTriplePathType: te.TypeAlias = Union[_TripleType, _TriplePathType]
+
+_QuadType: te.TypeAlias = Tuple[
+    _SubjectType, _PredicateType, _ObjectType, "_ContextType"
 ]
-_TripleOrOptionalQuadType = Union["_TripleType", "_OptionalQuadType"]
-_OptionalIdentifiedQuadType = Tuple[
-    "_SubjectType", "_PredicateType", "_ObjectType", Optional["_ContextIdentifierType"]
+_OptionalQuadType: te.TypeAlias = Tuple[
+    _SubjectType, _PredicateType, _ObjectType, Optional["_ContextType"]
 ]
-_TriplePatternType = Tuple[
-    Optional["_SubjectType"], Optional["_PredicateType"], Optional["_ObjectType"]
+_TripleOrOptionalQuadType: te.TypeAlias = Union[_TripleType, _OptionalQuadType]
+_OptionalIdentifiedQuadType: te.TypeAlias = Tuple[
+    _SubjectType, _PredicateType, _ObjectType, Optional[_ContextIdentifierType]
 ]
-_TriplePathPatternType = Tuple[Optional["_SubjectType"], Path, Optional["_ObjectType"]]
-_QuadPatternType = Tuple[
-    Optional["_SubjectType"],
-    Optional["_PredicateType"],
-    Optional["_ObjectType"],
+_TriplePatternType: te.TypeAlias = Tuple[
+    Optional[_SubjectType], Optional[_PredicateType], Optional[_ObjectType]
+]
+_TriplePathPatternType: te.TypeAlias = Tuple[
+    Optional[_SubjectType], Path, Optional[_ObjectType]
+]
+_QuadPatternType: te.TypeAlias = Tuple[
+    Optional[_SubjectType],
+    Optional[_PredicateType],
+    Optional[_ObjectType],
     Optional["_ContextType"],
 ]
-_QuadPathPatternType = Tuple[
-    Optional["_SubjectType"],
+_QuadPathPatternType: te.TypeAlias = Tuple[
+    Optional[_SubjectType],
     Path,
-    Optional["_ObjectType"],
+    Optional[_ObjectType],
     Optional["_ContextType"],
 ]
-_TripleOrQuadPatternType = Union["_TriplePatternType", "_QuadPatternType"]
-_TripleOrQuadPathPatternType = Union["_TriplePathPatternType", "_QuadPathPatternType"]
-_TripleSelectorType = Tuple[
-    Optional["_SubjectType"],
-    Optional[Union["Path", "_PredicateType"]],
-    Optional["_ObjectType"],
+_TripleOrQuadPatternType: te.TypeAlias = Union[_TriplePatternType, _QuadPatternType]
+_TripleOrQuadPathPatternType: te.TypeAlias = Union[
+    _TriplePathPatternType, _QuadPathPatternType
 ]
-_QuadSelectorType = Tuple[
-    Optional["_SubjectType"],
-    Optional[Union["Path", "_PredicateType"]],
-    Optional["_ObjectType"],
+_TripleSelectorType: te.TypeAlias = Tuple[
+    Optional[_SubjectType],
+    Optional[Union[Path, _PredicateType]],
+    Optional[_ObjectType],
+]
+_QuadSelectorType: te.TypeAlias = Tuple[
+    Optional[_SubjectType],
+    Optional[Union[Path, _PredicateType]],
+    Optional[_ObjectType],
     Optional["_ContextType"],
 ]
-_TripleOrQuadSelectorType = Union["_TripleSelectorType", "_QuadSelectorType"]
-_TriplePathType = Tuple["_SubjectType", Path, "_ObjectType"]
-_TripleOrTriplePathType = Union["_TripleType", "_TriplePathType"]
+_TripleOrQuadSelectorType: te.TypeAlias = Union[_TripleSelectorType, _QuadSelectorType]
+
 
 _GraphT = TypeVar("_GraphT", bound="Graph")
 _ConjunctiveGraphT = TypeVar("_ConjunctiveGraphT", bound="ConjunctiveGraph")
@@ -1896,7 +1904,7 @@ class Graph(Node):
         return subgraph
 
 
-_ContextType = Graph
+_ContextType: te.TypeAlias = Graph
 
 
 class ConjunctiveGraph(Graph):


### PR DESCRIPTION
Same as #2973 except for the 7.x branch, this is a bit different because its using the old python 3.8-compatible typing patterns, and still needs to work with sphinx-autodocs < 2.3, and sphinx < 7.4, for when running on python <3.9.

Fixes https://github.com/RDFLib/rdflib/issues/2912