### PR TITLE
test: fix dbpedia webtests

### DIFF
--- a/test/test_sparql/test_service.py
+++ b/test/test_sparql/test_service.py
@@ -18,17 +18,18 @@ from test.utils.outcome import OutcomeChecker
 @pytest.mark.webtest
 def test_service():
     g = Graph()
-    q = """select ?sameAs ?dbpComment
-    where
-    { service <http://DBpedia.org/sparql>
-    { select ?dbpHypernym ?dbpComment
-    where
-    {
-    <http://dbpedia.org/resource/John_Lilburne>
-        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
-        <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment .
-
-    } }  } limit 2"""
+    q = """
+        SELECT ?p ?o
+        WHERE {
+            SERVICE <http://DBpedia.org/sparql> {
+                SELECT ?p ?o
+                WHERE {
+                    <http://dbpedia.org/resource/John_Lilburne> ?p ?o
+                }
+            }
+        }
+        LIMIT 2
+    """
     try:
         results = helper.query_with_retry(g, q)
     except (RemoteDisconnected, IncompleteRead):
@@ -44,19 +45,23 @@ def test_service():
 @pytest.mark.webtest
 def test_service_with_bind():
     g = Graph()
-    q = """select ?sameAs ?dbpComment ?subject
-    where
-    { bind (<http://dbpedia.org/resource/Category:1614_births> as ?subject)
-      service <http://DBpedia.org/sparql>
-    { select ?sameAs ?dbpComment ?subject
-    where
-    {
-    <http://dbpedia.org/resource/John_Lilburne>
-        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
-        <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment ;
-        <http://purl.org/dc/terms/subject> ?subject .
-
-    } }  } limit 2"""
+    q = """
+        PREFIX dbp:	<http://dbpedia.org/property/>
+        SELECT ?sameAs ?dbpComment ?subject
+        WHERE {
+        BIND(<http://dbpedia.org/resource/Category:1614_births> AS ?subject)
+        SERVICE <http://DBpedia.org/sparql> {
+            SELECT ?sameAs ?dbpComment ?subject
+            WHERE {
+                <http://dbpedia.org/resource/John_Lilburne>
+                    <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
+                    dbp:caption ?dbpComment ;
+                    <http://purl.org/dc/terms/subject> ?subject .
+                }
+            }
+        }
+        LIMIT 2
+    """
     try:
         results = helper.query_with_retry(g, q)
     except (RemoteDisconnected, IncompleteRead):
@@ -80,27 +85,30 @@ def test_service_with_bound_solutions():
         """
     )
     q = """
-        SELECT ?sameAs ?dbpComment ?subject WHERE {
-          []
-            <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
-            <http://purl.org/dc/terms/subject> ?subject .
-
-          SERVICE <http://DBpedia.org/sparql> {
-            SELECT ?sameAs ?dbpComment ?subject WHERE {
-              <http://dbpedia.org/resource/John_Lilburne>
+            PREFIX dbp:	<http://dbpedia.org/property/>
+            SELECT ?sameAs ?dbpComment ?subject
+            WHERE {
+            []
                 <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
-                <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment ;
                 <http://purl.org/dc/terms/subject> ?subject .
+
+            SERVICE <http://DBpedia.org/sparql> {
+                SELECT ?sameAs ?dbpComment ?subject
+                WHERE {
+                    <http://dbpedia.org/resource/John_Lilburne>
+                        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
+                        dbp:caption ?dbpComment ;
+                        <http://purl.org/dc/terms/subject> ?subject .
+                    }
+                }
             }
-          }
-        }
-        LIMIT 2
+            LIMIT 2
         """
     try:
         results = helper.query_with_retry(g, q)
     except (RemoteDisconnected, IncompleteRead):
         pytest.skip("this test uses dbpedia which is down sometimes")
-    assert len(results) == 2
+    assert len(results) == 1
 
     for r in results:
         assert len(r) == 3
@@ -109,19 +117,25 @@ def test_service_with_bound_solutions():
 @pytest.mark.webtest
 def test_service_with_values():
     g = Graph()
-    q = """select ?sameAs ?dbpComment ?subject
-    where
-    { values (?sameAs ?subject) {(<http://de.dbpedia.org/resource/John_Lilburne> <http://dbpedia.org/resource/Category:1614_births>) (<https://global.dbpedia.org/id/4t6Fk> <http://dbpedia.org/resource/Category:Levellers>)}
-      service <http://DBpedia.org/sparql>
-    { select ?sameAs ?dbpComment ?subject
-    where
-    {
-    <http://dbpedia.org/resource/John_Lilburne>
-        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
-        <http://www.w3.org/2000/01/rdf-schema#comment> ?dbpComment ;
-        <http://purl.org/dc/terms/subject> ?subject .
-
-    } }  } limit 2"""
+    q = """
+        PREFIX dbp:	<http://dbpedia.org/property/>
+        SELECT ?sameAs ?dbpComment ?subject
+        WHERE {
+            VALUES (?sameAs ?subject) {
+                (<http://de.dbpedia.org/resource/John_Lilburne> <http://dbpedia.org/resource/Category:1614_births>) (<https://global.dbpedia.org/id/4t6Fk> <http://dbpedia.org/resource/Category:Levellers>)
+            }
+            SERVICE <http://DBpedia.org/sparql> {
+                SELECT ?sameAs ?dbpComment ?subject
+                WHERE {
+                    <http://dbpedia.org/resource/John_Lilburne>
+                        <http://www.w3.org/2002/07/owl#sameAs> ?sameAs ;
+                        dbp:caption ?dbpComment ;
+                        <http://purl.org/dc/terms/subject> ?subject .
+                }
+            }
+        }
+        LIMIT 2
+    """
     try:
         results = helper.query_with_retry(g, q)
     except (RemoteDisconnected, IncompleteRead):


### PR DESCRIPTION
# Summary of changes

Looks like the data in DBpedia has changed recently. This PR updates the SPARQL queries to pass the web tests again.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

