### PR TITLE
formatting: black conforming sparqlquery.py

### DIFF
--- a/rdflib/tools/sparqlquery.py
+++ b/rdflib/tools/sparqlquery.py
@@ -221,12 +221,10 @@ def parse_args():
         "Also prints information about given format.",
     )
     parser.add_argument(
-        "-u",
-        "--username", type=str, help="Username used during authentication."
+        "-u", "--username", type=str, help="Username used during authentication."
     )
     parser.add_argument(
-        "-p",
-        "--password", type=str, help="Password used during authentication."
+        "-p", "--password", type=str, help="Password used during authentication."
     )
     parser.add_argument(
         "-rs",


### PR DESCRIPTION
run `poetry run black` on sparqlquery.py.

# Checklist

Follow up to #3290 . Just reformatted for black

- [x] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

