### PR TITLE
Omit datatype when serialization xsd:string literals as ntriples

### DIFF
--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -47,18 +47,13 @@ class NQuadsSerializer(Serializer):
 
 
 def _nq_row(triple, context):
-    graph_name = context.n3() if context and context != DATASET_DEFAULT_GRAPH_ID else ""
+    graph_name = (
+        context.n3() + " "
+        if context and context != DATASET_DEFAULT_GRAPH_ID
+        else ""
+    )
     if isinstance(triple[2], Literal):
-        return "%s %s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            _quoteLiteral(triple[2]),
-            graph_name,
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {_quoteLiteral(triple[2])} {graph_name}.\n"
     else:
-        return "%s %s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            triple[2].n3(),
-            graph_name,
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {triple[2].n3()} {graph_name}.\n"
+

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -57,13 +57,9 @@ class NT11Serializer(NTSerializer):
 
 def _nt_row(triple: _TripleType) -> str:
     if isinstance(triple[2], Literal):
-        return "%s %s %s .\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            _quoteLiteral(triple[2]),
-        )
+        return f"{triple[0].n3()} {triple[1].n3()} {_quoteLiteral(triple[2])} .\n"
     else:
-        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())
+        return f"{triple[0].n3()} {triple[1].n3()} {triple[2].n3()} .\n"
 
 
 def _quoteLiteral(l_: Literal) -> str:  # noqa: N802

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -82,9 +82,32 @@ def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
 
 
 def _quote_encode(l_: str) -> str:
-    return '"%s"' % l_.replace("\\", "\\\\").replace("\n", "\\n").replace(
-        '"', '\\"'
-    ).replace("\r", "\\r")
+    # Accept either an rdflib Literal or a plain string
+    s = str(l_)
+
+    parts = ""
+    for ch in s:
+        code = ord(ch)
+        if ch == "\\":
+            parts += '\\\\'
+        elif ch == '"':
+            parts += '\\"'
+        elif ch == "\n":
+            parts += '\\n'
+        elif ch == "\r":
+            parts += '\\r'
+        elif ch == "\t":
+            parts += '\\t'
+        elif code == 0x08:  # backspace
+            parts += '\\b'
+        elif code == 0x0C:  # form feed
+            parts += '\\f'
+        elif code == 0x0B or (code < 0x20) or (code == 0x7F):  # vertical tab -> use \u000B
+            parts += f'\\u{code:04X}'
+        else:
+            parts += ch
+
+    return '"' + parts + '"'
 
 
 def _nt_unicode_error_resolver(

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -5,6 +5,7 @@ import warnings
 from typing import IO, TYPE_CHECKING, Any
 
 from rdflib.graph import Graph
+from rdflib.namespace import XSD
 from rdflib.serializer import Serializer
 from rdflib.term import Literal
 
@@ -71,7 +72,7 @@ def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
         if l_.datatype:
             raise Exception("Literal has datatype AND language!")
         return "%s@%s" % (encoded, l_.language)
-    elif l_.datatype:
+    elif l_.datatype and l_.datatype != XSD.string:
         return "%s^^<%s>" % (encoded, l_.datatype)
     else:
         return "%s" % encoded


### PR DESCRIPTION
This should not be merged before #3431 

# Summary of changes

- The NQuads / Ntriples serializer no longer prints the xsd:string as this is implicit.

# Checklist

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

