### PR TITLE
remove old hacks against 2to3

### DIFF
--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -298,8 +298,7 @@ class RDFXMLHandler(handler.ContentHandler):
         self, name: Tuple[str, str], qname, attrs: AttributesImpl
     ) -> None:
         if name[0] and URIRef("".join(name)) == RDFVOC.RDF:
-            # Cheap hack so 2to3 doesn't turn it into __next__
-            next = getattr(self, "next")
+            next = self.next
             next.start = self.node_element_start
             next.end = self.node_element_end
         else:
@@ -316,8 +315,7 @@ class RDFXMLHandler(handler.ContentHandler):
         current = self.current
         absolutize = self.absolutize
 
-        # Cheap hack so 2to3 doesn't turn it into __next__
-        next = getattr(self, "next")
+        next = self.next
         next.start = self.property_element_start
         next.end = self.property_element_end
 
@@ -410,8 +408,7 @@ class RDFXMLHandler(handler.ContentHandler):
         current = self.current
         absolutize = self.absolutize
 
-        # Cheap hack so 2to3 doesn't turn it into __next__
-        next = getattr(self, "next")
+        next = self.next
         object: Optional[_ObjectType] = None
         current.data = None
         current.list = None

--- a/rdflib/plugins/stores/berkeleydb.py
+++ b/rdflib/plugins/stores/berkeleydb.py
@@ -428,8 +428,7 @@ class BerkeleyDB(Store):
                 cursor = index.cursor(txn=txn)
                 try:
                     cursor.set_range(key)
-                    # Hack to stop 2to3 converting this to next(cursor)
-                    current = getattr(cursor, "next")()
+                    current = cursor.next
                 except db.DBNotFoundError:
                     current = None
                 cursor.close()
@@ -506,8 +505,7 @@ class BerkeleyDB(Store):
             cursor = index.cursor(txn=txn)
             try:
                 cursor.set_range(key)
-                # Cheap hack so 2to3 doesn't convert to next(cursor)
-                current = getattr(cursor, "next")()
+                current = cursor.next
             except db.DBNotFoundError:
                 current = None
             cursor.close()
@@ -539,8 +537,7 @@ class BerkeleyDB(Store):
             key, value = current
             if key.startswith(prefix):
                 count += 1
-                # Hack to stop 2to3 converting this to next(cursor)
-                current = getattr(cursor, "next")()
+                current = cursor.next
             else:
                 break
         cursor.close()
@@ -593,8 +590,7 @@ class BerkeleyDB(Store):
         while current:
             prefix, namespace = current
             results.append((prefix.decode("utf-8"), namespace.decode("utf-8")))
-            # Hack to stop 2to3 converting this to next(cursor)
-            current = getattr(cursor, "next")()
+            current = cursor.next
         cursor.close()
         for prefix, namespace in results:
             yield prefix, URIRef(namespace)
@@ -637,8 +633,7 @@ class BerkeleyDB(Store):
                 cursor = index.cursor()
                 try:
                     cursor.set_range(key)
-                    # Hack to stop 2to3 converting this to next(cursor)
-                    current = getattr(cursor, "next")()
+                    current = cursor.next
                 except db.DBNotFoundError:
                     current = None
                 cursor.close()


### PR DESCRIPTION
I noticed this while reviewing the last traces of `2to3` in Debian Testing.

Greetings

This reverts e2fb491a3da80f9e01f3303b3df24881ab41eefa from 2011.