### PR TITLE
Feature: Add Tentris Plugin to docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -32,6 +32,7 @@ The following Stores are defined externally to rdflib's core package, so look to
 
 | Name | Repository | Notes |
 | --- | --- | --- |
+| Tentris | [repo](https://github.com/tentris/tentris) &#124; [PyPI](https://pypi.org/project/tentris/) &#124; [docs](https://docs.tentris.io/running_with_python.html) | Use the fast, in-memory [Tentris](https://tentris.io/) [WCOJ](https://en.wikipedia.org/wiki/Worst-case_optimal_join_algorithm) SPARQL engine as [native backend for rdflib's Graph](https://docs.tentris.io/running_with_python.html#native) or use rdflib's Graph to [connect to a running persistent Tentris instances via HTTP](https://docs.tentris.io/running_with_python.html#http). |
 | SQLAlchemy | [github.com/RDFLib/rdflib-sqlalchemy](https://github.com/RDFLib/rdflib-sqlalchemy) | An SQLAlchemy-backed, formula-aware RDFLib Store. Tested dialects are: SQLite, MySQL & PostgreSQL |
 | leveldb | [github.com/RDFLib/rdflib-leveldb](https://github.com/RDFLib/rdflib-leveldb) | An adaptation of RDFLib BerkeleyDB Store's key-value approach, using LevelDB as a back-end |
 | Kyoto Cabinet | [github.com/RDFLib/rdflib-kyotocabinet](https://github.com/RDFLib/rdflib-kyotocabinet) | An adaptation of RDFLib BerkeleyDB Store's key-value approach, using Kyoto Cabinet as a back-end |


### PR DESCRIPTION
# Summary of changes

At Tentris, we developed a plugin that allows users to run their `rdflib.Graph` (1) with a native in-memory Tentris instance and (2) connect it to an Tentris SPARQL HTTP endpoint. 

I have added it to the list of Plugins. 

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
  
  **Note: Some organization policy seems to prevent that. If anybody is aware how I can adjust that I am happy to change it.**

