### PR TITLE
Can't turn off auto-updates for Black version in pre-commit-ci, so ch…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 ---
 ci:
   # https://pre-commit.ci/#configuration
-  autoupdate_schedule: weekly
+  autoupdate_schedule: quarterly
   autofix_prs: false
 
 # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # WARNING: Ruff version should be the same as in `pyproject.toml`
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1495,4 +1495,4 @@ orjson = ["orjson"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "a4e5382d42c7ab09d4191493411f893461b534d92a05344cde1077fe29b5f4b3"
+content-hash = "bbe86c8ee32a768ab2bbcdbccf0bed6ace146a23ede0dedbe5887d1d4d1a661b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ sphinx-autodoc-typehints = ">=2.3.0,<2.4.0"
 typing-extensions = "^4.11.0"
 
 [tool.poetry.group.lint.dependencies]
-ruff = ">=0.7.1,<0.8.0"
+ruff = ">=0.7.2,<1"
 
 [tool.poetry.extras]
 berkeleydb = ["berkeleydb"]


### PR DESCRIPTION
pre-commit-ci keeps trying to auto-update to newer Black versions even though we need it pinned.
Also, keeps wanting to downgrade Poetry to v1.8.0, even though we are on v1.8.4.
Switch to quarterly updates, because we will probably bump Black and Poetry every quarter anyway.