### PR TITLE
Improve `SPARQLStore` type annotations and add optional (opt-in) tests against public endpoints

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -93,7 +93,7 @@ solely on the basis that it was not discussed upfront.
 RDFLib follows `semantic versioning <https://semver.org/spec/v2.0.0.html>`_ and `trunk-based development
 <https://trunkbaseddevelopment.com/>`_, so if any breaking changes were
 introduced into the main branch since the last release, then the next release
-will be a major release with an incremented major version. 
+will be a major release with an incremented major version.
 
 Releases of RDFLib will not as a rule be conditioned on specific features, so
 there may be new major releases that contain very few breaking changes, and
@@ -200,6 +200,15 @@ executing the tests.
 
    $ poetry install --all-extras
    $ poetry run pytest
+
+By default tests of the ``SPARQLStore`` against remote public endpoints are skipped, to enable them add the flag:
+
+.. code-block:: console
+
+   $ poetry run pytest --public-endpoints
+   $ # Or exclusively run the SPARQLStore tests:
+   $ poetry run pytest test/test_store/test_store_sparqlstore_public.py --public-endpoints
+
 
 Writing tests
 ~~~~~~~~~~~~~
@@ -406,7 +415,7 @@ container:
 
     # Inside the repository base directory
     cd ./rdflib/
-    
+
     # Build the development container.
     devcontainer build .
 
@@ -448,7 +457,7 @@ Create a release-preparation pull request with the following changes:
 * Updated version and date in ``CITATION.cff``.
 * Updated copyright year in the ``LICENSE`` file.
 * Updated copyright year in the ``docs/conf.py`` file.
-* Updated main branch version and current version in the ``README.md`` file. 
+* Updated main branch version and current version in the ``README.md`` file.
 * Updated version in the ``pyproject.toml`` file.
 * Updated ``__date__`` in the ``rdflib/__init__.py`` file.
 * Accurate ``CHANGELOG.md`` entry for the release.
@@ -456,7 +465,7 @@ Create a release-preparation pull request with the following changes:
 Once the PR is merged, switch to the main branch, build the release and upload it to PyPI:
 
 .. code-block:: bash
-    
+
     # Clean up any previous builds
     \rm -vf dist/*
 
@@ -468,7 +477,7 @@ Once the PR is merged, switch to the main branch, build the release and upload i
     bsdtar -xvf dist/rdflib-*.tar.gz -O '*/PKG-INFO' | view -
 
     # Check that the built wheel and sdist works correctly:
-    ## Ensure pipx is installed but not within RDFLib's environment 
+    ## Ensure pipx is installed but not within RDFLib's environment
     pipx run --no-cache --spec "$(readlink -f dist/rdflib*.whl)" rdfpipe --version
     pipx run --no-cache --spec "$(readlink -f dist/rdflib*.whl)" rdfpipe https://github.com/RDFLib/rdflib/raw/main/test/data/defined_namespaces/rdfs.ttl
     pipx run --no-cache --spec "$(readlink -f dist/rdflib*.tar.gz)" rdfpipe --version
@@ -485,7 +494,7 @@ Once the PR is merged, switch to the main branch, build the release and upload i
     # Publish to PyPI
     poetry publish
     ## poetry publish -u __token__ -p pypi-<REDACTED>
-    
+
 
 Once this is done, create a release tag from `GitHub releases
 <https://github.com/RDFLib/rdflib/releases/new>`_. For a release of version

--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -442,23 +442,23 @@ class _TripleCanonicalizer:
             experimental = self._experimental_path(coloring_copy)
             experimental_score = set([c.key() for c in experimental])
             if last_coloring:
-                generator = self._create_generator(  # type: ignore[unreachable]
+                generator = self._create_generator(
                     [last_coloring, experimental], generator
                 )
             last_coloring = experimental
-            if best_score is None or best_score < color_score:  # type: ignore[unreachable]
+            if best_score is None or best_score < color_score:
                 best = [refined_coloring]
                 best_score = color_score
                 best_experimental_score = experimental_score
-            elif best_score > color_score:  # type: ignore[unreachable]
+            elif best_score > color_score:
                 # prune this branch.
-                if stats is not None:
+                if stats is not None and isinstance(stats["prunings"], int):
                     stats["prunings"] += 1
             elif experimental_score != best_experimental_score:
                 best.append(refined_coloring)
             else:
                 # prune this branch.
-                if stats is not None:
+                if stats is not None and isinstance(stats["prunings"], int):
                     stats["prunings"] += 1
         discrete: list[list[Color]] = [x for x in best if self._discrete(x)]
         if len(discrete) == 0:
@@ -468,7 +468,7 @@ class _TripleCanonicalizer:
                 d = [depth[0]]
                 new_color = self._traces(coloring, stats=stats, depth=d)
                 color_score = tuple([c.key() for c in refined_coloring])
-                if best_score is None or color_score > best_score:  # type: ignore[unreachable]
+                if best_score is None or color_score > best_score:
                     discrete = [new_color]
                     best_score = color_score
                     best_depth = d[0]

--- a/rdflib/plugins/parsers/jsonld.py
+++ b/rdflib/plugins/parsers/jsonld.py
@@ -663,7 +663,7 @@ class Parser:
 
             if rest:
                 # type error: Statement is unreachable
-                graph.add((subj, RDF.rest, rest))  # type: ignore[unreachable]
+                graph.add((subj, RDF.rest, rest))
                 subj = rest
 
             obj = self._to_object(dataset, graph, context, term, node, inlist=True)

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     import typing_extensions as te
 
+    SUPPORTED_METHODS = te.Literal["GET", "POST", "POST_FORM"]
+    SUPPORTED_FORMATS = te.Literal["xml", "json", "csv", "tsv", "application/rdf+xml"]
+
 
 class SPARQLConnectorException(Exception):  # noqa: N818
     pass
@@ -41,8 +44,8 @@ class SPARQLConnector:
         self,
         query_endpoint: str | None = None,
         update_endpoint: str | None = None,
-        returnFormat: str = "xml",  # noqa: N803
-        method: te.Literal["GET", "POST", "POST_FORM"] = "GET",
+        returnFormat: SUPPORTED_FORMATS = "xml",  # noqa: N803
+        method: SUPPORTED_METHODS = "GET",
         auth: tuple[str, str] | None = None,
         **kwargs,
     ):

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -123,7 +123,7 @@ class NodePickler:
         up = Unpickler(BytesIO(s))
         # NOTE on type error: https://github.com/python/mypy/issues/2427
         # type error: Cannot assign to a method
-        up.persistent_load = self._get_object  # type: ignore[assignment]
+        up.persistent_load = self._get_object
         try:
             return up.load()
         except KeyError as e:
@@ -134,7 +134,7 @@ class NodePickler:
         p = Pickler(src)
         # NOTE on type error: https://github.com/python/mypy/issues/2427
         # type error: Cannot assign to a method
-        p.persistent_id = self._get_ids  # type: ignore[assignment]
+        p.persistent_id = self._get_ids
         p.dump(obj)
         return src.getvalue()
 

--- a/test/test_store/test_store_sparqlstore_public.py
+++ b/test/test_store/test_store_sparqlstore_public.py
@@ -1,0 +1,208 @@
+import json
+
+import pytest
+
+from rdflib import Dataset
+from rdflib.plugins.sparql.results.jsonresults import JSONResult
+from rdflib.plugins.sparql.results.xmlresults import XMLResult
+from rdflib.plugins.stores.sparqlstore import SPARQLStore
+from rdflib.query import Result
+
+# Mark all tests in this module as public_endpoints
+# They will be skipped by default, unless the --public-endpoints flag is passed to pytest
+pytestmark = pytest.mark.public_endpoints
+
+
+# NOTE: dbpedia virtuoso can be unstable, sometimes everything working as expected
+# But it has phases where sometimes it sends (405, 'HTTP Error 405: Not Allowed', None), or urllib.error.HTTPError: HTTP Error 502: Bad Gateway
+# While accessing the endpoint directly in the browser works fine (so this is not a network issue or the endpoint being down), classic virtuoso
+VIRTUOSO_8_DBPEDIA = "https://dbpedia.org/sparql"
+BLAZEGRAPH_WIKIDATA = "https://query.wikidata.org/sparql"
+GRAPHDB_FF = "http://factforge.net/repositories/ff-news"  # http://factforge.net/
+RDF4J_GEOSCIML = "http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2018-revised-corrected"
+ALLEGROGRAPH_AGROVOC = "https://agrovoc.fao.org/sparql"
+ALLEGROGRAPH_4_MMI = "https://mmisw.org/sparql"  # AllegroServe/1.3.28 http://mmisw.org:10035/doc/release-notes.html
+FUSEKI_LOV = "https://lov.linkeddata.es/dataset/lov/sparql"  # Fuseki - version 1.1.1 (Build date: 2014-10-02T16:36:17+0100)
+FUSEKI2_STW = "http://zbw.eu/beta/sparql/stw/query"  # Fuseki 3.8.0 (Fuseki2)
+STARDOG_LINDAS = (
+    "https://lindas.admin.ch/query"  # human UI https://lindas.admin.ch/sparql/
+)
+STORE4_CHISE = "http://rdf.chise.org/sparql"  # 4store SPARQL server v1.1.4
+QLEVER_WIKIDATA = "https://qlever.cs.uni-freiburg.de/api/wikidata"  # https://qlever.cs.uni-freiburg.de/wikidata
+
+
+@pytest.fixture(
+    params=[
+        VIRTUOSO_8_DBPEDIA,
+        GRAPHDB_FF,
+        ALLEGROGRAPH_AGROVOC,
+        ALLEGROGRAPH_4_MMI,
+        BLAZEGRAPH_WIKIDATA,
+        FUSEKI_LOV,
+        RDF4J_GEOSCIML,
+        STARDOG_LINDAS,
+        STORE4_CHISE,
+        FUSEKI2_STW,
+        QLEVER_WIKIDATA,
+    ]
+)
+def endpoint(request):
+    return request.param
+
+
+def query_sparql(query, endpoint, return_format, method):
+    """Generic function to make a SPARQL request and return the result"""
+    g = Dataset(
+        SPARQLStore(endpoint, returnFormat=return_format, method=method),
+        default_union=True,
+    )
+    return g.query(query)
+
+
+METHODS_SUPPORTED = ["GET", "POST", "POST_FORM"]
+
+## SELECT and ASK
+
+ROWS_TYPES_MAP = {
+    "xml": XMLResult,
+    "json": JSONResult,
+    "csv": Result,
+    "tsv": Result,
+}
+
+
+@pytest.mark.parametrize("return_format", ROWS_TYPES_MAP.keys())
+@pytest.mark.parametrize("method", METHODS_SUPPORTED)
+def test_select_query(endpoint, return_format, method):
+    """Test SELECT queries with various return formats and methods"""
+    if endpoint in [STORE4_CHISE, FUSEKI2_STW] and method in ["POST", "POST_FORM"]:
+        pytest.skip(f"{endpoint} does not support POST requests")
+    if endpoint in [FUSEKI_LOV] and method == "POST":
+        pytest.skip("Return type issue with POST requests")
+        # NOTE: getting rdflib.plugin.PluginException: No plugin registered for (text/plain, <class 'rdflib.query.ResultParser'>)
+
+    query = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5"
+    res = query_sparql(query, endpoint, return_format, method)
+    assert isinstance(res, ROWS_TYPES_MAP[return_format])
+    assert len(res) > 3
+
+    res_json = json.loads(res.serialize(format="json"))
+    assert len(res_json["results"]["bindings"]) > 3
+
+
+# NOTE: an error usually returns a tuple, e.g. (404, 'HTTP Error 404: Not Found', None)
+# But sometimes it can also throws it
+
+
+@pytest.mark.parametrize("return_format", ROWS_TYPES_MAP.keys())
+@pytest.mark.parametrize("method", METHODS_SUPPORTED)
+def test_ask_query(endpoint, return_format, method):
+    """Test ASK queries with various return formats and methods"""
+    if endpoint in [STORE4_CHISE, FUSEKI2_STW] and method in ["POST", "POST_FORM"]:
+        pytest.skip("POST requests not supported")
+    if endpoint in [STORE4_CHISE] and method == "GET" and return_format == "tsv":
+        pytest.skip("TSV not supported with GET requests")
+    if endpoint in [
+        QLEVER_WIKIDATA,
+        ALLEGROGRAPH_4_MMI,
+        GRAPHDB_FF,
+        RDF4J_GEOSCIML,
+        STARDOG_LINDAS,
+    ] and return_format in ["csv", "tsv"]:
+        pytest.skip("CSV/TSV not supported for ASK query type")
+    if endpoint in [VIRTUOSO_8_DBPEDIA] and return_format == "tsv":
+        pytest.skip("TSV not supported for ASK query type")
+    if endpoint in [FUSEKI_LOV] and method == "POST":
+        pytest.skip("Return type issue with POST requests")
+        # NOTE: getting rdflib.plugin.PluginException: No plugin registered for (text/plain, <class 'rdflib.query.ResultParser'>)
+
+    query = "ASK WHERE { ?s ?p ?o }"
+    res = query_sparql(query, endpoint, return_format, method)
+    assert isinstance(res, ROWS_TYPES_MAP[return_format])
+    for row in res:
+        if return_format in ["csv", "tsv"] and not isinstance(row, bool):
+            # NOTE: Sometimes CSV/TSV with ASK returns a tuple. But sometimes it returns a boolean (e.g. wikidata)
+            assert len(row) == 1
+            assert row[0].toPython() in [True, "true", "1"]
+            # And yes the content of the tuple can be one of the 3 above
+        else:
+            # So it is highly recommended to use XML or JSON for consistency
+            assert row is True
+
+
+## CONSTRUCT and DESCRIBE
+
+RDF_TYPES_MAP = {
+    "xml": Result,
+    "application/rdf+xml": Result,
+    # "turtle": Result,
+    # NOTE: Turtle not in SPARQLConnector list of _response_mime_types
+    # Only XML available for RDF results
+}
+
+
+@pytest.mark.parametrize("return_format", RDF_TYPES_MAP.keys())
+@pytest.mark.parametrize("method", METHODS_SUPPORTED)
+def test_construct_query(endpoint, return_format, method):
+    """Test CONSTRUCT queries with various return formats and methods"""
+    if endpoint in [STORE4_CHISE, FUSEKI2_STW] and method in ["POST", "POST_FORM"]:
+        pytest.skip(f"{endpoint} does not support POST requests")
+    if endpoint in [FUSEKI_LOV] and method == "POST":
+        pytest.skip("Return type issue with POST requests")
+        # NOTE: getting rdflib.plugin.PluginException: No plugin registered for (text/plain, <class 'rdflib.query.ResultParser'>)
+    if endpoint in [QLEVER_WIKIDATA]:
+        pytest.skip("Qlever does not support application/rdf+xml")
+
+    query = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 5"
+    res = query_sparql(query, endpoint, return_format, method)
+    assert isinstance(res, RDF_TYPES_MAP[return_format])
+    assert len(res) > 3
+
+    # Test if serialization works
+    res_g = Dataset()
+    res_g.parse(res.serialize(format="ttl"), format="ttl")
+    assert len(res_g) > 3
+
+
+@pytest.mark.parametrize("return_format", RDF_TYPES_MAP.keys())
+@pytest.mark.parametrize("method", METHODS_SUPPORTED)
+def test_describe_query(endpoint, return_format, method):
+    """Test DESCRIBE queries with various return formats and methods"""
+    if endpoint in [STORE4_CHISE, FUSEKI2_STW] and method in ["POST", "POST_FORM"]:
+        pytest.skip(f"{endpoint} does not support POST requests")
+    if endpoint in [FUSEKI_LOV] and method == "POST":
+        pytest.skip("Return type issue with POST requests")
+        # NOTE: getting rdflib.plugin.PluginException: No plugin registered for (text/plain, <class 'rdflib.query.ResultParser'>)
+    if endpoint in [QLEVER_WIKIDATA] and return_format in [
+        "xml",
+        "application/rdf+xml",
+    ]:
+        pytest.skip("Qlever does not support application/rdf+xml")
+
+    query = "DESCRIBE <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"
+    res = query_sparql(query, endpoint, return_format, method)
+    assert isinstance(res, RDF_TYPES_MAP[return_format])
+    # Would need to get a valid URI for each endpoint to properly test this. But is it worth the pain?
+    # assert len(res) > 0
+
+
+@pytest.mark.parametrize("return_format", ROWS_TYPES_MAP.keys())
+@pytest.mark.parametrize("method", METHODS_SUPPORTED)
+def test_query_invalid(endpoint, return_format, method):
+    """Test invalid query with various return formats and methods"""
+    if endpoint in [STORE4_CHISE, FUSEKI2_STW] and method in ["POST", "POST_FORM"]:
+        pytest.skip(f"{endpoint} does not support POST requests")
+    if endpoint in [FUSEKI_LOV]:
+        pytest.skip("Unsupported text/plain type returned by LOV Fuseki when error")
+        # rdflib.plugin.PluginException: No plugin registered for (text/plain, <class 'rdflib.query.ResultParser'>)
+
+    query = "SELECT ?s ?p ?o WHERE { ?s } LIMIT 5"
+    try:
+        res = query_sparql(query, endpoint, return_format, method)
+        # NOTE: some endpoints return a tuple with error, others will throw an error
+        if "HTTP Error 400" in res[1]:
+            assert True
+        else:
+            assert False, f"Unexpected results for invalid query: {res}"
+    except ValueError:
+        assert True


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

This PR brings improvements to make `SPARQLStore` a better and more reliable option to execute SPARQL queries on remote endpoints (instead of using the SPARQLWrapper)

- Add tests of the `SPARQLStore` on public endpoints, taking inspiration from the SPARQLWrapper tests. Many popular SPARQL endpoints are tested in real world condition (graphdb, qlever, blazegraph, allegrograph, virtuoso...), which is really helpful to better know actually which features work, and which one are tricky
  - There are many comments explaining the current limitations, which will be helpful to people who tries to use it, and for future improvements of the store.
  - Since public endpoints are prone to be unavailable and the tests are a bit slower than the rest, these tests are optional and need to be opt-in by adding the flag `--public-endpoints` when running pytest. We do not run those tests as part of the CI/CD, we expect maintainers would run them locally from time to time, or when they are working on improving the `SPARQLStore` implementation
  - Documentation about these optional tests have been added to the developer docs
- Make the `method` param available directly on the `SPARQLStore` constructor so that it is proposed with autocomplete in all IDEs (before it was passed as kwargs to the `SPARQLConnector`, so users would not now about it unless they dive in the `SPARQLConnector` code)
- Use `Literal` type annotations for `returnFormats` and `method` at on the `SPARQLConnector` and `SPARQLStore`, this enable users to know exactly which values are possible just from basic autocomplete suggestions. Instead of having to dive in the code again
- Improve the `SPARQLStore` docstring documentation to provide a short, yet complete, working example for running a query: just copy/paste and it works
- Also fixed some small type checking errors that were already failing before these changes

  ```
  rdflib/store.py:126: error: Unused "type: ignore" comment  [unused-ignore]
  rdflib/compare.py:456: error: Unsupported operand types for + ("str" and "int")  [operator]
  rdflib/compare.py:456: note: Left operand is of type "Union[int, str]"
  ```


Running the test on public endpoints right now might give some errors, all related to the Linked Open Vocabulary SPARQL endpoint being down since this morning. It will probably be back up soon

```sh
poetry run pytest --public-endpoints
```

@nicholascar 

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
  - [x] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.