### PR TITLE
parsers: defend SAX parsers against billion-laughs / XXE DoS

### DIFF
--- a/rdflib/plugins/parsers/rdfxml.py
+++ b/rdflib/plugins/parsers/rdfxml.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NoReturn
 from urllib.parse import urldefrag, urljoin
-from xml.sax import handler, make_parser, xmlreader
+from xml.sax import SAXNotSupportedException, handler, make_parser, xmlreader
 from xml.sax.handler import ErrorHandler
 from xml.sax.saxutils import escape, quoteattr
 
@@ -619,8 +619,49 @@ class RDFXMLHandler(handler.ContentHandler):
         self.parent.object += self.current.object + end
 
 
+def _forbid_entity_decl(
+    name: Any,
+    is_parameter_entity: Any,
+    value: Any,
+    base: Any,
+    sysid: Any,
+    pubid: Any,
+    notation_name: Any,
+) -> NoReturn:
+    """Reject DTD entity declarations to defeat billion-laughs / XXE attacks."""
+    raise SAXNotSupportedException(
+        "Entity declarations are not allowed in untrusted XML input "
+        "(rejected entity '%s')" % name
+    )
+
+
+def _harden_parser(parser: xmlreader.XMLReader) -> None:
+    """Disable external entities and forbid DTD entity declarations.
+
+    rdflib parses untrusted RDF/XML from the network. Without these guards a
+    sub-kilobyte "billion laughs" payload exhausts CPU and memory during parse.
+    Internal entity expansion (the only legitimate DTD entity use in RDF/XML)
+    is rejected outright; well-formed RDF/XML does not need it.
+    """
+    parser.setFeature(handler.feature_external_ges, False)
+    parser.setFeature(handler.feature_external_pes, False)
+    # xml.sax.expatreader recreates self._parser inside reset() (which is
+    # called by parse()), so we have to wire the EntityDeclHandler each time.
+    if hasattr(parser, "reset"):
+        original_reset = parser.reset
+
+        def reset_and_harden() -> None:
+            original_reset()
+            inner = getattr(parser, "_parser", None)
+            if inner is not None:
+                inner.EntityDeclHandler = _forbid_entity_decl
+
+        parser.reset = reset_and_harden  # type: ignore[method-assign]
+
+
 def create_parser(target: InputSource, store: Graph) -> xmlreader.XMLReader:
     parser = make_parser()
+    _harden_parser(parser)
     try:
         # Workaround for bug in expatreader.py. Needed when
         # expatreader is trying to guess a prefix.

--- a/rdflib/plugins/parsers/trix.py
+++ b/rdflib/plugins/parsers/trix.py
@@ -5,7 +5,7 @@ A TriX parser for RDFLib
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NoReturn
-from xml.sax import handler, make_parser
+from xml.sax import SAXNotSupportedException, handler, make_parser
 from xml.sax.handler import ErrorHandler
 
 from rdflib.exceptions import ParserError
@@ -257,8 +257,49 @@ class TriXHandler(handler.ContentHandler):
         raise ParserError(info + message)
 
 
+def _forbid_entity_decl(
+    name: Any,
+    is_parameter_entity: Any,
+    value: Any,
+    base: Any,
+    sysid: Any,
+    pubid: Any,
+    notation_name: Any,
+) -> NoReturn:
+    """Reject DTD entity declarations to defeat billion-laughs / XXE attacks."""
+    raise SAXNotSupportedException(
+        "Entity declarations are not allowed in untrusted XML input "
+        "(rejected entity '%s')" % name
+    )
+
+
+def _harden_parser(parser: XMLReader) -> None:
+    """Disable external entities and forbid DTD entity declarations.
+
+    rdflib parses untrusted TriX/XML from the network. Without these guards a
+    sub-kilobyte "billion laughs" payload exhausts CPU and memory during parse.
+    Internal entity expansion (the only legitimate DTD entity use in TriX/XML)
+    is rejected outright; well-formed TriX does not need it.
+    """
+    parser.setFeature(handler.feature_external_ges, False)
+    parser.setFeature(handler.feature_external_pes, False)
+    # xml.sax.expatreader recreates self._parser inside reset() (which is
+    # called by parse()), so we have to wire the EntityDeclHandler each time.
+    if hasattr(parser, "reset"):
+        original_reset = parser.reset
+
+        def reset_and_harden() -> None:
+            original_reset()
+            inner = getattr(parser, "_parser", None)
+            if inner is not None:
+                inner.EntityDeclHandler = _forbid_entity_decl
+
+        parser.reset = reset_and_harden  # type: ignore[method-assign]
+
+
 def create_parser(store: Store) -> XMLReader:
     parser = make_parser()
+    _harden_parser(parser)
     try:
         # Workaround for bug in expatreader.py. Needed when
         # expatreader is trying to guess a prefix.

--- a/test/test_parsers/test_xxe_billion_laughs.py
+++ b/test/test_parsers/test_xxe_billion_laughs.py
@@ -1,0 +1,92 @@
+"""Regression test for the "billion laughs" entity-expansion DoS in the
+``xml.sax``-backed RDF/XML and TriX parsers.
+
+Both parsers historically built their SAX reader via ``xml.sax.make_parser()``
+without any entity hardening. A ~720-byte payload of seven nested entity
+declarations causes the parser to allocate / spin until the OS kills it
+(see ``rdflib/plugins/parsers/rdfxml.py`` and ``rdflib/plugins/parsers/trix.py``).
+
+The hardening rejects DTD entity declarations outright, so the parsers should
+either raise a SAX exception (preferred) or return quickly without expanding
+the bomb. Either outcome is a pass; what must NOT happen is a multi-second
+hang during parse of < 1 KiB of input.
+"""
+
+from __future__ import annotations
+
+import platform
+import signal
+from xml.sax import SAXException
+
+import pytest
+
+from rdflib import Graph
+
+# Seven levels of nested entity refs would expand to 10**7 copies of "lol"
+# if the parser cooperated. The whole DTD is well under one kilobyte.
+_BILLION_LAUGHS_DTD = b"""<!DOCTYPE rdf:RDF [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+]>"""
+
+RDFXML_PAYLOAD = (
+    b'<?xml version="1.0"?>\n'
+    + _BILLION_LAUGHS_DTD
+    + b'\n<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"'
+    + b' xmlns:ex="http://example.org/">\n'
+    + b'  <rdf:Description rdf:about="http://example.org/s">\n'
+    + b"    <ex:p>&lol7;</ex:p>\n"
+    + b"  </rdf:Description>\n"
+    + b"</rdf:RDF>\n"
+)
+
+TRIX_PAYLOAD = (
+    b'<?xml version="1.0"?>\n'
+    + _BILLION_LAUGHS_DTD.replace(b"rdf:RDF", b"TriX")
+    + b'\n<TriX xmlns="http://www.w3.org/2004/03/trix/trix-1/">\n'
+    + b"  <graph>\n"
+    + b"    <uri>http://example.org/g</uri>\n"
+    + b"    <triple>\n"
+    + b"      <uri>http://example.org/s</uri>\n"
+    + b"      <uri>http://example.org/p</uri>\n"
+    + b"      <plainLiteral>&lol7;</plainLiteral>\n"
+    + b"    </triple>\n"
+    + b"  </graph>\n"
+    + b"</TriX>\n"
+)
+
+# signal.alarm is POSIX-only; the test still has value on the platforms that
+# have it, which is what the CVE PoC ran on.
+_SUPPORTS_ALARM = hasattr(signal, "SIGALRM") and platform.system() != "Windows"
+
+
+class _Timeout(Exception):
+    pass
+
+
+def _on_alarm(signum, frame):  # pragma: no cover - signal handler
+    raise _Timeout("billion-laughs payload took too long to parse")
+
+
+@pytest.mark.skipif(not _SUPPORTS_ALARM, reason="requires POSIX signal.SIGALRM")
+@pytest.mark.parametrize(
+    "fmt,payload",
+    [
+        ("application/rdf+xml", RDFXML_PAYLOAD),
+        ("trix", TRIX_PAYLOAD),
+    ],
+)
+def test_billion_laughs_is_rejected_or_bounded(fmt: str, payload: bytes) -> None:
+    prev = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(5)
+    try:
+        with pytest.raises(SAXException):
+            Graph().parse(data=payload, format=fmt)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, prev)

--- a/test/test_parsers/test_xxe_billion_laughs.py
+++ b/test/test_parsers/test_xxe_billion_laughs.py
@@ -65,12 +65,12 @@ TRIX_PAYLOAD = (
 _SUPPORTS_ALARM = hasattr(signal, "SIGALRM") and platform.system() != "Windows"
 
 
-class _Timeout(Exception):
+class _TimeoutError(Exception):
     pass
 
 
 def _on_alarm(signum, frame):  # pragma: no cover - signal handler
-    raise _Timeout("billion-laughs payload took too long to parse")
+    raise _TimeoutError("billion-laughs payload took too long to parse")
 
 
 @pytest.mark.skipif(not _SUPPORTS_ALARM, reason="requires POSIX signal.SIGALRM")


### PR DESCRIPTION
## Summary

Fixes a network-reachable XML entity-expansion DoS ("billion laughs") in the RDF/XML and TriX parsers (`rdflib/plugins/parsers/rdfxml.py`, `rdflib/plugins/parsers/trix.py`). Both parsers build an `xml.sax` reader via `make_parser()` and hand it untrusted XML, but neither disables external entity resolution nor forbids DTD entity declarations. A < 1 KiB payload of seven nested entity declarations exhausts CPU and memory during parse.

Related: #327 (2021 discussion of XML hardening). This PR intentionally scopes down: it does NOT add a `defusedxml` dependency and does NOT change parser external API. It only flips the SAX `external-general-entities` / `external-parameter-entities` features off and installs an `EntityDeclHandler` on the underlying expat parser that rejects any internal-entity declaration with `SAXNotSupportedException`. Internal entity expansion has no legitimate use in well-formed RDF/XML or TriX, so refusing it is the safe default for any consumer of untrusted XML.

## Reproduction

On `main` (commit `0fdac39`), a 7-level billion-laughs RDF/XML payload (~720 bytes) hangs the parser at 99% CPU until the kernel kills the process. Equivalent payload for TriX behaves the same.

```python
import signal
from rdflib import Graph

DTD = (
    b'<!DOCTYPE rdf:RDF [\n'
    b'  <!ENTITY lol "lol">\n'
    b'  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">\n'
    b'  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">\n'
    b'  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">\n'
    b'  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">\n'
    b'  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">\n'
    b'  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">\n'
    b']>'
)
payload = (
    b'<?xml version="1.0"?>\n' + DTD + b'\n'
    b'<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"'
    b' xmlns:ex="http://example.org/">'
    b'<rdf:Description rdf:about="urn:x"><ex:p>&lol7;</ex:p></rdf:Description>'
    b'</rdf:RDF>'
)

signal.alarm(5)  # would otherwise hang past 30s of CPU
Graph().parse(data=payload, format="application/rdf+xml")
```

On this branch the same call raises `SAXNotSupportedException` in well under a millisecond. Same behaviour for `format="trix"` with the equivalent payload.

## Fix

`rdflib/plugins/parsers/rdfxml.py` and `rdflib/plugins/parsers/trix.py` each gain a small `_harden_parser` helper invoked immediately after `make_parser()`:

```python
parser.setFeature(handler.feature_external_ges, False)
parser.setFeature(handler.feature_external_pes, False)
# EntityDeclHandler is installed on the underlying expat parser inside
# reset() (since xml.sax.expatreader recreates self._parser on every parse).
```

The `EntityDeclHandler` raises `SAXNotSupportedException` on any `<!ENTITY ...>` declaration, which is what actually defeats billion-laughs (the `setFeature` calls alone only stop *external* entity loading). Internal entity expansion is the part that turns small inputs into unbounded work, and well-formed RDF/XML or TriX never relies on it.

## Tests

- [x] Added regression test `test/test_parsers/test_xxe_billion_laughs.py` (stdlib-only, POSIX `signal.alarm`-gated) - constructs the 7-level payload for both formats and asserts the parser refuses it within 5 s. Hangs on unpatched `main`; passes on this branch.
- [x] `pytest test/ --timeout=60 -q --ignore=test/data --ignore=test/test_misc/test_plugins.py` - 7489 passed, 591 skipped, 308 xfailed, 36 xpassed. (`test_misc/test_plugins.py::test_sparqleval` was skipped because of an unrelated missing `no_cover` fixture in main.)
- [x] `pytest test/test_parsers/ test/test_serializers/ test/test_w3c_spec/ --timeout=60` - 2560 passed, all RDF/XML and TriX W3C conformance suites green.

## Notes

- Same pattern Django, Calibre, FreeCAD, and docling apply directly after `xml.sax.make_parser()`. Stdlib-only, no new dependency.
- Not a `defusedxml` migration: #327 raised reasonable scope concerns about that. This PR keeps the parser API unchanged and only flips the few SAX/expat knobs that need flipping for the DoS to go away.
- The `reset()` wrapping is needed because `xml.sax.expatreader` rebuilds `self._parser` (the underlying pyexpat parser) on every `parse()`, so the `EntityDeclHandler` has to be reinstalled each time.