### PR TITLE
sparqlconnector sends correct accept header in case of construct query

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -379,6 +379,12 @@ register(
     "TurtleParser",
 )
 register(
+    "application/x-turtle",
+    Parser,
+    "rdflib.plugins.parsers.notation3",
+    "TurtleParser",
+)
+register(
     "turtle",
     Parser,
     "rdflib.plugins.parsers.notation3",

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -224,10 +224,13 @@ class SPARQLConnector:
         else:
             return ", ".join(rdf_mimetype_map)
 
-    def __get_query_type__(self, query: str) -> str:
-        q = prepareQuery(query)
-        algebra = getattr(q, "algebra", None)
-        name = getattr(algebra, "name", None) # e.g. 'SelectQuery', 'ConstructQuery', 'DescribeQuery', 'AskQuery'
-        return name
+    def __get_query_type__(self, query: str) -> str | None:
+        try:
+            q = prepareQuery(query)
+            algebra = getattr(q, "algebra", None)
+            name = getattr(algebra, "name", None) 
+            return name # e.g. 'SelectQuery', 'ConstructQuery', 'DescribeQuery', 'AskQuery'
+        except Exception:
+            log.debug(f"cannot parse query: {query}")
 
 __all__ = ["SPARQLConnector", "SPARQLConnectorException"]

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from rdflib.plugin import plugins
+from rdflib.plugins.sparql import prepareQuery
 from rdflib.query import Result, ResultParser
 from rdflib.term import BNode
 from rdflib.util import FORMAT_MIMETYPE_MAP, RESPONSE_TABLE_FORMAT_MIMETYPE_MAP
@@ -91,6 +92,11 @@ class SPARQLConnector:
             params["default-graph-uri"] = default_graph
 
         headers = {"Accept": self.response_mime_types()}
+        
+        # change Accept header to an RDF mime type in case of a construct query
+        qtype = self.__get_query_type__(query)
+        if qtype in ("ConstructQuery", "DescribeQuery"):
+            headers.update({"Accept": self.response_mime_types_rdf()})
 
         args = copy.deepcopy(self.kwargs)
 
@@ -205,5 +211,23 @@ class SPARQLConnector:
                 supported_formats.add(plugin.name)
         return ", ".join(supported_formats)
 
+    def response_mime_types_rdf(self) -> str:
+        """Construct a HTTP-Header Accept field to reflect the supported mime types for SPARQL construct/describe queries that return a graph.
+
+        If the return_format parameter is set, the mime types are restricted to these accordingly.
+        """
+        rdf_mimetype_map = [mime for mlist in FORMAT_MIMETYPE_MAP.values() for mime in mlist]
+
+        # use the matched returnType if it matches one of the rdf mime types
+        if self.returnFormat in FORMAT_MIMETYPE_MAP:
+            return FORMAT_MIMETYPE_MAP[self.returnFormat][0]
+        else:
+            return ", ".join(rdf_mimetype_map)
+
+    def __get_query_type__(self, query: str) -> str:
+        q = prepareQuery(query)
+        algebra = getattr(q, "algebra", None)
+        name = getattr(algebra, "name", None) # e.g. 'SelectQuery', 'ConstructQuery', 'DescribeQuery', 'AskQuery'
+        return name
 
 __all__ = ["SPARQLConnector", "SPARQLConnectorException"]

--- a/rdflib/plugins/stores/sparqlconnector.py
+++ b/rdflib/plugins/stores/sparqlconnector.py
@@ -92,7 +92,7 @@ class SPARQLConnector:
             params["default-graph-uri"] = default_graph
 
         headers = {"Accept": self.response_mime_types()}
-        
+
         # change Accept header to an RDF mime type in case of a construct query
         qtype = self.__get_query_type__(query)
         if qtype in ("ConstructQuery", "DescribeQuery"):
@@ -216,7 +216,9 @@ class SPARQLConnector:
 
         If the return_format parameter is set, the mime types are restricted to these accordingly.
         """
-        rdf_mimetype_map = [mime for mlist in FORMAT_MIMETYPE_MAP.values() for mime in mlist]
+        rdf_mimetype_map = [
+            mime for mlist in FORMAT_MIMETYPE_MAP.values() for mime in mlist
+        ]
 
         # use the matched returnType if it matches one of the rdf mime types
         if self.returnFormat in FORMAT_MIMETYPE_MAP:
@@ -228,9 +230,11 @@ class SPARQLConnector:
         try:
             q = prepareQuery(query)
             algebra = getattr(q, "algebra", None)
-            name = getattr(algebra, "name", None) 
-            return name # e.g. 'SelectQuery', 'ConstructQuery', 'DescribeQuery', 'AskQuery'
+            name = getattr(algebra, "name", None)
+            return name  # e.g. 'SelectQuery', 'ConstructQuery', 'DescribeQuery', 'AskQuery'
         except Exception:
             log.debug(f"cannot parse query: {query}")
+        return None
+
 
 __all__ = ["SPARQLConnector", "SPARQLConnectorException"]

--- a/test/test_store/test_store_sparqlstore_query.py
+++ b/test/test_store/test_store_sparqlstore_query.py
@@ -127,3 +127,50 @@ def test_query_construct_format(
     logging.debug("request = %s", request)
     logging.debug("request.headers = %s", request.headers.as_string())
     assert request.path_query["query"][0] == query
+
+def test_query_construct_accept_header(
+    function_httpmock: ServedBaseHTTPServerMock
+) -> None:
+    """
+    Test that no SPARQL result media types are used for construct queries
+    """
+    graph = Graph(
+        "SPARQLStore",
+        identifier="http://example.com",
+        bind_namespaces="none",
+    )
+    url = f"{function_httpmock.url}/query"
+    graph.open(url)
+
+    function_httpmock.responses[MethodName.GET].extend(
+        [
+            MockHTTPResponse(
+                200,
+                "OK",
+                b"<> a <#test> .",
+                {"Content-Type": ["text/turtle"]},
+            )
+        ] * 2  # two identical responses
+    )
+
+    # case 1: construct query
+
+    query_construct = "CONSTRUCT WHERE { ?s ?p ?o }"
+    graph.query(query_construct)
+
+    request_construct = function_httpmock.requests[MethodName.GET].pop()
+    accept_header_construct = request_construct.headers.get('Accept').lower()
+    # 'Accept' header must not include types for XML or JSON sparql results
+    assert "application/sparql-results" not in accept_header_construct
+    # 'Accept' header should be at least the default RDF/XML
+    assert "application/rdf+xml" in accept_header_construct
+
+    # case 2: select query
+
+    query_select = "SELECT * WHERE { ?s ?p ?o }"
+    graph.query(query_select)
+
+    request_select = function_httpmock.requests[MethodName.GET].pop()
+    accept_header_select = request_select.headers.get('Accept').lower()
+    # 'Accept' header should include types for XML or JSON sparql results
+    assert "application/sparql-results" in accept_header_select

--- a/test/test_store/test_store_sparqlstore_query.py
+++ b/test/test_store/test_store_sparqlstore_query.py
@@ -128,8 +128,9 @@ def test_query_construct_format(
     logging.debug("request.headers = %s", request.headers.as_string())
     assert request.path_query["query"][0] == query
 
+
 def test_query_construct_accept_header(
-    function_httpmock: ServedBaseHTTPServerMock
+    function_httpmock: ServedBaseHTTPServerMock,
 ) -> None:
     """
     Test that no SPARQL result media types are used for construct queries
@@ -150,7 +151,8 @@ def test_query_construct_accept_header(
                 b"<> a <#test> .",
                 {"Content-Type": ["text/turtle"]},
             )
-        ] * 2  # two identical responses
+        ]
+        * 2  # two identical responses
     )
 
     # case 1: construct query
@@ -159,7 +161,7 @@ def test_query_construct_accept_header(
     graph.query(query_construct)
 
     request_construct = function_httpmock.requests[MethodName.GET].pop()
-    accept_header_construct = request_construct.headers.get('Accept').lower()
+    accept_header_construct = request_construct.headers.get("Accept", "").lower()
     # 'Accept' header must not include types for XML or JSON sparql results
     assert "application/sparql-results" not in accept_header_construct
     # 'Accept' header should be at least the default RDF/XML
@@ -171,6 +173,6 @@ def test_query_construct_accept_header(
     graph.query(query_select)
 
     request_select = function_httpmock.requests[MethodName.GET].pop()
-    accept_header_select = request_select.headers.get('Accept').lower()
+    accept_header_select = request_select.headers.get("Accept", "").lower()
     # 'Accept' header should include types for XML or JSON sparql results
     assert "application/sparql-results" in accept_header_select


### PR DESCRIPTION
resolves #3332

# Summary of changes

**For SPARQL construct queries, send mime types for RDF instead of for SPARQL results in the header of the HTTP request.**
Some SPARQL servers (in my case Anzo) respond with a 400 'Bad Request' response if the Accept header does not describe RDF for construct or describe queries.

sparqlconnector.py
* get the type of SPARQL query from the passed query string
* if it's a construct or describe query, use an HTTP Accept header that represents an RDF serialization

plugin.py
* register the TurtleParser for the mime type "application/x-turtle" (for compatibility with legacy systems)

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.

**update:**
- [x] Checked that all tests and type checking passes.
`7600 passed, 592 skipped, 331 xfailed, 36 xpassed, 36012 warnings in 139.91s (0:02:19)`
