### PR TITLE
Added Node as an exported name from the root package location. 

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -231,20 +231,17 @@ our black.toml config file:
 
     poetry run black .
 
-Check style and conventions with `flake8 <https://flake8.pycqa.org/en/latest/>`_:
+Check style and conventions with `ruff <https://docs.astral.sh/ruff/linter/>`_:
 
 .. code-block:: bash
 
-    poetry run flake8 rdflib
+    poetry run ruff check
 
-We also provide a `flakeheaven <https://pypi.org/project/flakeheaven/>`_
-baseline that ignores existing flake8 errors and only reports on newly
-introduced flake8 errors:
+Any issues that are found can potentially be fixed automatically using:
 
 .. code-block:: bash
 
-    poetry run flakeheaven
-
+   poetry run ruff check --fix
 
 Check types with `mypy <http://mypy-lang.org/>`_:
 

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "BNode",
     "IdentifiedNode",
     "Literal",
+    "Node",
     "Variable",
     "Namespace",
     "Dataset",
@@ -195,7 +196,7 @@ from rdflib.namespace import (
     XSD,
     Namespace,
 )
-from rdflib.term import BNode, IdentifiedNode, Literal, URIRef, Variable
+from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef, Variable
 
 from rdflib import plugin, query, util  # isort:skip
 from rdflib.container import *  # isort:skip # noqa: F403


### PR DESCRIPTION
# Summary of changes

- Added `Node` as an exported name from root package i.e. `rdflib.Node`. A little bugbear i've had when writing
type annotations, currently using importing `rdflib.term` specifically to do so.
- Updated the linting commands section of the docs to reflect the move over to ruff from flake8.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

