### PR TITLE
fix: remove python version upperbound

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1727,5 +1727,5 @@ orjson = ["orjson"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<4"
-content-hash = "a9cc938b3991e860d9081d0912b0b1362edf47b30febbc1ace7ed40e62930223"
+python-versions = ">=3.9"
+content-hash = "08fe09128d28a53f15f1d11cbed8e7110b95267969643b908ff1b0dec688f64d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Natural Language :: English"
 ]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.9"
 readme = "README.md"
 packages = [
     { include = "rdflib" },

--- a/rdflib/extras/shacl.py
+++ b/rdflib/extras/shacl.py
@@ -18,9 +18,6 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from rdflib.term import IdentifiedNode
 
-if TYPE_CHECKING:
-    from rdflib.term import IdentifiedNode
-
 
 class SHACLPathError(Exception):
     pass


### PR DESCRIPTION
# Summary of changes

This PR removes the python version upper bound and also removes a duplicate type checking import.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

