### PR TITLE
Adjust the type hint for Graph open to reflect a SPARQLUpdateStore configuration

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -562,7 +562,9 @@ class Graph(Node):
         self.__store.rollback()
         return self
 
-    def open(self, configuration: str, create: bool = False) -> Optional[int]:
+    def open(
+        self, configuration: Union[str, tuple[str, str]], create: bool = False
+    ) -> Optional[int]:
         """Open the graph store
 
         Might be necessary for stores that require opening a connection to a
@@ -2824,7 +2826,7 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
     def rollback(self) -> NoReturn:
         raise ModificationException()
 
-    def open(self, configuration: str, create: bool = False) -> None:
+    def open(self, configuration: str | tuple[str, str], create: bool = False) -> None:
         # TODO: is there a use case for this method?
         for graph in self.graphs:
             # type error: Too many arguments for "open" of "Graph"

--- a/rdflib/plugins/stores/auditable.py
+++ b/rdflib/plugins/stores/auditable.py
@@ -18,7 +18,7 @@ system fails): A and I out of ACID.
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, Tuple, Union
 
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.store import Store
@@ -62,7 +62,9 @@ class AuditableStore(Store):
         ] = []
         self.rollbackLock = threading.RLock()
 
-    def open(self, configuration: str, create: bool = True) -> Optional[int]:
+    def open(
+        self, configuration: Union[str, tuple[str, str]], create: bool = True
+    ) -> Optional[int]:
         return self.store.open(configuration, create)
 
     def close(self, commit_pending_transaction: bool = False) -> None:

--- a/rdflib/plugins/stores/berkeleydb.py
+++ b/rdflib/plugins/stores/berkeleydb.py
@@ -4,7 +4,17 @@ import logging
 from os import mkdir
 from os.path import abspath, exists
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 from urllib.request import pathname2url
 
 from rdflib.store import NO_STORE, VALID_STORE, Store
@@ -127,10 +137,16 @@ class BerkeleyDB(Store):
     def is_open(self) -> bool:
         return self.__open
 
-    def open(self, path: str, create: bool = True) -> Optional[int]:
+    def open(
+        self, configuration: Union[str, tuple[str, str]], create: bool = True
+    ) -> Optional[int]:
         if not has_bsddb:
             return NO_STORE
-        homeDir = path  # noqa: N806
+
+        if type(configuration) is str:
+            homeDir = configuration  # noqa: N806
+        else:
+            raise Exception("Invalid configuration provided")
 
         if self.__identifier is None:
             self.__identifier = URIRef(pathname2url(abspath(homeDir)))

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -148,11 +148,11 @@ class SPARQLStore(SPARQLConnector, Store):
         self._queries = 0
 
     # type error: Missing return statement
-    def open(self, configuration: str, create: bool = False) -> Optional[int]:  # type: ignore[return]
+    def open(self, configuration: Union[str, tuple[str, str]], create: bool = False) -> Optional[int]:  # type: ignore[return]
         """This method is included so that calls to this Store via Graph, e.g. Graph("SPARQLStore"),
         can set the required parameters
         """
-        if type(configuration) == str:  # noqa: E721
+        if type(configuration) is str:
             self.query_endpoint = configuration
         else:
             raise Exception(

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -205,15 +205,21 @@ class Store:
     def create(self, configuration: str) -> None:
         self.dispatcher.dispatch(StoreCreatedEvent(configuration=configuration))
 
-    def open(self, configuration: str, create: bool = False) -> Optional[int]:
-        """
-        Opens the store specified by the configuration string. If
-        create is True a store will be created if it does not already
-        exist. If create is False and a store does not already exist
-        an exception is raised. An exception is also raised if a store
-        exists, but there is insufficient permissions to open the
-        store.  This should return one of:
-        VALID_STORE, CORRUPTED_STORE, or NO_STORE
+    def open(
+        self, configuration: Union[str, tuple[str, str]], create: bool = False
+    ) -> Optional[int]:
+        """Opens the store specified by the configuration string.
+
+        Args:
+            configuration: Store configuration as string or tuple
+            create: If True, a store will be created if it doesn't exist.
+                If False and the store doesn't exist, an exception is raised.
+
+        Returns:
+            One of: VALID_STORE, CORRUPTED_STORE, or NO_STORE
+
+        Raises:
+            Exception: If there are insufficient permissions to open the store.
         """
         return UNKNOWN
 

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -208,18 +208,13 @@ class Store:
     def open(
         self, configuration: Union[str, tuple[str, str]], create: bool = False
     ) -> Optional[int]:
-        """Opens the store specified by the configuration string.
-
-        Args:
-            configuration: Store configuration as string or tuple
-            create: If True, a store will be created if it doesn't exist.
-                If False and the store doesn't exist, an exception is raised.
-
-        Returns:
-            One of: VALID_STORE, CORRUPTED_STORE, or NO_STORE
-
-        Raises:
-            Exception: If there are insufficient permissions to open the store.
+        """Opens the store specified by the configuration string or tuple. If
+        create is True a store will be created if it does not already
+        exist. If create is False and a store does not already exist
+        an exception is raised. An exception is also raised if a store
+        exists, but there is insufficient permissions to open the
+        store.  This should return one of:
+        VALID_STORE, CORRUPTED_STORE, or NO_STORE
         """
         return UNKNOWN
 


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

The `SPARQLUpdateStore`'s `open` method can handle a string or a tuple of two strings (query and update endpoint). To reflect this situation, this pull-request adjusts the type hints for the Graph and Store open methods.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

It changes the public API just in terms of a type hint and makes it wider, so it should not break things.
