### PR TITLE
Fixed incorrect ASK behaviour for dataset with one element

### DIFF
--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -1483,7 +1483,7 @@ ConstructQuery = Comp(
 AskQuery = Comp(
     "AskQuery",
     Keyword("ASK")
-    + Param("datasetClause", ZeroOrMore(DatasetClause))
+    + ZeroOrMore(ParamList("datasetClause", DatasetClause))
     + WhereClause
     + SolutionModifier
     + ValuesClause,

--- a/test/test_sparql/test_dataset_exclusive.py
+++ b/test/test_sparql/test_dataset_exclusive.py
@@ -82,3 +82,13 @@ def test_from_and_from_named():
         (None, URIRef("urn:s1"), URIRef("urn:p1"), URIRef("urn:o1")),
         (URIRef("urn:g2"), URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")),
     ]
+
+
+def test_ask_from():
+    query = """
+        ASK
+        FROM <urn:g1>
+        WHERE {?s ?p ?o}
+    """
+    results = bool(dataset.query(query))
+    assert results


### PR DESCRIPTION
# Summary of changes
 - Fixed incorrect behaviour for ASK queries with a single FROM or FROM NAMED statement.
 - Previously, the dataset clause would be a single element instead of a singleton list, leading to the query failing.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

