### PR TITLE
validation workflow fix and deprecation bumps

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -41,8 +41,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
+          version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install poetry
         run: |
@@ -66,8 +67,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
+          version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install poetry
         run: |

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -11,7 +11,7 @@ jobs:
       checks: write
       statuses: write
     steps:
-      - uses: dorny/test-reporter@v2
+      - uses: dorny/test-reporter@v3
         with:
           artifact: /(.*)-mypy-junit-xml$/
           name: mypy report

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -48,12 +48,6 @@ jobs:
             os: ubuntu-latest
             TOX_EXTRA_COMMAND: "- black --check --diff ./rdflib"
             TOXENV_SUFFIX: "-lxml"
-          - python-version: "3.11"
-            os: ubuntu-latest
-            TOXENV_SUFFIX: "-docs"
-            PREPARATION: "sudo apt-get install -y firejail"
-            extensive-tests: true
-            TOX_TEST_HARNESS: "-- firejail --net=none --"
             TOX_PYTEST_EXTRA_ARGS: "-m 'not webtest'"
           - python-version: "3.12"
             os: ubuntu-latest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -100,12 +100,12 @@ jobs:
           TOX_PYTEST_EXTRA_ARGS: ${{ matrix.TOX_PYTEST_EXTRA_ARGS }}
           TOX_TEST_HARNESS: ${{ matrix.TOX_TEST_HARNESS }}
           TOX_EXTRA_COMMAND: ${{ matrix.TOX_EXTRA_COMMAND }}
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: ${{ (success() || failure()) }}
         with:
           name: ${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-mypy-junit-xml
           path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-mypy-junit.xml
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: ${{ (success() || failure()) }}
         with:
           name: ${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-pytest-junit-xml

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -48,6 +48,9 @@ jobs:
             os: ubuntu-latest
             TOX_EXTRA_COMMAND: "- black --check --diff ./rdflib"
             TOXENV_SUFFIX: "-lxml"
+          - python-version: "3.11"
+            os: ubuntu-latest
+            TOXENV_SUFFIX: "-docs"
             TOX_PYTEST_EXTRA_ARGS: "-m 'not webtest'"
           - python-version: "3.12"
             os: ubuntu-latest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -79,8 +79,9 @@ jobs:
           distribution: "temurin"
           java-version: "17"
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
+          version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run preparation
         if: ${{ matrix.PREPARATION }}
@@ -141,8 +142,9 @@ jobs:
         run: |
           pip install -r devtools/requirements-poetry.in
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
+          version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run task
         shell: bash

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache XDG_CACHE_HOME
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.XDG_CACHE_HOME }}
           key: ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock', '**/with-fuseki.sh', '**/*requirements*.txt', '**/*requirements*.in') }}
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache XDG_CACHE_HOME
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.XDG_CACHE_HOME }}
           key: ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock', '**/with-fuseki.sh', '**/*requirements*.txt', '**/*requirements*.in') }}


### PR DESCRIPTION
# Summary of changes
The persistent tox run failure issue with 3.11+ubuntu-latest appears to be related to the use of the firejail harness specified in the validate workflow yaml --- https://github.com/RDFLib/rdflib/blob/0fdac395078b81313f30eeab74b1a18eb7bb4db6/.github/workflows/validate.yaml#L54

The [firejail README](https://github.com/netblue30/firejail) makes specific recommendations for Ubuntu:
`>>>`
### Ubuntu

Note: The versions from the distribution and PPA are likely to be outdated, so currently we recommend either downloading and installing the .deb package from the latest release:
`<<<`

In the course of addressing this, I tracked down the advised bumps to address the GH deprecations warnings:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/upload-artifact@v5, arduino/setup-task@v2.

I found bumps for actions/cache@v4 and actions/upload-artifact@v5 (grounded in the accompanying commit messages) but I wasn't able to resolve arduino/setup-task@v2 satisfactorily. Others have noted that an as-yet-unaddressed issue was raised back in early March and have started to migrate to [go-task/setup-task@v2](https://github.com/go-task/setup-task)
which purports to be a drop-in replacement, except that [isn't the case for the RDFLib validation workflow](https://github.com/RDFLib/rdflib/actions/runs/26132139918)

# Checklist

- [✅] Checked that there aren't other open pull requests for
  the same change.
- [✅] Checked that all tests and type checking passes.
- [✅] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

