### PR TITLE
skip prefix generation for predicates corresponding to base namespace

### DIFF
--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -264,6 +264,9 @@ class TurtleSerializer(RecursiveSerializer):
             if i == VERB and node in self.keywords:
                 # predicate is a keyword
                 continue
+            if i == VERB and node.startswith(self.store.base):
+                # predicate corresponds to base namespace
+                continue
             # Don't use generated prefixes for subjects and objects
             self.getQName(node, gen_prefix=(i == VERB))
             if isinstance(node, Literal) and node.datatype:


### PR DESCRIPTION
# Summary of changes
Small fix to prevent the turtle serializer from generating prefixes when predicates contain the base uri.
cfr. issue #3237 

# Checklist
- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

