### PR TITLE
Remove trivial code from turtle serializer

### DIFF
--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -244,13 +244,10 @@ class TurtleSerializer(RecursiveSerializer):
 
         self.startDocument()
 
-        firstTime = True
         for subject in subjects_list:
             if self.isDone(subject):
                 continue
-            if firstTime:
-                firstTime = False
-            if self.statement(subject) and not firstTime:
+            if self.statement(subject):
                 self.write("\n")
 
         self.endDocument()


### PR DESCRIPTION
# Summary of changes

firstTime is alway true when checked in the last if statement, so it can be removed.

# Checklist
- [x] Checked that all tests and type checking passes.