### PR TITLE
feat: sort longturtle blank nodes

### DIFF
--- a/rdflib/plugins/serializers/longturtle.py
+++ b/rdflib/plugins/serializers/longturtle.py
@@ -293,7 +293,34 @@ class LongTurtleSerializer(RecursiveSerializer):
     def verb(self, node, newline=False):
         self.path(node, VERB, newline)
 
+    def sortObjects(
+        self, values: list[URIRef | BNode | Literal]
+    ) -> list[URIRef | BNode | Literal]:
+        """
+        Perform a sort on the values where each value is a blank node. Grab the CBD of the
+        blank node and sort it by its longturtle serialization value.
+
+        Identified nodes come first and the sorted blank nodes are tacked on after.
+        """
+        bnode_map: dict[BNode, list[str]] = {}
+        objects = []
+        for value in values:
+            if isinstance(value, BNode):
+                bnode_map[value] = []
+            else:
+                objects.append(value)
+
+        for bnode in bnode_map:
+            cbd = self.store.cbd(bnode).serialize(format="longturtle")
+            bnode_map[bnode].append(cbd)
+
+        sorted_bnodes = sorted(
+            [(k, v) for k, v in bnode_map.items()], key=lambda x: x[1]
+        )
+        return objects + [x[0] for x in sorted_bnodes]
+
     def objectList(self, objects):
+        objects = self.sortObjects(objects)
         count = len(objects)
         if count == 0:
             return

--- a/rdflib/plugins/serializers/longturtle.py
+++ b/rdflib/plugins/serializers/longturtle.py
@@ -330,6 +330,8 @@ class LongTurtleSerializer(RecursiveSerializer):
         if count > 1:
             if not isinstance(objects[0], BNode):
                 self.write("\n" + self.indent(1))
+            else:
+                self.write(" ")
             first_nl = True
         self.path(objects[0], OBJECT, newline=first_nl)
         for obj in objects[1:]:

--- a/test/data/longturtle/longturtle-target.ttl
+++ b/test/data/longturtle/longturtle-target.ttl
@@ -1,0 +1,74 @@
+PREFIX cn: <https://linked.data.gov.au/def/cn/>
+PREFIX ex: <http://example.com/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX sdo: <https://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ex:nicholas
+    a sdo:Person ;
+    sdo:age 41 ;
+    sdo:alternateName
+        "N.J. Car" ,
+        "Nick Car" ,
+        [
+            sdo:name "Dr N.J. Car" ;
+        ] ;
+    sdo:name
+        [
+            a cn:CompoundName ;
+            sdo:hasPart 
+                [
+                    a cn:CompoundName ;
+                    rdf:value "John" ;
+                ] ,
+                [
+                    a cn:CompoundName ;
+                    rdf:value "Nicholas" ;
+                ] ,
+                [
+                    a cn:CompoundName ;
+                    sdo:hasPart 
+                        [
+                            a cn:CompoundName ;
+                            rdf:value "Car" ;
+                        ] ,
+                        [
+                            a cn:CompoundName ;
+                            rdf:value "Maxov" ;
+                        ] ;
+                ] ;
+        ] ;
+    sdo:worksFor <https://kurrawong.ai> ;
+.
+
+<https://kurrawong.ai>
+    a sdo:Organization ;
+    sdo:location <https://kurrawong.ai/hq> ;
+.
+
+<https://kurrawong.ai/hq>
+    a sdo:Place ;
+    sdo:address
+        [
+            a sdo:PostalAddress ;
+            sdo:addressCountry
+                [
+                    sdo:identifier "au" ;
+                    sdo:name "Australia" ;
+                ] ;
+            sdo:addressLocality "Shorncliffe" ;
+            sdo:addressRegion "QLD" ;
+            sdo:postalCode 4017 ;
+            sdo:streetAddress (
+                72
+                "Yundah"
+                "Street"
+            ) ;
+        ] ;
+    sdo:geo
+        [
+            sdo:polygon "POLYGON((153.082403 -27.325801, 153.08241 -27.32582, 153.082943 -27.325612, 153.083010 -27.325742, 153.083543 -27.325521, 153.083456 -27.325365, 153.082403 -27.325801))"^^geo:wktLiteral ;
+        ] ;
+    sdo:name "KurrawongAI HQ" ;
+.

--- a/test/test_serializers/test_serializer_longturtle.py
+++ b/test/test_serializers/test_serializer_longturtle.py
@@ -182,22 +182,22 @@ def test_longturtle():
         a sdo:Person ;
         sdo:age 41 ;
         sdo:alternateName
+            "N.J. Car" ,
+            "Nick Car" ,
             [
                 sdo:name "Dr N.J. Car" ;
-            ] ,
-            "N.J. Car" ,
-            "Nick Car" ;
+            ] ;
         sdo:name
             [
                 a cn:CompoundName ;
                 sdo:hasPart
                     [
                         a cn:CompoundName ;
-                        rdf:value "Nicholas" ;
+                        rdf:value "John" ;
                     ] ,
                     [
                         a cn:CompoundName ;
-                        rdf:value "John" ;
+                        rdf:value "Nicholas" ;
                     ] ,
                     [
                         a cn:CompoundName ;

--- a/test/test_serializers/test_serializer_longturtle.py
+++ b/test/test_serializers/test_serializer_longturtle.py
@@ -1,5 +1,5 @@
 import difflib
-from textwrap import dedent
+from pathlib import Path
 
 from rdflib import Graph, Namespace
 from rdflib.namespace import GEO, SDO
@@ -170,83 +170,11 @@ def test_longturtle():
     output = g.serialize(format="longturtle")
 
     # fix the target
-    target = dedent(
-        """    PREFIX cn: <https://linked.data.gov.au/def/cn/>
-    PREFIX ex: <http://example.com/>
-    PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-    PREFIX sdo: <https://schema.org/>
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    current_dir = Path.cwd()  # Get the current directory
+    target_file_path = current_dir / "test/data/longturtle" / "longturtle-target.ttl"
 
-    ex:nicholas
-        a sdo:Person ;
-        sdo:age 41 ;
-        sdo:alternateName
-            "N.J. Car" ,
-            "Nick Car" ,
-            [
-                sdo:name "Dr N.J. Car" ;
-            ] ;
-        sdo:name
-            [
-                a cn:CompoundName ;
-                sdo:hasPart
-                    [
-                        a cn:CompoundName ;
-                        rdf:value "John" ;
-                    ] ,
-                    [
-                        a cn:CompoundName ;
-                        rdf:value "Nicholas" ;
-                    ] ,
-                    [
-                        a cn:CompoundName ;
-                        sdo:hasPart
-                            [
-                                a cn:CompoundName ;
-                                rdf:value "Car" ;
-                            ] ,
-                            [
-                                a cn:CompoundName ;
-                                rdf:value "Maxov" ;
-                            ] ;
-                    ] ;
-            ] ;
-        sdo:worksFor <https://kurrawong.ai> ;
-    .
-
-    <https://kurrawong.ai>
-        a sdo:Organization ;
-        sdo:location <https://kurrawong.ai/hq> ;
-    .
-
-    <https://kurrawong.ai/hq>
-        a sdo:Place ;
-        sdo:address
-            [
-                a sdo:PostalAddress ;
-                sdo:addressCountry
-                    [
-                        sdo:identifier "au" ;
-                        sdo:name "Australia" ;
-                    ] ;
-                sdo:addressLocality "Shorncliffe" ;
-                sdo:addressRegion "QLD" ;
-                sdo:postalCode 4017 ;
-                sdo:streetAddress (
-                    72
-                    "Yundah"
-                    "Street"
-                ) ;
-            ] ;
-        sdo:geo
-            [
-                sdo:polygon "POLYGON((153.082403 -27.325801, 153.08241 -27.32582, 153.082943 -27.325612, 153.083010 -27.325742, 153.083543 -27.325521, 153.083456 -27.325365, 153.082403 -27.325801))"^^geo:wktLiteral ;
-            ] ;
-        sdo:name "KurrawongAI HQ" ;
-    .
-    """
-    )
+    with open(target_file_path, encoding="utf-8") as file:
+        target = file.read()
 
     # compare output to target
     # - any differences will produce output


### PR DESCRIPTION
# Summary of changes

### Fixes https://github.com/RDFLib/rdflib/issues/1890 - Sorting Turtle output?

This change improves git diffing Turtle data serialized with the `longturtle` serializer. Previously, blank nodes were not sorted, and round-trips using RDFLib's `turtle` parser and `longturtle` serializer would have blank node objects flip flop around, making it difficult to read real changes using git diff.

This PR fixes the above by implementing a sort on values where triples in the object position are blank nodes. The blank nodes are sorted by grabbing their concise-bounded description graph and sorting it as a string in their `longturtle` serialization.

This adds an additional cost to the `longturtle` serializer, but I think the cost is worth it if we are after a deterministic output with blank nodes.

Note that this depends on RDF data parsed using the `turtle` parser and its behaviour of how it assigns blank nodes. Exact serialization with data added via the graph object cannot be guaranteed. This would require implementing RDF Canonicalization to guarantee the same blank node identifiers in the graph.

Once RDF Canonicalization is implemented, sorting by the blank node identifier directly will be enough to guarantee deterministic serialization, and the expensive CBD sorting can be removed.

Update: looks like top-level blank nodes with no inbound relationships don't get sorted. I think this makes sense since we're only applying the sort to blank nodes in the object position. If we cared about sorting blank nodes in the subject position, we can apply the same kind of sorting based on the text serialization of the CBD onto the subject blank nodes.

https://github.com/RDFLib/rdflib/blob/08dd4b79f84638250529adb650c75a3305bad66d/rdflib/plugins/serializers/longturtle.py#L106-L112

### Fixes https://github.com/RDFLib/rdflib/issues/2767 - Bug in `longturtle` serialization

This PR also fixes the missing trailing whitespace in the special case described by @mschiedon.

> The longturtle serializer fails to emit a whitespace separator between a predicate and a list of objects if one of these objects is a blank node (and the blank node cannot be 'inlined', i.e. is used more than once)

This fix was previously fixed in PR https://github.com/RDFLib/rdflib/pull/2700 but was inadvertently reverted in PR https://github.com/RDFLib/rdflib/pull/2731 when I was trying to fix the ruff linting rule in the test case. To get around the ruff linting rule, I've now moved the target result of the test case into a text file.

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

