### PR TITLE
feat: change dataset's default serialize format to trig

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -2671,6 +2671,73 @@ class Dataset(ConjunctiveGraph):
         """Iterates over all quads in the store"""
         return self.quads((None, None, None, None))
 
+    @overload
+    def serialize(
+        self,
+        destination: None,
+        format: str,
+        base: Optional[str],
+        encoding: str,
+        **args: Any,
+    ) -> bytes: ...
+
+    # no destination and non-None keyword encoding
+    @overload
+    def serialize(
+        self,
+        destination: None = ...,
+        format: str = ...,
+        base: Optional[str] = ...,
+        *,
+        encoding: str,
+        **args: Any,
+    ) -> bytes: ...
+
+    # no destination and None encoding
+    @overload
+    def serialize(
+        self,
+        destination: None = ...,
+        format: str = ...,
+        base: Optional[str] = ...,
+        encoding: None = ...,
+        **args: Any,
+    ) -> str: ...
+
+    # non-None destination
+    @overload
+    def serialize(
+        self,
+        destination: Union[str, pathlib.PurePath, IO[bytes]],
+        format: str = ...,
+        base: Optional[str] = ...,
+        encoding: Optional[str] = ...,
+        **args: Any,
+    ) -> Graph: ...
+
+    # fallback
+    @overload
+    def serialize(
+        self,
+        destination: Optional[Union[str, pathlib.PurePath, IO[bytes]]] = ...,
+        format: str = ...,
+        base: Optional[str] = ...,
+        encoding: Optional[str] = ...,
+        **args: Any,
+    ) -> Union[bytes, str, Graph]: ...
+
+    def serialize(
+        self,
+        destination: Optional[Union[str, pathlib.PurePath, IO[bytes]]] = None,
+        format: str = "trig",
+        base: Optional[str] = None,
+        encoding: Optional[str] = None,
+        **args: Any,
+    ) -> Union[bytes, str, Graph]:
+        return super(Dataset, self).serialize(
+            destination=destination, format=format, base=base, encoding=encoding, **args
+        )
+
 
 class QuotedGraph(Graph):
     """

--- a/test/test_dataset/test_dataset_default_serialize_format.py
+++ b/test/test_dataset/test_dataset_default_serialize_format.py
@@ -1,0 +1,18 @@
+from rdflib import Dataset
+from test.data import TEST_DATA_DIR
+
+
+def test_dataset_default_serialize_format_trig():
+    ds = Dataset()
+    ds.parse(source=TEST_DATA_DIR / "nquads.rdflib" / "test5.nquads", format="nquads")
+    statements_count = len(ds)
+    assert statements_count
+
+    # Previously, when the default format is 'turtle', given that the dataset has no
+    # statements in the default graph, the output of serialize() was empty.
+    output = ds.serialize().strip()
+    assert output != ""
+
+    ds2 = Dataset()
+    ds2.parse(data=output, format="trig")
+    assert len(ds2) == statements_count


### PR DESCRIPTION
# Summary of changes

Previously, calls to a dataset's serialize method used the superclass (Graph)'s default format, "turtle". However, serializing a dataset with the turtle format results in only triples in the default graph, with named graph triples omitted. A better default format for datasets is "trig", which serializes all triples from all graphs.

This PR changes the default serializer format for datasets to "trig".

This was raised in this issue: https://github.com/RDFLib/rdflib/issues/2021

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

