### PR TITLE
Align quoting of ntriples/nquads literals with RDFC1.0

### DIFF
--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -47,18 +47,10 @@ class NQuadsSerializer(Serializer):
 
 
 def _nq_row(triple, context):
-    graph_name = context.n3() if context and context != DATASET_DEFAULT_GRAPH_ID else ""
+    graph_name = (
+        context.n3() + " " if context and context != DATASET_DEFAULT_GRAPH_ID else ""
+    )
     if isinstance(triple[2], Literal):
-        return "%s %s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            _quoteLiteral(triple[2]),
-            graph_name,
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {_quoteLiteral(triple[2])} {graph_name}.\n"
     else:
-        return "%s %s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            triple[2].n3(),
-            graph_name,
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {triple[2].n3()} {graph_name}.\n"

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -57,13 +57,9 @@ class NT11Serializer(NTSerializer):
 
 def _nt_row(triple: _TripleType) -> str:
     if isinstance(triple[2], Literal):
-        return "%s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            _quoteLiteral(triple[2]),
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {_quoteLiteral(triple[2])} .\n"
     else:
-        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())
+        return f"{triple[0].n3()} {triple[1].n3()} {triple[2].n3()} .\n"
 
 
 def _quoteLiteral(l_: Literal) -> str:  # noqa: N802

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -78,9 +78,34 @@ def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
 
 
 def _quote_encode(l_: str) -> str:
-    return '"%s"' % l_.replace("\\", "\\\\").replace("\n", "\\n").replace(
-        '"', '\\"'
-    ).replace("\r", "\\r")
+    # Accept either an rdflib Literal or a plain string
+    s = str(l_)
+
+    parts = ""
+    for ch in s:
+        code = ord(ch)
+        if ch == "\\":
+            parts += "\\\\"
+        elif ch == '"':
+            parts += '\\"'
+        elif ch == "\n":
+            parts += "\\n"
+        elif ch == "\r":
+            parts += "\\r"
+        elif ch == "\t":
+            parts += "\\t"
+        elif code == 0x08:  # backspace
+            parts += "\\b"
+        elif code == 0x0C:  # form feed
+            parts += "\\f"
+        elif (
+            code == 0x0B or (code < 0x20) or (code == 0x7F)
+        ):  # vertical tab -> use \u000B
+            parts += f"\\u{code:04X}"
+        else:
+            parts += ch
+
+    return '"' + parts + '"'
 
 
 def _nt_unicode_error_resolver(


### PR DESCRIPTION
# Summary of changes

- reimplement `_quote_encode()` according to [Canonical form of N-Quads](https://www.w3.org/TR/rdf-canon/#canonical-quads) from RDFC1.0
- converted `_nt_row` and `_nq_row` syntax to f-string.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

