### PR TITLE
7.1.4 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 2025-03-29 RELEASE 7.1.4
+
+A tidy-up release with no major updates over 7.1.3. This may be the last 7.x 
+release as we move to a version 8 with breaking changes to Dataset and a few
+APIs.
+
+Interesting PRs merged:
+
+* 2025-03-24 - remove old hacks against 2to3
+  [PR #3095](https://github.com/RDFLib/rdflib/pull/3095)
+* 2025-03-24 - Allow multi subjects & objects in graph funcs
+  [PR #3086](https://github.com/RDFLib/rdflib/pull/3086)
+* 2025-03-24 - Reduce test warnings
+  [PR #3085](https://github.com/RDFLib/rdflib/pull/3085)
+* 2025-03-22 - Downgrade log message about plugin
+  [PR #3063](https://github.com/RDFLib/rdflib/pull/3063)
+* 2025-03-22 - remove old hacks against 2to3
+  [PR #3076](https://github.com/RDFLib/rdflib/pull/3076)
+* 2025-03-22 - Cope with Namespace annotations in Python 3.14
+  [PR #3084](https://github.com/RDFLib/rdflib/pull/3084)
+* 2025-01-18 - small docco update
+  [PR #3053](https://github.com/RDFLib/rdflib/pull/3053)
+
+... and lots of boring dependency bump PRs merged!
+
 ## 2025-01-17 RELEASE 7.1.3
 
 A fix-up release that re-adds support for Python 3.8 after it was accidentally 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Help with maintenance of all of the RDFLib family of packages is always welcome 
 
 ## Versions & Releases
 
-* `main` branch in this repository is the current unstable release
+* `main` branch in this repository is the current unstable release - version 8 alpha
+* `7.1.4` tidy-up release, possibly last 7.x release
 * `7.1.3` current stable release, small improvements to 7.1.1
 * `7.1.2` previously deleted release
 * `7.1.1` previous stable release

--- a/admin/get_merged_prs.py
+++ b/admin/get_merged_prs.py
@@ -5,7 +5,7 @@ import urllib.parse
 import urllib.request
 
 # https://api.github.com/search/issues?q=repo:rdflib/rdflib+is:pr+merged:%3E=2023-08-02&per_page=300&page=1
-LAST_RELEASE_DATE = "2024-10-17"
+LAST_RELEASE_DATE = "2025-01-18"
 ISSUES_URL = "https://api.github.com/search/issues"
 ITEMS = []
 PAGE = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rdflib"
-version = "7.1.4a"
+version = "7.1.4"
 description = """RDFLib is a Python library for working with RDF, \
 a simple yet powerful language for representing information."""
 authors = ["Daniel 'eikeon' Krech <eikeon@eikeon.com>"]

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -52,7 +52,7 @@ _DISTRIBUTION_METADATA = metadata.metadata("rdflib")
 __docformat__ = "restructuredtext en"
 
 __version__: str = _DISTRIBUTION_METADATA["Version"]
-__date__ = "2025-01-18"
+__date__ = "2025-03-29"
 
 __all__ = [
     "URIRef",


### PR DESCRIPTION
A tidy-up release with no major updates over 7.1.3. This may be the last 7.x release as we move to a version 8 with breaking changes to Dataset and a few APIs.

Fixed some small pre-commit issues too