### PR TITLE
Create to_quads to support triples and quads; add add_many as a new

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -668,7 +668,9 @@ class Graph(Node):
         )
         return self
 
-    def addN(self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]) -> _GraphT:  # noqa: N802
+    def addN(  # noqa: N802
+        self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]
+    ) -> _GraphT:
         """Add a sequence of triples or quads.
 
         .. deprecated::
@@ -943,12 +945,12 @@ class Graph(Node):
         (subject, predicate, object).
         """
         (subject, predicate, object_) = triple
-        assert subject is not None, (
-            "s can't be None in .set([s,p,o]), as it would remove (*, p, *)"
-        )
-        assert predicate is not None, (
-            "p can't be None in .set([s,p,o]), as it would remove (s, *, *)"
-        )
+        assert (
+            subject is not None
+        ), "s can't be None in .set([s,p,o]), as it would remove (*, p, *)"
+        assert (
+            predicate is not None
+        ), "p can't be None in .set([s,p,o]), as it would remove (s, *, *)"
         self.remove((subject, predicate, None))
         self.add((subject, predicate, object_))
         return self
@@ -2188,9 +2190,9 @@ class ConjunctiveGraph(Graph):
                 stacklevel=2,
             )
 
-        assert self.store.context_aware, (
-            "ConjunctiveGraph must be backed by a context aware store."
-        )
+        assert (
+            self.store.context_aware
+        ), "ConjunctiveGraph must be backed by a context aware store."
         self.context_aware = True
         self.default_union = True  # Conjunctive!
         self._default_context: _ContextType = Graph(
@@ -3366,8 +3368,8 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
     def bind(  # type: ignore[override]
         self,
         prefix: str | None,
-        namespace: Any,
-        override: bool = True,  # noqa: F811
+        namespace: Any,  # noqa: F811
+        override: bool = True,
     ) -> NoReturn:
         raise UnSupportedAggregateOperation()
 

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -315,7 +315,7 @@ from rdflib.term import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Mapping
+    from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
 
     import typing_extensions as te
 
@@ -339,6 +339,7 @@ _OptionalQuadType: te.TypeAlias = tuple[
     _SubjectType, _PredicateType, _ObjectType, Optional["_ContextType"]
 ]
 _TripleOrOptionalQuadType: te.TypeAlias = Union[_TripleType, _OptionalQuadType]
+_TripleOrQuadType: te.TypeAlias = Union[_TripleType, _QuadType]
 _OptionalIdentifiedQuadType: te.TypeAlias = tuple[
     _SubjectType, _PredicateType, _ObjectType, Optional[_ContextIdentifierType]
 ]
@@ -428,7 +429,9 @@ __all__ = [
     "_QuadType",
     "_SubjectType",
     "_TripleOrOptionalQuadType",
+    "_TripleOrQuadType",
     "_TripleOrTriplePathType",
+    "to_quads",
     "_TripleOrQuadPathPatternType",
     "_TripleOrQuadPatternType",
     "_TripleOrQuadSelectorType",
@@ -639,17 +642,42 @@ class Graph(Node):
         self.__store.add((s, p, o), self, quoted=False)
         return self
 
-    def addN(self: _GraphT, quads: Iterable[_QuadType]) -> _GraphT:  # noqa: N802
-        """Add a sequence of triple with context"""
+    def add_many(self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]) -> _GraphT:
+        """Add a sequence of triples or quads.
+
+        When a triple ``(s, p, o)`` is given, ``self`` is used as the context.
+        When a quad ``(s, p, o, context)`` is given, only quads whose context
+        identifier matches this graph's identifier are added.
+
+        Args:
+            triples_or_quads: An iterable of triples ``(s, p, o)`` or quads
+                ``(s, p, o, context)``.
+
+        Returns:
+            The graph instance.
+        """
 
         self.__store.addN(
             (s, p, o, c)
-            for s, p, o, c in quads
+            for s, p, o, c in to_quads(triples_or_quads, self)
             if isinstance(c, Graph)
             and c.identifier is self.identifier
             and _assertnode(s, p, o)
         )
         return self
+
+    def addN(self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]) -> _GraphT:  # noqa: N802
+        """Add a sequence of triples or quads.
+
+        .. deprecated::
+            Use :meth:`add_many` instead.
+        """
+        warnings.warn(
+            "Graph.addN is deprecated, use Graph.add_many instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_many(triples_or_quads)
 
     def remove(self: _GraphT, triple: _TriplePatternType) -> _GraphT:
         """Remove a triple from the graph
@@ -845,7 +873,7 @@ class Graph(Node):
     def __iadd__(self: _GraphT, other: Iterable[_TripleType]) -> _GraphT:
         """Add all triples in Graph other to Graph.
         BNode IDs are not changed."""
-        self.addN((s, p, o, self) for s, p, o in other)
+        self.add_many((s, p, o, self) for s, p, o in other)
         return self
 
     def __isub__(self: _GraphT, other: Iterable[_TripleType]) -> _GraphT:
@@ -2297,15 +2325,43 @@ class ConjunctiveGraph(Graph):
                 # Return the graph with the same backing store.
                 return _graph
 
-    def addN(  # noqa: N802
-        self: _ConjunctiveGraphT, quads: Iterable[_QuadType]
+    def add_many(
+        self: _ConjunctiveGraphT, triples_or_quads: Iterable[_TripleOrQuadType]
     ) -> _ConjunctiveGraphT:
-        """Add a sequence of triples with context"""
+        """Add a sequence of triples or quads.
+
+        When a triple ``(s, p, o)`` is given, ``self.default_context`` is used
+        as the context.
+
+        Args:
+            triples_or_quads: An iterable of triples ``(s, p, o)`` or quads
+                ``(s, p, o, context)``.
+
+        Returns:
+            The graph instance.
+        """
 
         self.store.addN(
-            (s, p, o, self._graph(c)) for s, p, o, c in quads if _assertnode(s, p, o)
+            (s, p, o, self._graph(c))
+            for s, p, o, c in to_quads(triples_or_quads, self.default_context)
+            if _assertnode(s, p, o)
         )
         return self
+
+    def addN(  # noqa: N802
+        self: _ConjunctiveGraphT, triples_or_quads: Iterable[_TripleOrQuadType]
+    ) -> _ConjunctiveGraphT:
+        """Add a sequence of triples or quads.
+
+        .. deprecated::
+            Use :meth:`add_many` instead.
+        """
+        warnings.warn(
+            "ConjunctiveGraph.addN is deprecated, use add_many instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_many(triples_or_quads)
 
     # type error: Argument 1 of "remove" is incompatible with supertype "Graph"; supertype defines the argument type as "tuple[Optional[Node], Optional[Node], Optional[Node]]"
     def remove(self: _ConjunctiveGraphT, triple_or_quad: _TripleOrOptionalQuadType) -> _ConjunctiveGraphT:  # type: ignore[override]
@@ -2769,7 +2825,7 @@ class Dataset(ConjunctiveGraph):
     def __iadd__(self: _DatasetT, other: Iterable[_QuadType]) -> _DatasetT:  # type: ignore[override, misc]
         """Add all quads in Dataset other to Dataset.
         BNode IDs are not changed."""
-        self.addN((s, p, o, g) for s, p, o, g in other)
+        self.add_many((s, p, o, g) for s, p, o, g in other)
         return self
 
     def graph(
@@ -3354,6 +3410,31 @@ def _assertnode(*terms: Any) -> bool:
     return True
 
 
+def to_quads(
+    triples_or_quads: Iterable[_TripleOrQuadType],
+    default_context: _ContextType,
+) -> Iterator[_QuadType]:
+    """Normalise an iterable of triples or quads into quads.
+
+    Triples ``(s, p, o)`` are extended with *default_context* as the fourth
+    element.  Quads are yielded unchanged.
+
+    Args:
+        triples_or_quads: An iterable of triples ``(s, p, o)`` or quads
+            ``(s, p, o, context)``.
+        default_context: The graph to use as context when the input item is a
+            triple.
+
+    Yields:
+        4-tuples ``(subject, predicate, object, context)``.
+    """
+    for item in triples_or_quads:
+        if len(item) == 3:
+            yield *item, default_context  # type: ignore[misc]
+        else:
+            yield item  # type: ignore[misc]
+
+
 class BatchAddGraph:
     """Wrapper around graph that turns batches of calls to Graph's add
     (and optionally, addN) into calls to batched calls to addN`.
@@ -3398,7 +3479,7 @@ class BatchAddGraph:
             The BatchAddGraph instance
         """
         if len(self.batch) >= self.__batch_size:
-            self.graph.addN(self.batch)
+            self.graph.add_many(self.batch)
             self.batch = []
         self.count += 1
         if len(triple_or_quad) == 3:
@@ -3409,13 +3490,23 @@ class BatchAddGraph:
             self.batch.append(triple_or_quad)  # type: ignore[arg-type, unused-ignore]
         return self
 
-    def addN(self, quads: Iterable[_QuadType]) -> BatchAddGraph:  # noqa: N802
+    def add_many(self, quads: Iterable[_QuadType]) -> BatchAddGraph:
+        """Add a sequence of quads to the buffer."""
         if self.__batch_addn:
             for q in quads:
                 self.add(q)
         else:
-            self.graph.addN(quads)
+            self.graph.add_many(quads)
         return self
+
+    def addN(self, quads: Iterable[_QuadType]) -> BatchAddGraph:  # noqa: N802
+        """.. deprecated:: Use :meth:`add_many` instead."""
+        warnings.warn(
+            "BatchAddGraph.addN is deprecated, use add_many instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_many(quads)
 
     def __enter__(self) -> BatchAddGraph:
         self.reset()
@@ -3423,4 +3514,4 @@ class BatchAddGraph:
 
     def __exit__(self, *exc) -> None:
         if exc[0] is None:
-            self.graph.addN(self.batch)
+            self.graph.add_many(self.batch)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -642,7 +642,9 @@ class Graph(Node):
         self.__store.add((s, p, o), self, quoted=False)
         return self
 
-    def add_many(self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]) -> _GraphT:
+    def add_many(
+        self: _GraphT, triples_or_quads: Iterable[_TripleOrQuadType]
+    ) -> _GraphT:
         """Add a sequence of triples or quads.
 
         When a triple ``(s, p, o)`` is given, ``self`` is used as the context.
@@ -941,12 +943,12 @@ class Graph(Node):
         (subject, predicate, object).
         """
         (subject, predicate, object_) = triple
-        assert (
-            subject is not None
-        ), "s can't be None in .set([s,p,o]), as it would remove (*, p, *)"
-        assert (
-            predicate is not None
-        ), "p can't be None in .set([s,p,o]), as it would remove (s, *, *)"
+        assert subject is not None, (
+            "s can't be None in .set([s,p,o]), as it would remove (*, p, *)"
+        )
+        assert predicate is not None, (
+            "p can't be None in .set([s,p,o]), as it would remove (s, *, *)"
+        )
         self.remove((subject, predicate, None))
         self.add((subject, predicate, object_))
         return self
@@ -1132,7 +1134,8 @@ class Graph(Node):
         # type error: Argument 1 to "triples_choices" of "Store" has incompatible type "tuple[Union[list[Node], Node], Union[Node, list[Node]], Union[Node, list[Node]]]"; expected "Union[tuple[list[Node], Node, Node], tuple[Node, list[Node], Node], tuple[Node, Node, list[Node]]]"
         # type error note: unpacking discards type info
         for (s, p, o), cg in self.store.triples_choices(
-            (subject, predicate, object_), context=self  # type: ignore[arg-type]
+            (subject, predicate, object_),
+            context=self,  # type: ignore[arg-type]
         ):
             yield s, p, o
 
@@ -2186,7 +2189,7 @@ class ConjunctiveGraph(Graph):
             )
 
         assert self.store.context_aware, (
-            "ConjunctiveGraph must be backed by" " a context aware store."
+            "ConjunctiveGraph must be backed by a context aware store."
         )
         self.context_aware = True
         self.default_union = True  # Conjunctive!
@@ -2364,7 +2367,9 @@ class ConjunctiveGraph(Graph):
         return self.add_many(triples_or_quads)
 
     # type error: Argument 1 of "remove" is incompatible with supertype "Graph"; supertype defines the argument type as "tuple[Optional[Node], Optional[Node], Optional[Node]]"
-    def remove(self: _ConjunctiveGraphT, triple_or_quad: _TripleOrOptionalQuadType) -> _ConjunctiveGraphT:  # type: ignore[override]
+    def remove(
+        self: _ConjunctiveGraphT, triple_or_quad: _TripleOrOptionalQuadType
+    ) -> _ConjunctiveGraphT:  # type: ignore[override]
         """Removes a triple or quads
 
         if a triple is given it is removed from all contexts
@@ -2802,9 +2807,7 @@ class Dataset(ConjunctiveGraph):
         return (self.store, self.default_union, self.default_context.base)
 
     def __str__(self) -> str:
-        pattern = (
-            "[a rdflib:Dataset;rdflib:storage " "[a rdflib:Store;rdfs:label '%s']]"
-        )
+        pattern = "[a rdflib:Dataset;rdflib:storage [a rdflib:Store;rdfs:label '%s']]"
         return pattern % self.store.__class__.__name__
 
     # type error: Return type "tuple[Type[Dataset], tuple[Store, bool]]" of "__reduce__" incompatible with return type "tuple[Type[Graph], tuple[Store, IdentifiedNode]]" in supertype "ConjunctiveGraph"
@@ -3186,7 +3189,7 @@ class UnSupportedAggregateOperation(Exception):  # noqa: N818
         pass
 
     def __str__(self) -> str:
-        return "This operation is not supported by ReadOnlyGraphAggregate " "instances"
+        return "This operation is not supported by ReadOnlyGraphAggregate instances"
 
 
 class ReadOnlyGraphAggregate(ConjunctiveGraph):
@@ -3361,7 +3364,10 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
 
     # type error: Signature of "bind" incompatible with supertype "Graph"
     def bind(  # type: ignore[override]
-        self, prefix: str | None, namespace: Any, override: bool = True  # noqa: F811
+        self,
+        prefix: str | None,
+        namespace: Any,
+        override: bool = True,  # noqa: F811
     ) -> NoReturn:
         raise UnSupportedAggregateOperation()
 

--- a/test/test_graph/test_add_many.py
+++ b/test/test_graph/test_add_many.py
@@ -1,0 +1,131 @@
+"""Tests for to_quads() and the Graph/ConjunctiveGraph/Dataset add_many() methods."""
+
+from __future__ import annotations
+
+from rdflib import ConjunctiveGraph, Dataset, Graph, URIRef
+from rdflib.graph import to_quads
+
+S = URIRef("urn:s")
+P = URIRef("urn:p")
+O = URIRef("urn:o")
+
+
+class TestToQuads:
+    def test_triple_uses_default_context(self) -> None:
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        result = list(to_quads([(S, P, O)], ctx))
+        assert result == [(S, P, O, ctx)]
+
+    def test_quad_is_yielded_unchanged(self) -> None:
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        other = Graph(identifier=URIRef("urn:other"))
+        result = list(to_quads([(S, P, O, other)], ctx))
+        assert result == [(S, P, O, other)]
+
+    def test_mixed_triples_and_quads(self) -> None:
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        other = Graph(identifier=URIRef("urn:other"))
+        items = [(S, P, O), (S, P, O, other)]
+        result = list(to_quads(items, ctx))
+        assert result == [(S, P, O, ctx), (S, P, O, other)]
+
+    def test_empty_input(self) -> None:
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        assert list(to_quads([], ctx)) == []
+
+    def test_multiple_triples_all_get_default_context(self) -> None:
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
+        result = list(to_quads([(S, P, O), (s2, p2, o2)], ctx))
+        assert result == [(S, P, O, ctx), (s2, p2, o2, ctx)]
+
+    def test_result_is_lazy_generator(self) -> None:
+        """to_quads should return a generator, not a list."""
+        ctx = Graph(identifier=URIRef("urn:ctx"))
+        import types
+
+        result = to_quads([(S, P, O)], ctx)
+        assert isinstance(result, types.GeneratorType)
+
+
+class TestGraphAddMany:
+    def test_triple_uses_self_as_context(self) -> None:
+        g = Graph(identifier=URIRef("urn:g"))
+        g.add_many([(S, P, O)])
+        assert (S, P, O) in g
+
+    def test_quad_with_matching_context_is_added(self) -> None:
+        g = Graph(identifier=URIRef("urn:g"))
+        g.add_many([(S, P, O, g)])
+        assert (S, P, O) in g
+
+    def test_quad_with_non_matching_context_is_skipped(self) -> None:
+        g = Graph(identifier=URIRef("urn:g"))
+        other = Graph(identifier=URIRef("urn:other"))
+        g.add_many([(S, P, O, other)])
+        assert (S, P, O) not in g
+
+    def test_mixed_triple_and_matching_quad(self) -> None:
+        g = Graph(identifier=URIRef("urn:g"))
+        s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
+        g.add_many([(S, P, O), (s2, p2, o2, g)])
+        assert (S, P, O) in g
+        assert (s2, p2, o2) in g
+
+    def test_returns_self(self) -> None:
+        g = Graph()
+        assert g.add_many([(S, P, O)]) is g
+
+    def test_empty_input(self) -> None:
+        g = Graph()
+        g.add_many([])
+        assert len(g) == 0
+
+
+class TestConjunctiveGraphAddMany:
+    def test_triple_goes_to_default_context(self) -> None:
+        cg = ConjunctiveGraph()
+        cg.add_many([(S, P, O)])
+        assert (S, P, O) in cg.default_context
+
+    def test_quad_goes_to_named_context(self) -> None:
+        cg = ConjunctiveGraph()
+        ctx = cg.get_context(URIRef("urn:ctx"))
+        cg.add_many([(S, P, O, ctx)])
+        assert (S, P, O) in ctx
+        assert (S, P, O) not in cg.default_context
+
+    def test_mixed_triple_and_quad(self) -> None:
+        cg = ConjunctiveGraph()
+        ctx = cg.get_context(URIRef("urn:ctx"))
+        s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
+        cg.add_many([(S, P, O), (s2, p2, o2, ctx)])
+        assert (S, P, O) in cg.default_context
+        assert (s2, p2, o2) in ctx
+
+    def test_returns_self(self) -> None:
+        cg = ConjunctiveGraph()
+        assert cg.add_many([(S, P, O)]) is cg
+
+    def test_empty_input(self) -> None:
+        cg = ConjunctiveGraph()
+        cg.add_many([])
+        assert len(cg) == 0
+
+
+class TestDatasetAddMany:
+    def test_triple_goes_to_default_context(self) -> None:
+        ds = Dataset()
+        ds.add_many([(S, P, O)])
+        assert (S, P, O) in ds.default_context
+
+    def test_quad_goes_to_named_context(self) -> None:
+        ds = Dataset()
+        ctx = ds.graph(URIRef("urn:ctx"))
+        ds.add_many([(S, P, O, ctx)])
+        assert (S, P, O) in ctx
+        assert (S, P, O) not in ds.default_context
+
+    def test_returns_self(self) -> None:
+        ds = Dataset()
+        assert ds.add_many([(S, P, O)]) is ds

--- a/test/test_graph/test_add_many.py
+++ b/test/test_graph/test_add_many.py
@@ -5,29 +5,32 @@ from __future__ import annotations
 from rdflib import ConjunctiveGraph, Dataset, Graph, URIRef
 from rdflib.graph import to_quads
 
-S = URIRef("urn:s")
-P = URIRef("urn:p")
-O = URIRef("urn:o")
+subject = URIRef("urn:s")
+predicate = URIRef("urn:p")
+object = URIRef("urn:o")
 
 
 class TestToQuads:
     def test_triple_uses_default_context(self) -> None:
         ctx = Graph(identifier=URIRef("urn:ctx"))
-        result = list(to_quads([(S, P, O)], ctx))
-        assert result == [(S, P, O, ctx)]
+        result = list(to_quads([(subject, predicate, object)], ctx))
+        assert result == [(subject, predicate, object, ctx)]
 
     def test_quad_is_yielded_unchanged(self) -> None:
         ctx = Graph(identifier=URIRef("urn:ctx"))
         other = Graph(identifier=URIRef("urn:other"))
-        result = list(to_quads([(S, P, O, other)], ctx))
-        assert result == [(S, P, O, other)]
+        result = list(to_quads([(subject, predicate, object, other)], ctx))
+        assert result == [(subject, predicate, object, other)]
 
     def test_mixed_triples_and_quads(self) -> None:
         ctx = Graph(identifier=URIRef("urn:ctx"))
         other = Graph(identifier=URIRef("urn:other"))
-        items = [(S, P, O), (S, P, O, other)]
+        items = [(subject, predicate, object), (subject, predicate, object, other)]
         result = list(to_quads(items, ctx))
-        assert result == [(S, P, O, ctx), (S, P, O, other)]
+        assert result == [
+            (subject, predicate, object, ctx),
+            (subject, predicate, object, other),
+        ]
 
     def test_empty_input(self) -> None:
         ctx = Graph(identifier=URIRef("urn:ctx"))
@@ -36,45 +39,45 @@ class TestToQuads:
     def test_multiple_triples_all_get_default_context(self) -> None:
         ctx = Graph(identifier=URIRef("urn:ctx"))
         s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
-        result = list(to_quads([(S, P, O), (s2, p2, o2)], ctx))
-        assert result == [(S, P, O, ctx), (s2, p2, o2, ctx)]
+        result = list(to_quads([(subject, predicate, object), (s2, p2, o2)], ctx))
+        assert result == [(subject, predicate, object, ctx), (s2, p2, o2, ctx)]
 
     def test_result_is_lazy_generator(self) -> None:
         """to_quads should return a generator, not a list."""
         ctx = Graph(identifier=URIRef("urn:ctx"))
         import types
 
-        result = to_quads([(S, P, O)], ctx)
+        result = to_quads([(subject, predicate, object)], ctx)
         assert isinstance(result, types.GeneratorType)
 
 
 class TestGraphAddMany:
     def test_triple_uses_self_as_context(self) -> None:
         g = Graph(identifier=URIRef("urn:g"))
-        g.add_many([(S, P, O)])
-        assert (S, P, O) in g
+        g.add_many([(subject, predicate, object)])
+        assert (subject, predicate, object) in g
 
     def test_quad_with_matching_context_is_added(self) -> None:
         g = Graph(identifier=URIRef("urn:g"))
-        g.add_many([(S, P, O, g)])
-        assert (S, P, O) in g
+        g.add_many([(subject, predicate, object, g)])
+        assert (subject, predicate, object) in g
 
     def test_quad_with_non_matching_context_is_skipped(self) -> None:
         g = Graph(identifier=URIRef("urn:g"))
         other = Graph(identifier=URIRef("urn:other"))
-        g.add_many([(S, P, O, other)])
-        assert (S, P, O) not in g
+        g.add_many([(subject, predicate, object, other)])
+        assert (subject, predicate, object) not in g
 
     def test_mixed_triple_and_matching_quad(self) -> None:
         g = Graph(identifier=URIRef("urn:g"))
         s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
-        g.add_many([(S, P, O), (s2, p2, o2, g)])
-        assert (S, P, O) in g
+        g.add_many([(subject, predicate, object), (s2, p2, o2, g)])
+        assert (subject, predicate, object) in g
         assert (s2, p2, o2) in g
 
     def test_returns_self(self) -> None:
         g = Graph()
-        assert g.add_many([(S, P, O)]) is g
+        assert g.add_many([(subject, predicate, object)]) is g
 
     def test_empty_input(self) -> None:
         g = Graph()
@@ -85,27 +88,27 @@ class TestGraphAddMany:
 class TestConjunctiveGraphAddMany:
     def test_triple_goes_to_default_context(self) -> None:
         cg = ConjunctiveGraph()
-        cg.add_many([(S, P, O)])
-        assert (S, P, O) in cg.default_context
+        cg.add_many([(subject, predicate, object)])
+        assert (subject, predicate, object) in cg.default_context
 
     def test_quad_goes_to_named_context(self) -> None:
         cg = ConjunctiveGraph()
         ctx = cg.get_context(URIRef("urn:ctx"))
-        cg.add_many([(S, P, O, ctx)])
-        assert (S, P, O) in ctx
-        assert (S, P, O) not in cg.default_context
+        cg.add_many([(subject, predicate, object, ctx)])
+        assert (subject, predicate, object) in ctx
+        assert (subject, predicate, object) not in cg.default_context
 
     def test_mixed_triple_and_quad(self) -> None:
         cg = ConjunctiveGraph()
         ctx = cg.get_context(URIRef("urn:ctx"))
         s2, p2, o2 = URIRef("urn:s2"), URIRef("urn:p2"), URIRef("urn:o2")
-        cg.add_many([(S, P, O), (s2, p2, o2, ctx)])
-        assert (S, P, O) in cg.default_context
+        cg.add_many([(subject, predicate, object), (s2, p2, o2, ctx)])
+        assert (subject, predicate, object) in cg.default_context
         assert (s2, p2, o2) in ctx
 
     def test_returns_self(self) -> None:
         cg = ConjunctiveGraph()
-        assert cg.add_many([(S, P, O)]) is cg
+        assert cg.add_many([(subject, predicate, object)]) is cg
 
     def test_empty_input(self) -> None:
         cg = ConjunctiveGraph()
@@ -116,16 +119,16 @@ class TestConjunctiveGraphAddMany:
 class TestDatasetAddMany:
     def test_triple_goes_to_default_context(self) -> None:
         ds = Dataset()
-        ds.add_many([(S, P, O)])
-        assert (S, P, O) in ds.default_context
+        ds.add_many([(subject, predicate, object)])
+        assert (subject, predicate, object) in ds.default_context
 
     def test_quad_goes_to_named_context(self) -> None:
         ds = Dataset()
         ctx = ds.graph(URIRef("urn:ctx"))
-        ds.add_many([(S, P, O, ctx)])
-        assert (S, P, O) in ctx
-        assert (S, P, O) not in ds.default_context
+        ds.add_many([(subject, predicate, object, ctx)])
+        assert (subject, predicate, object) in ctx
+        assert (subject, predicate, object) not in ds.default_context
 
     def test_returns_self(self) -> None:
         ds = Dataset()
-        assert ds.add_many([(S, P, O)]) is ds
+        assert ds.add_many([(subject, predicate, object)]) is ds


### PR DESCRIPTION

# Summary of changes

* Create `to_quads` to support triples and quads
* Add `Graph.add_many` as a new recommended way to add multiple tuples
* Deprecate `Graph.addN`
* Closes https://github.com/RDFLib/rdflib/issues/3353

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [x] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

