### PR TITLE
jsonld: Do not merge nodes with different invalid URIs

### DIFF
--- a/test/jsonld/local-suite/manifest.jsonld
+++ b/test/jsonld/local-suite/manifest.jsonld
@@ -27,6 +27,17 @@
       "purpose": "Multiple @id aliases.  Issue #2164",
       "input": "toRdf-twoimports-in.jsonld",
       "expect": "toRdf-twoimports-out.nq"
+    },
+    {
+      "@id": "#toRdf-two-invalid-ids",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Two invalid identifiers",
+      "purpose": "Multiple nodes with invalid @ids are not merged together.",
+      "option": {
+        "produceGeneralizedRdf": true
+      },
+      "input": "toRdf-twoinvalidids-in.jsonld",
+      "expect": "toRdf-twoinvalidids-out.nq"
     }
   ]
 }

--- a/test/jsonld/local-suite/toRdf-twoinvalidids-in.jsonld
+++ b/test/jsonld/local-suite/toRdf-twoinvalidids-in.jsonld
@@ -1,0 +1,20 @@
+{
+    "@id": "https://example.org/root-object",
+    "https://schema.org/author": [
+        {
+            "@id": "https://example.org/ invalid url 1",
+            "https://schema.org/name": "Jane Doe"
+        },
+        {
+            "@id": "https://example.org/ invalid url 1",
+            "https://schema.org/givenName": "Jane",
+            "https://schema.org/familyName": "Doe"
+        },
+        {
+            "@id": "https://example.org/ invalid url 2",
+            "https://schema.org/name": "John Doe",
+            "https://schema.org/givenName": "John",
+            "https://schema.org/familyName": "Doe"
+        }
+    ]
+}

--- a/test/jsonld/local-suite/toRdf-twoinvalidids-out.nq
+++ b/test/jsonld/local-suite/toRdf-twoinvalidids-out.nq
@@ -1,0 +1,10 @@
+
+<https://example.org/root-object> <https://schema.org/author> _:b1.
+<https://example.org/root-object> <https://schema.org/author> _:b2.
+
+_:b1 <https://schema.org/name> "Jane Doe".
+_:b1 <https://schema.org/givenName> "Jane".
+_:b1 <https://schema.org/familyName> "Doe".
+_:b2 <https://schema.org/name> "John Doe".
+_:b2 <https://schema.org/givenName> "John".
+_:b2 <https://schema.org/familyName> "Doe".


### PR DESCRIPTION
# Summary of changes

When parsing JSON-LD with invalid URIs in the `@id`, the `generalized_rdf: True` option allows parsing these nodes as blank nodes instead of outright rejecting the document.

However, all nodes with invalid URIs were mapped to the same blank node, resulting in incorrect data. For example, without this patch, the new test fails with:

```
AssertionError: Expected:
@prefix schema: <https://schema.org/> .

<https://example.org/root-object> schema:author [ schema:familyName "Doe" ;
            schema:givenName "Jane" ;
            schema:name "Jane Doe" ],
        [ schema:familyName "Doe" ;
            schema:givenName "John" ;
            schema:name "John Doe" ] .

Got:
@prefix schema: <https://schema.org/> .

<https://example.org/root-object> schema:author <> .

<> schema:familyName "Doe" ;
    schema:givenName "Jane",
        "John" ;
    schema:name "Jane Doe",
        "John Doe" .
```

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation. -> should this be documented in `generalized_rdf`'s description? It's not clear to me what the spec says should happen to invalid URIs here
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

