### PR TITLE
reworked documentation of JSONLDSerializer.

### DIFF
--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -2,7 +2,7 @@
 
 Implements serialization for [JSON-LD version 1.1](https://www.w3.org/TR/json-ld11/).
 For more information, see [json-ld.org](http://json-ld.org/).
-Additional `args` support by [`Graph.serialize`][rdflib.graph.Graph.serialize]
+Additional `args` supported by [`Graph.serialize`][rdflib.graph.Graph.serialize]
 are described by
 [`JsonLDSerializer.serialize`][rdflib.plugins.serializers.jsonld.JsonLDSerializer.serialize].
 


### PR DESCRIPTION
Still work in correspondence to #3307. 
Added missing documentation arguments. 
Working towards that all arguments are accesible with `inspect`.

# Summary of changes

Added more documentation to module and `JsonLDSerializer.serialize`.
Set default of `use_native_types` to `False`.
Moved Arguments to serialize arguments, instead of extracting them from `**args`.
No functional change, but because i dont extract anything from `**args` anymore, there are some changes in the program code. 
Still missing explanation to argument `context`.
Added docstring to `PLAIN_LITERAL_TYPES`.
Added crosslink to `graph.serialize`

# Checklist


- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

