### PR TITLE
Check that by default sparql accepts xml

### DIFF
--- a/test/test_store/test_store_sparqlstore_query.py
+++ b/test/test_store/test_store_sparqlstore_query.py
@@ -127,6 +127,6 @@ def test_query_construct_format(
     logging.debug("request = %s", request)
     logging.debug("request.headers = %s", request.headers.as_string())
     assert request.path_query["query"][0] == query
-    #check for current rdflibs default behaviour, to accept xml
+    # check for current rdflibs default behaviour, to accept xml
     assert "application/rdf+xml" in request.headers["Accept"]
     assert "application/sparql-results+xml" in request.headers["Accept"]


### PR DESCRIPTION
See #3332  for more discussion.
Prevent, that by chance the default behaviour of `sparqlstore`, to accept `xml` on a query is changed.
This change may also be incorporated into PR #3324 

# Summary of changes

Added check for `xml` at test `test.test_store.test_store_sparqlstore_query.test_query_construct_format`

# Checklist

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

