### PR TITLE
Fix recursion error when parsing nested `SERVICE` calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ exclude = '''
     | \.pytest_cache
     | \.tox
     | \.venv
+    | \.poetry
     | \.var
     | \.github
     | site

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -1026,13 +1026,6 @@ class _AlgebraTranslator:
                     for triple in node.triples
                 )
                 self._replace("{BGP}", triples)
-                # The dummy -*-SELECT-*- is placed during a SelectQuery or Multiset pattern in order to be able
-                # to match extended variables in a specific Select-clause (see "Extend" below)
-                self._replace("-*-SELECT-*-", "SELECT", count=-1)
-                # If there is no "Group By" clause the placeholder will simply be deleted. Otherwise there will be
-                # no matching {GroupBy} placeholder because it has already been replaced by "group by variables"
-                self._replace("{GroupBy}", "", count=-1)
-                self._replace("{Having}", "", count=-1)
             elif node.name == "Join":
                 self._replace(
                     "{Join}", "{" + node.p1.name + "}{" + node.p2.name + "}"
@@ -1151,6 +1144,24 @@ class _AlgebraTranslator:
                     "GroupGraphPatternSub",
                     " ".join([self.convert_node_arg(pattern) for pattern in node.part]),
                 )
+            elif node.name == "OptionalGraphPattern":
+                # Raw parse node (not yet translated to algebra LeftJoin)
+                # Appears inside SERVICE graph patterns where inner content is
+                # kept in raw parse form
+                self._replace(
+                    "{OptionalGraphPattern}",
+                    "OPTIONAL {" + node.graph.name + "}",
+                )
+                traverse(node.graph, visitPre=self.sparql_query_text)
+                return node.graph
+            elif node.name == "MinusGraphPattern":
+                # Raw parse node (not yet translated to algebra Minus)
+                self._replace(
+                    "{MinusGraphPattern}",
+                    "MINUS {" + node.graph.name + "}",
+                )
+                traverse(node.graph, visitPre=self.sparql_query_text)
+                return node.graph
             elif node.name == "TriplesBlock":
                 self._replace(
                     "{TriplesBlock}",
@@ -1630,6 +1641,14 @@ class _AlgebraTranslator:
 
     def translateAlgebra(self) -> str:
         traverse(self.query_algebra.algebra, visitPre=self.sparql_query_text)
+        # The dummy -*-SELECT-*- marker is used during traversal so that Extend can
+        # locate the right SELECT clause for nested subqueries (see Extend handler)
+        # Replace all remaining occurrences with SELECT now that traversal is done
+        self._alg_translation = self._alg_translation.replace("-*-SELECT-*-", "SELECT")
+        # {GroupBy} and {Having} are filled by the Group handler, if there is no GROUP BY
+        # clause the placeholders remain and must be removed.
+        self._alg_translation = self._alg_translation.replace("{GroupBy}", "")
+        self._alg_translation = self._alg_translation.replace("{Having}", "")
         return self._alg_translation
 
 

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -1286,7 +1286,6 @@ ValuesClause = Optional(
     Param("valuesClause", Comp("ValuesClause", Keyword("VALUES") + DataBlock))
 )
 
-
 # [74] ConstructTriples ::= TriplesSameSubject ( '.' Optional(ConstructTriples) )?
 ConstructTriples = Forward()
 ConstructTriples <<= ParamList("template", TriplesSameSubject) + Optional(

--- a/rdflib/plugins/sparql/parserutils.py
+++ b/rdflib/plugins/sparql/parserutils.py
@@ -35,7 +35,7 @@ from typing import (
     Union,
 )
 
-from pyparsing import ParserElement, ParseResults, TokenConverter, originalTextFor
+from pyparsing import ParserElement, ParseResults, TokenConverter
 
 from rdflib.term import BNode, Identifier, Variable
 
@@ -235,6 +235,18 @@ class Comp(TokenConverter):
         self.set_name(name)
         self.evalfn: Callable[[Any, Any], Any] | None = None
 
+    def parseImpl(
+        self, instring: str, loc: int = 0, do_actions: bool = True
+    ) -> tuple[int, ParseResults]:
+        if self.name == "ServiceGraphPattern":
+            # Embed the start position as a named key in the ParseResults so
+            # postParse can extract the original SERVICE text, avoiding
+            # RecursionError with nested SERVICE).
+            new_loc, results = super().parseImpl(instring, loc, do_actions)
+            results["_service_start"] = loc
+            return new_loc, results
+        return super().parseImpl(instring, loc, do_actions)
+
     def postParse(
         self, instring: str, loc: int, tokenList: ParseResults
     ) -> Union[Expr, CompValue]:
@@ -245,12 +257,8 @@ class Comp(TokenConverter):
         else:
             res = CompValue(self.name)
             if self.name == "ServiceGraphPattern":
-                # Then this must be a service graph pattern and have
-                # already matched.
-                # lets assume there is one, for now, then test for two later.
-                sgp = originalTextFor(self.expr)
-                service_string = sgp.searchString(instring)[0][0]
-                res["service_string"] = service_string
+                start = tokenList["_service_start"]
+                res["service_string"] = instring[start:loc]
 
         for t in tokenList:
             if isinstance(t, ParamValue):

--- a/test/test_sparql/test_sparql_parser.py
+++ b/test/test_sparql/test_sparql_parser.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import math
 import sys
 
-from rdflib import Graph, Literal, Variable
+from rdflib import Graph, Literal, URIRef, Variable
 from rdflib.namespace import Namespace
+from rdflib.plugins.sparql.algebra import translateQuery
+from rdflib.plugins.sparql.parser import parseQuery
 from rdflib.plugins.sparql.processor import processUpdate
 from rdflib.term import IdentifiedNode, Node
 
@@ -43,3 +45,30 @@ class TestSPARQLParser:
         processUpdate(g1, f"INSERT DATA {{ {g0ntriples!s} }}")
 
         assert triple_set(g0) == triple_set(g1)
+
+    def test_nested_service(self) -> None:
+        query = """
+        PREFIX wikibase: <http://wikiba.se/ontology#>
+        PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+        PREFIX bd: <http://www.bigdata.com/rdf#>
+        PREFIX wd: <http://www.wikidata.org/entity/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?item ?pic
+        WHERE
+        {
+            SERVICE <https://query.wikidata.org/sparql> {
+                ?item wdt:P31 wd:Q146 .
+                ?item wdt:P18 ?pic
+                SERVICE wikibase:label {
+                    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en".
+                }
+            }
+        }"""
+        parsed_query = translateQuery(parseQuery(query))
+        outer_service = parsed_query.algebra.p.p
+        assert outer_service.name == "ServiceGraphPattern"
+        assert outer_service.term == URIRef("https://query.wikidata.org/sparql")
+        inner_parts = outer_service.graph.part
+        inner_services = [p for p in inner_parts if p.name == "ServiceGraphPattern"]
+        assert len(inner_services) == 1
+        assert inner_services[0].term == URIRef("http://wikiba.se/ontology#label")

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -10,7 +10,6 @@ from typing import Union, cast
 
 import pytest
 from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
-from pyparsing import ParseException
 
 import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
@@ -259,12 +258,7 @@ if os.name != "nt":
     algebra_tests.append(
         AlgebraTest(
             "test_other__service1",
-            "Test if a nested service pattern is properly translated"
-            "into the query text.",
-            pytest.mark.xfail(
-                raises=ParseException,
-                reason="translateAlgebra produces invalid SPARQL for nested OPTIONAL/SERVICE patterns",
-            ),
+            "Test if a nested service pattern is properly translated",
         )
     )
 else:

--- a/test/test_sparql/test_translate_algebra.py
+++ b/test/test_sparql/test_translate_algebra.py
@@ -10,6 +10,7 @@ from typing import Union, cast
 
 import pytest
 from _pytest.mark.structures import Mark, MarkDecorator, ParameterSet
+from pyparsing import ParseException
 
 import rdflib.plugins.sparql.algebra as algebra
 import rdflib.plugins.sparql.parser as parser
@@ -251,7 +252,7 @@ unused_files = {
 
 
 if os.name != "nt":
-    # On Windows this test causes a stackoverflow or memory error, so don't run
+    # On Windows this test was causing a stackoverflow or memory error, so don't run
     # it on Windows. The test fails anyway on linux and should be fixed. Once
     # the cause of this failure is fixed the condition to not run it on windows
     # should be removed and it should be added to the normal tests.
@@ -261,8 +262,8 @@ if os.name != "nt":
             "Test if a nested service pattern is properly translated"
             "into the query text.",
             pytest.mark.xfail(
-                raises=(RecursionError, TypeError),
-                reason="Fails with RecursionError inside parser.parseQuery",
+                raises=ParseException,
+                reason="translateAlgebra produces invalid SPARQL for nested OPTIONAL/SERVICE patterns",
             ),
         )
     )


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

This PR fixes https://github.com/RDFLib/rdflib/issues/2136 where RDFLib faces infinite recursion loop when a `SERVICE` call is used in another `SERVICE` call, which is not uncommon (Wikidata, one of the most popular public triplestore uses `SERVICE` call to resolve label, so if someone tries to do a service call to wikidata with labels they would face error at parsing time when executing it with rdflib), e.g.

```sparql
PREFIX wikibase: <http://wikiba.se/ontology#>
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
PREFIX bd: <http://www.bigdata.com/rdf#>
PREFIX wd: <http://www.wikidata.org/entity/>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT ?item ?pic WHERE {
    SERVICE <https://query.wikidata.org/sparql> {
        ?item wdt:P31 wd:Q146 .
		?item wdt:P18 ?pic
        SERVICE wikibase:label {
            bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en".
        }
    }
}
```

* update the `Comp(TokenConverter)` class to properly track and parse `SERVICE` calls instead of re-parsing the entire input which caused `RecursionError` with nested services
* add a test for parsing nested SERVICE calls in `test_sparql_parser.py`
* in existing `test_translate_algebra.py` update the xfail for `test_other__service1.txt` as it now fails due an issue with parsing nested OPTIONAL/SERVICE blocks instead of triggering a RecursionError (it is a different issue that already existed but was never noticed as the recursion error was triggered first)
* added `.poetry` to black skip as this was causing error when running black with precommit hook, preventing to commit 

```
error: cannot format rdflib/.poetry/plugins/poetry_plugin_export/exporter.py: Cannot parse for target version Python 3.9: 328:18:             match dependency:
```

Note fixing nested OPTIONAL/SERVICE blocks would require small changes to `plugins/sparql/algebra.py` to properly handle `OptionalGraphPattern` nodes in `_AlgebraTranslator` class. I can add it to this PR if you want, or create a new PR later

@nicholascar @aucampia 

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

