### PR TITLE
docs: Fix GeoSPARQL links in rdf_terms.md

### DIFF
--- a/docs/rdf_terms.md
+++ b/docs/rdf_terms.md
@@ -71,7 +71,7 @@ name = Literal("Nicholas", lang="en")  # the name 'Nicholas', as an English stri
 imie = Literal("Mikołaj", lang="pl")  # the Polish version of the name 'Nicholas'
 ```
 
-Special literal types indicated by use of a custom IRI for a literal's `datatype` value, for example the [GeoSPARQL RDF standard](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html#_geometry_serializations) invents a custom datatype, `geoJSONLiteral` to indicate [GeoJSON geometry serlializations](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html#_rdfs_datatype_geogeojsonliteral) like this:
+Special literal types indicated by use of a custom IRI for a literal's `datatype` value, for example the [GeoSPARQL RDF standard](https://docs.ogc.org/is/22-047r1/22-047r1.html#_877a702f-f4d3-464c-81e9-d8a1f37a13f5) invents a custom datatype, `geoJSONLiteral` to indicate [GeoJSON geometry serlializations](https://docs.ogc.org/is/22-047r1/22-047r1.html#_rdfs_datatype_geogeojsonliteral) like this:
 
 ```python
 GEO = Namespace("http://www.opengis.net/ont/geosparql#")


### PR DESCRIPTION

<!--
PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

Updated two broken links to the GeoSPARQL standard found in `rdf_terms.md`.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

