### PR TITLE
Add initial RDF 1.2 support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -107,6 +107,7 @@ Mark Watts
 Mark van der Pas
 Martin Wendt
 Martin van der Werff
+Matt Goldberg
 Matthias Urban
 Maurizio Nagni
 Maxim Kolchin

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "IdentifiedNode",
     "Literal",
     "Node",
+    "TripleTerm",
     "Variable",
     "Namespace",
     "Dataset",
@@ -200,7 +201,15 @@ from rdflib.namespace import (
     XSD,
     Namespace,
 )
-from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef, Variable
+from rdflib.term import (
+    BNode,
+    IdentifiedNode,
+    Literal,
+    Node,
+    TripleTerm,
+    URIRef,
+    Variable,
+)
 
 from rdflib import plugin, query, util  # isort:skip
 from rdflib.container import *  # isort:skip # noqa: F403

--- a/rdflib/compare.py
+++ b/rdflib/compare.py
@@ -119,10 +119,91 @@ from typing import (
 )
 
 from rdflib.graph import ConjunctiveGraph, Graph, ReadOnlyGraphAggregate, _TripleType
-from rdflib.term import BNode, IdentifiedNode, Node, URIRef
+from rdflib.term import BNode, IdentifiedNode, Literal, Node, TripleTerm, URIRef
 
 if TYPE_CHECKING:
     from _hashlib import HASH
+
+
+def _get_bnodes_from_term(term: Node) -> Set[BNode]:
+    """Extract all blank nodes from a term, recursing into TripleTerms.
+
+    RDF 1.2 introduces triple terms (see
+    https://www.w3.org/TR/rdf12-concepts/#section-triple-terms) which may
+    contain blank nodes in their subject and object positions. For graph
+    canonicalization and isomorphism checking, we need to discover *all*
+    blank nodes that participate in a graph -- including those embedded
+    inside triple terms that appear as objects of asserted triples.
+
+    Per the RDF 1.2 abstract model:
+      - A triple term's **subject** is always an IRI or blank node (never
+        a nested TripleTerm, since triple terms can only appear in the
+        object position of a triple).
+      - A triple term's **predicate** is always an IRI.
+      - A triple term's **object** may be an IRI, blank node, literal, or
+        another (nested) triple term.
+
+    This function therefore:
+      1. Returns ``{term}`` immediately if the term itself is a BNode.
+      2. For a TripleTerm, collects BNodes from the subject and object
+         positions, recursing into nested TripleTerms in the object.
+      3. Returns the empty set for IRIs and Literals.
+
+    Args:
+        term: Any RDF node (BNode, URIRef, Literal, or TripleTerm).
+
+    Returns:
+        The set of all BNodes reachable within this term.
+    """
+    if isinstance(term, BNode):
+        return {term}
+    elif isinstance(term, TripleTerm):
+        result: Set[BNode] = set()
+        if isinstance(term.subject, BNode):
+            result.add(term.subject)
+        if isinstance(term.object, BNode):
+            result.add(term.object)
+        elif isinstance(term.object, TripleTerm):
+            result.update(_get_bnodes_from_term(term.object))
+        return result
+    return set()
+
+
+def _remap_triple_term(tt: TripleTerm, mapping: Dict[BNode, BNode]) -> TripleTerm:
+    """Apply a blank node mapping to a TripleTerm, producing a new TripleTerm.
+
+    During graph canonicalization and isomorphism checking, blank nodes are
+    relabeled (e.g., to canonical ``cb<hash>`` identifiers or to a mock BNode
+    for similarity checks). When a blank node appears *inside* an RDF 1.2
+    triple term -- either as the subject or the object -- those embedded
+    BNodes must be remapped consistently with how they are remapped at the
+    graph level.
+
+    This function walks the TripleTerm structure and replaces any BNode that
+    appears in the provided ``mapping`` dict. Because the RDF 1.2 spec allows
+    nested triple terms only in the **object** position, we recurse into the
+    object when it is itself a TripleTerm, but never into the subject.
+
+    Args:
+        tt: The TripleTerm whose embedded BNodes should be remapped.
+        mapping: A dictionary mapping original BNodes to their replacements.
+
+    Returns:
+        A new TripleTerm with BNodes replaced according to the mapping.
+        If no BNodes in the TripleTerm appear in the mapping, the returned
+        TripleTerm may still be a new instance.
+    """
+    s: Union[URIRef, BNode] = (
+        mapping.get(tt.subject, tt.subject)
+        if isinstance(tt.subject, BNode)
+        else tt.subject
+    )
+    o: Union[URIRef, BNode, Literal, TripleTerm] = tt.object
+    if isinstance(o, BNode):
+        o = mapping.get(o, o)
+    elif isinstance(o, TripleTerm):
+        o = _remap_triple_term(o, mapping)
+    return TripleTerm(s, tt.predicate, o)
 
 
 def _total_seconds(td):
@@ -320,25 +401,149 @@ class _TripleCanonicalizer:
         non-blank nodes that are adjacent. Nodes that are not adjacent to blank
         nodes are not included, as they are a) already colored (by URI or literal)
         and b) do not factor into the color of any blank node.
+
+        RDF 1.2 TripleTerm handling:
+            Triple terms (``<<( s p o )>>``) may contain embedded blank nodes
+            in their subject or object positions. For correct canonicalization,
+            the algorithm must handle two classes of BNodes differently:
+
+            **Graph-level BNodes** (those that appear as a direct subject,
+            predicate, or object in asserted triples) are collected into a
+            single initial color class and refined by ``Color.distinguish()``
+            which uses ``graph.triples()`` to find their structural edges.
+
+            **Embedded-only BNodes** (those that appear exclusively inside
+            TripleTerms and never directly in asserted triple positions) are
+            invisible to ``graph.triples()`` queries, so ``distinguish()``
+            cannot differentiate them. To solve this, we record each embedded
+            BNode's *structural context* -- its position within the TripleTerm
+            (subject vs object), the asserted triple's subject and predicate,
+            and the other non-bnode terms in the TripleTerm. Embedded-only
+            BNodes are then grouped by this context and assigned distinct
+            initial colors, ensuring that BNodes in different structural
+            positions produce different canonical hashes deterministically.
+
+            Additionally:
+            1. BNodes embedded inside TripleTerms are discovered via
+               ``_get_bnodes_from_term`` and included in the bnode set.
+            2. The TripleTerm itself is added to "others" as a composite value
+               for coloring (it is not a blank node, even though it contains
+               blank nodes).
+            3. Each embedded BNode is registered as a neighbor of the asserted
+               triple's subject (used as supplementary structural data).
         """
         bnodes: Set[BNode] = set()
         others = set()
         self._neighbors = defaultdict(set)
+        # RDF 1.2: Track structural context for BNodes embedded in TripleTerms.
+        # BNodes that appear only inside TripleTerms are invisible to
+        # graph.triples() queries, so Color.distinguish() cannot differentiate
+        # them from other embedded BNodes. We record contextual information
+        # (their position and surrounding terms in the TripleTerm) so that we
+        # can assign them distinguishing initial colors.
+        self._embedded_bnode_contexts: Dict[BNode, Set[tuple]] = defaultdict(set)
+        # Collect graph-level BNodes (those appearing directly as s/p/o in
+        # asserted triples) in the same pass to avoid a second iteration.
+        graph_level_bnodes: Set[BNode] = set()
         for s, p, o in self.graph:
-            nodes = set([s, p, o])
-            b = set([x for x in nodes if isinstance(x, BNode)])
+            # Track graph-level BNodes as we encounter them.
+            if isinstance(s, BNode):
+                graph_level_bnodes.add(s)
+            if isinstance(p, BNode):
+                graph_level_bnodes.add(p)
+            if isinstance(o, BNode):
+                graph_level_bnodes.add(o)
+
+            # RDF 1.2: Extract BNodes embedded inside TripleTerms in object
+            # position. These must participate in the canonicalization just
+            # like top-level BNodes.
+            embedded_bnodes: Set[BNode] = set()
+            if isinstance(o, TripleTerm):
+                embedded_bnodes = _get_bnodes_from_term(o)
+                # Record structural context for each embedded BNode.
+                # This enables distinguish-by-context for BNodes that are
+                # invisible to graph.triples().
+                self._record_triple_term_context(o, s, p)
+
+            b = set([x for x in (s, p, o) if isinstance(x, BNode)]) | embedded_bnodes
             if len(b) > 0:
-                others |= nodes - b
+                # Collect non-bnode, non-TripleTerm terms as "others" for
+                # coloring. Only `o` can be a TripleTerm per the RDF model.
+                for term in (s, p, o):
+                    if term not in b and not isinstance(term, TripleTerm):
+                        others.add(term)
+                # Add the TripleTerm itself to "others" for coloring. It acts
+                # as a distinguishing label (like a literal or IRI) but is not
+                # a bnode.
+                if isinstance(o, TripleTerm):
+                    others.add(o)
                 bnodes |= b
                 if isinstance(s, BNode):
                     self._neighbors[s].add(o)
                 if isinstance(o, BNode):
                     self._neighbors[o].add(s)
+                elif isinstance(o, TripleTerm):
+                    # Each BNode embedded in a TripleTerm is considered a
+                    # neighbor of the asserted triple's subject. This ensures
+                    # that the coloring algorithm can distinguish graphs where
+                    # the same BNode appears inside different TripleTerms.
+                    for bn in embedded_bnodes:
+                        self._neighbors[bn].add(s)
                 if isinstance(p, BNode):
                     self._neighbors[p].add(s)
                     self._neighbors[p].add(p)
         if len(bnodes) > 0:
-            return [Color(list(bnodes), self.hashfunc, hash_cache=self._hash_cache)] + [
+            # Separate embedded-only BNodes into distinct initial color
+            # classes based on their structural context within TripleTerms.
+            # BNodes that also appear at the graph level are handled normally
+            # by distinguish() since graph.triples() can see them.
+            embedded_only = bnodes - graph_level_bnodes
+            graph_bnodes = bnodes & graph_level_bnodes
+
+            # Group embedded-only BNodes by their structural context hash
+            # so that structurally equivalent BNodes get the same color.
+            embedded_color_groups: Dict[str, List[BNode]] = defaultdict(list)
+            for bn in embedded_only:
+                # Create a hashable context key from the sorted string
+                # representations of the BNode's structural contexts.
+                ctx = self._embedded_bnode_contexts.get(bn, set())
+                ctx_key = str(sorted(str(c) for c in ctx))
+                embedded_color_groups[ctx_key].append(bn)
+
+            # Build the initial coloring:
+            # - One color for all graph-level BNodes (they will be refined by
+            #   distinguish() using graph.triples()).
+            # - Separate colors for each group of embedded-only BNodes that
+            #   share the same structural context. Each group receives a
+            #   unique initial color derived from its context key, ensuring
+            #   that BNodes in different positions produce different canonical
+            #   hashes even when they cannot be reached by graph.triples().
+            bnode_colors: List[Color] = []
+            if graph_bnodes:
+                bnode_colors.append(
+                    Color(
+                        list(graph_bnodes), self.hashfunc, hash_cache=self._hash_cache
+                    )
+                )
+            for ctx_key, group in embedded_color_groups.items():
+                # Use the context key as the initial color so that BNodes in
+                # different structural positions start with different colors
+                # and thus produce different canonical labels.
+                # We wrap it in a tuple-of-tuples structure compatible with
+                # Color.hash_color() which expects ColorItemTuple.
+                context_color: Tuple = (
+                    (ctx_key, URIRef("urn:rdflib:tt-ctx"), ctx_key),
+                )
+                bnode_colors.append(
+                    Color(
+                        list(group),
+                        self.hashfunc,
+                        context_color,
+                        hash_cache=self._hash_cache,
+                    )
+                )
+
+            return bnode_colors + [
                 # type error: List item 0 has incompatible type "Union[IdentifiedNode, Literal]"; expected "IdentifiedNode"
                 # type error: Argument 3 to "Color" has incompatible type "Union[IdentifiedNode, Literal]"; expected "Tuple[Tuple[Union[int, str], URIRef, Union[int, str]], ...]"
                 Color([x], self.hashfunc, x, hash_cache=self._hash_cache)  # type: ignore[list-item, arg-type]
@@ -346,6 +551,67 @@ class _TripleCanonicalizer:
             ]
         else:
             return []
+
+    @staticmethod
+    def _describe_term(term: Node) -> str:
+        """Return a position-stable descriptor for a term, masking BNode identity.
+
+        Used by ``_record_triple_term_context`` to build structural context
+        tuples without leaking specific BNode labels (which would defeat the
+        purpose of position-based coloring).
+        """
+        if isinstance(term, BNode):
+            return "_:*"
+        elif isinstance(term, TripleTerm):
+            return "<<TripleTerm>>"
+        return term.n3()
+
+    def _record_triple_term_context(
+        self, tt: TripleTerm, graph_subject: Node, graph_predicate: Node
+    ) -> None:
+        """Record structural context for BNodes embedded in a TripleTerm.
+
+        For each BNode found inside the TripleTerm, we record a tuple
+        describing its position and the surrounding non-bnode terms. This
+        contextual information is used during initial coloring to distinguish
+        BNodes that appear only inside TripleTerms (and are thus invisible
+        to graph.triples() queries used by Color.distinguish()).
+
+        The context tuple for a BNode in the **subject** position of a
+        TripleTerm is: ``("tt_subject", graph_subject, graph_predicate,
+        tt.predicate, <object_descriptor>)``
+
+        The context tuple for a BNode in the **object** position is:
+        ``("tt_object", graph_subject, graph_predicate, <subject_descriptor>,
+        tt.predicate)``
+
+        Where descriptors for non-bnode terms are their n3() representation,
+        and descriptors for BNode terms are the placeholder string "_:*".
+
+        Args:
+            tt: The TripleTerm to scan.
+            graph_subject: The subject of the asserted triple containing this
+                TripleTerm.
+            graph_predicate: The predicate of the asserted triple containing
+                this TripleTerm.
+        """
+        desc = self._describe_term
+        obj_desc = desc(tt.object)
+        subj_desc = desc(tt.subject)
+        gs = desc(graph_subject)
+        gp = desc(graph_predicate)
+
+        if isinstance(tt.subject, BNode):
+            self._embedded_bnode_contexts[tt.subject].add(
+                ("tt_subject", gs, gp, tt.predicate.n3(), obj_desc)
+            )
+        if isinstance(tt.object, BNode):
+            self._embedded_bnode_contexts[tt.object].add(
+                ("tt_object", gs, gp, subj_desc, tt.predicate.n3())
+            )
+        elif isinstance(tt.object, TripleTerm):
+            # Recurse into nested TripleTerms
+            self._record_triple_term_context(tt.object, graph_subject, graph_predicate)
 
     def _individuate(self, color, individual):
         new_color = list(color.color)
@@ -540,9 +806,43 @@ class _TripleCanonicalizer:
         triple: _TripleType,
         labels: Dict[Node, str],
     ):
+        """Yield canonicalized terms for a triple, replacing BNodes with
+        deterministic canonical labels.
+
+        For each term in the triple:
+          - **BNode**: replaced with a new BNode whose identifier is
+            ``cb<hash>`` where ``<hash>`` is the canonical color computed
+            by the coloring algorithm.
+          - **TripleTerm** (RDF 1.2): any BNodes embedded inside the triple
+            term are remapped using the same canonical labels via
+            ``_remap_triple_term``. This ensures that a BNode appearing both
+            at the graph level and inside a TripleTerm receives the same
+            canonical identifier, preserving structural consistency.
+          - **Other terms** (URIRef, Literal): yielded unchanged.
+
+        Args:
+            triple: A 3-tuple (subject, predicate, object) from the graph.
+            labels: A mapping from BNode -> canonical hash string, as
+                computed by the coloring/individualization algorithm.
+
+        Yields:
+            The canonicalized terms in order (subject, predicate, object).
+        """
         for term in triple:
             if isinstance(term, BNode):
                 yield BNode(value="cb%s" % labels[term])
+            elif isinstance(term, TripleTerm):
+                # Remap any bnodes inside the TripleTerm to their canonical
+                # labels so that isomorphic graphs produce identical TripleTerms.
+                bnode_mapping = {
+                    bn: BNode(value="cb%s" % labels[bn])
+                    for bn in _get_bnodes_from_term(term)
+                    if bn in labels
+                }
+                if bnode_mapping:
+                    yield _remap_triple_term(term, bnode_mapping)
+                else:
+                    yield term
             else:
                 yield term
 
@@ -644,4 +944,38 @@ def _squash_graph(graph: Graph):
 
 
 def _squash_bnodes(triple):
-    return tuple((isinstance(t, BNode) and _MOCK_BNODE) or t for t in triple)
+    """Replace all BNodes in a triple with a singular mock BNode.
+
+    This is used by the ``similar()`` function as a cheap approximation of
+    graph isomorphism. By replacing every BNode with the same mock value,
+    two graphs can be compared structurally without needing full
+    canonicalization.
+
+    RDF 1.2 TripleTerm handling:
+        When the object of a triple is a TripleTerm that contains embedded
+        BNodes (in subject or object position), those embedded BNodes are
+        also replaced with the mock BNode via ``_remap_triple_term``. This
+        ensures that TripleTerms with different BNodes are treated as
+        structurally equivalent for the purposes of the similarity check,
+        mirroring how top-level BNodes are squashed.
+
+    Args:
+        triple: A 3-tuple (subject, predicate, object) from the graph.
+
+    Returns:
+        A new tuple where all BNodes (including those inside TripleTerms)
+        have been replaced with ``_MOCK_BNODE``.
+    """
+
+    def _squash_term(t):
+        if isinstance(t, BNode):
+            return _MOCK_BNODE
+        elif isinstance(t, TripleTerm):
+            bnodes = _get_bnodes_from_term(t)
+            if bnodes:
+                mapping = {bn: _MOCK_BNODE for bn in bnodes}
+                return _remap_triple_term(t, mapping)
+            return t
+        return t
+
+    return tuple(_squash_term(t) for t in triple)

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -319,6 +319,7 @@ from rdflib.term import (
     Literal,
     Node,
     RDFLibGenid,
+    TripleTerm,
     URIRef,
 )
 
@@ -1304,6 +1305,8 @@ class Graph(Node):
             return
         remember[subject] = 1
         yield subject
+        # subject may include TripleTerm via _ObjectType; the store returns
+        # no results when a TripleTerm is used as subject (it can't match).
         for object in self.objects(subject, predicate):
             for o in self.transitive_objects(object, predicate, remember):
                 yield o
@@ -1869,6 +1872,8 @@ class Graph(Node):
             x = visiting.pop()
             if x not in discovered:
                 discovered.append(x)
+            # x may be a TripleTerm (from _ObjectType) which can't be a subject;
+            # the store will simply return no results in that case.
             for new_x in self.objects(subject=x):
                 if new_x not in discovered and new_x not in visiting:
                     visiting.append(new_x)
@@ -1949,6 +1954,19 @@ class Graph(Node):
         authority: Optional[str] = None,
         basepath: Optional[str] = None,
     ) -> Graph:
+        def _skolemize_triple_term(tt: TripleTerm) -> TripleTerm:
+            """Recursively skolemize blank nodes inside a TripleTerm."""
+            s = tt.subject
+            p = tt.predicate
+            o = tt.object
+            if isinstance(s, BNode):
+                s = s.skolemize(authority=authority, basepath=basepath)
+            if isinstance(o, BNode):
+                o = o.skolemize(authority=authority, basepath=basepath)
+            elif isinstance(o, TripleTerm):
+                o = _skolemize_triple_term(o)
+            return TripleTerm(s, p, o)
+
         def do_skolemize(bnode: BNode, t: _TripleType) -> _TripleType:
             (s, p, o) = t
             if s == bnode:
@@ -1959,6 +1977,8 @@ class Graph(Node):
                 if TYPE_CHECKING:
                     assert isinstance(o, BNode)
                 o = o.skolemize(authority=authority, basepath=basepath)
+            elif isinstance(o, TripleTerm):
+                o = _skolemize_triple_term(o)
             return s, p, o
 
         def do_skolemize2(t: _TripleType) -> _TripleType:
@@ -1967,6 +1987,8 @@ class Graph(Node):
                 s = s.skolemize(authority=authority, basepath=basepath)
             if isinstance(o, BNode):
                 o = o.skolemize(authority=authority, basepath=basepath)
+            elif isinstance(o, TripleTerm):
+                o = _skolemize_triple_term(o)
             return s, p, o
 
         retval = Graph() if new_graph is None else new_graph
@@ -1994,6 +2016,25 @@ class Graph(Node):
                 o = o.de_skolemize()
             return s, p, o
 
+        def _de_skolemize_triple_term(tt: TripleTerm) -> TripleTerm:
+            """Recursively de-skolemize URIs inside a TripleTerm."""
+            s = tt.subject
+            p = tt.predicate
+            o = tt.object
+            if isinstance(s, URIRef):
+                if RDFLibGenid._is_rdflib_skolem(s):
+                    s = RDFLibGenid(s).de_skolemize()
+                elif Genid._is_external_skolem(s):
+                    s = Genid(s).de_skolemize()
+            if isinstance(o, URIRef):
+                if RDFLibGenid._is_rdflib_skolem(o):
+                    o = RDFLibGenid(o).de_skolemize()
+                elif Genid._is_external_skolem(o):
+                    o = Genid(o).de_skolemize()
+            elif isinstance(o, TripleTerm):
+                o = _de_skolemize_triple_term(o)
+            return TripleTerm(s, p, o)
+
         def do_de_skolemize2(t: _TripleType) -> _TripleType:
             (s, p, o) = t
 
@@ -2009,6 +2050,8 @@ class Graph(Node):
                     o = RDFLibGenid(o).de_skolemize()
                 elif Genid._is_external_skolem(o):
                     o = Genid(o).de_skolemize()
+            elif isinstance(o, TripleTerm):
+                o = _de_skolemize_triple_term(o)
 
             return s, p, o
 
@@ -2022,11 +2065,45 @@ class Graph(Node):
 
         return retval
 
+    def reify(
+        self: _GraphT,
+        subject: Union[URIRef, BNode],
+        predicate: URIRef,
+        object: Union[URIRef, BNode, Literal, TripleTerm],
+        reifier: Optional[IdentifiedNode] = None,
+        asserted: bool = False,
+    ) -> IdentifiedNode:
+        """Create a reifying triple for the given triple components.
+
+        This creates an RDF 1.2 reification by adding a triple of the form:
+        ``(reifier, rdf:reifies, <<( subject predicate object )>>)``
+
+        Args:
+            subject: The subject of the triple to reify (an IRI or blank node).
+            predicate: The predicate of the triple to reify (an IRI).
+            object: The object of the triple to reify (an IRI, blank node,
+                literal, or triple term).
+            reifier: The node to use as the reifier. If None, a new BNode is
+                created.
+            asserted: If True, also assert the triple (subject, predicate, object)
+                in the graph. Defaults to False.
+
+        Returns:
+            The reifier node (an IRI or blank node).
+        """
+        if reifier is None:
+            reifier = BNode()
+        triple_term = TripleTerm(subject, predicate, object)
+        self.add((reifier, RDF.reifies, triple_term))
+        if asserted:
+            self.add((subject, predicate, object))
+        return reifier
+
     def cbd(
         self,
         resource: _SubjectType,
         *,
-        target_graph: Graph | None = None,
+        target_graph: Optional[Graph] = None,
         include_reifications: bool = True,
     ) -> Graph:
         """Retrieves the Concise Bounded Description of a Resource from a Graph.
@@ -2053,11 +2130,14 @@ class Graph(Node):
             2. Recursively, for all statements identified in the subgraph thus far having a blank
                 node object, include in the subgraph all statements in the source graph where the
                 subject of the statement is the blank node in question and which are not already
-                included in the subgraph.
+                included in the subgraph. (In RDF 1.2, this also applies to blank nodes appearing
+                as the subject or object within triple term objects, including nested triple terms.)
 
             3. Recursively, for all statements included in the subgraph thus far, for all
                 reifications of each statement in the source graph, include the concise bounded
-                description beginning from the rdf:Statement node of each reification.
+                description beginning from the rdf:Statement node of each reification. (In
+                RDF 1.2, this also applies to reifiers linked via ``rdf:reifies`` to a triple
+                term matching a statement in the subgraph.)
 
             This results in a subgraph where the object nodes are either URI references, literals,
             or blank nodes not serving as the subject of any statement in the graph.
@@ -2072,12 +2152,23 @@ class Graph(Node):
         else:
             subgraph = target_graph
 
+        def _follow_bnodes_in_triple_term(tt: TripleTerm) -> None:
+            """Follow blank nodes inside triple terms for CBD."""
+            if isinstance(tt.subject, BNode):
+                if (tt.subject, None, None) not in subgraph:
+                    add_to_cbd(tt.subject)
+            if isinstance(tt.object, BNode):
+                if (tt.object, None, None) not in subgraph:
+                    add_to_cbd(tt.object)
+            elif isinstance(tt.object, TripleTerm):
+                _follow_bnodes_in_triple_term(tt.object)
+
         def add_to_cbd(uri: _SubjectType) -> None:
-            # Rule 3 Preparation:
-            # If reifications are to be included, build an index mapping triples with
-            # this subject to the set of reification nodes (rdf:Statement nodes) that reify them.
+            # Rule 3 Preparation (RDF 1.1 style):
+            # If reifications are to be included, build an index mapping triples
+            # with this subject to the set of rdf:Statement nodes that reify them.
             if include_reifications:
-                reif_index: dict[_TripleType, set[_SubjectType]] = {}
+                reif_index: Dict[_TripleType, Set[_SubjectType]] = {}
                 for stmt in self.subjects(RDF.subject, uri):
                     p: _PredicateType = self.value(stmt, RDF.predicate)  # type: ignore[assignment]
                     o = self.value(stmt, RDF.object)
@@ -2088,21 +2179,36 @@ class Graph(Node):
                         else:
                             reif_index[triple].add(stmt)
 
-            # For all triples where the subject is the current subject (Rule 1)
-            for s, p, o in self.triples((uri, None, None)):
-                # Add the triple to the CBD subgraph
+            # Rule 1: Include all triples where the subject is the current node.
+            uri_triples = list(self.triples((uri, None, None)))
+            for s, p, o in uri_triples:
                 subgraph.add((s, p, o))
-                # If the object is a blank node, recursively add its CBD (Rule 2)
+
+                # Rule 2: Recursively follow blank node objects.
                 if type(o) is BNode and (o, None, None) not in subgraph:
                     add_to_cbd(o)
+                elif isinstance(o, TripleTerm):
+                    # RDF 1.2 Rule 2 extension: follow BNodes inside triple terms
+                    _follow_bnodes_in_triple_term(o)
 
-                # If including reifications (Rule 3):
+                # Rule 3: Follow reifications of this triple.
                 if include_reifications:
-                    # For each reification node of this triple, recursively add its CBD
-                    stmts = reif_index.get((s, p, o), set())
-                    for stmt in stmts:
+                    # RDF 1.1: follow rdf:Statement nodes that reify (s, p, o)
+                    for stmt in reif_index.get((s, p, o), set()):
                         if (stmt, None, None) not in subgraph:
                             add_to_cbd(stmt)
+
+                    # RDF 1.2: follow reifiers linked via rdf:reifies to a
+                    # triple term matching (s, p, o)
+                    if (
+                        isinstance(s, (URIRef, BNode))
+                        and isinstance(p, URIRef)
+                        and isinstance(o, (URIRef, BNode, Literal, TripleTerm))
+                    ):
+                        tt = TripleTerm(s, p, o)
+                        for reifier, _, _ in self.triples((None, RDF.reifies, tt)):
+                            if (reifier, None, None) not in subgraph:
+                                add_to_cbd(reifier)
 
         # Start the CBD construction from the given resource
         add_to_cbd(resource)

--- a/rdflib/namespace/_RDF.py
+++ b/rdflib/namespace/_RDF.py
@@ -6,7 +6,8 @@ class RDF(DefinedNamespace):
     """
     The RDF Concepts Vocabulary (RDF)
 
-    This is the RDF Schema for the RDF vocabulary terms in the RDF Namespace, defined in RDF 1.1 Concepts.
+    This is the RDF Schema for the RDF vocabulary terms in the RDF Namespace, defined in
+    RDF 1.1 Concepts and extended with RDF 1.2 vocabulary terms.
 
     Generated from: http://www.w3.org/1999/02/22-rdf-syntax-ns#
     Date: 2020-05-26 14:20:05.642859
@@ -27,6 +28,7 @@ class RDF(DefinedNamespace):
     language: URIRef  # The language component of a CompoundLiteral.
     object: URIRef  # The object of the subject RDF statement.
     predicate: URIRef  # The predicate of the subject RDF statement.
+    reifies: URIRef  # The predicate of a reifying triple relating a reifier to a triple term.
     rest: URIRef  # The rest of the subject RDF list after the first item.
     subject: URIRef  # The subject of the subject RDF statement.
     type: URIRef  # The subject is an instance of a class.
@@ -46,6 +48,7 @@ class RDF(DefinedNamespace):
     JSON: URIRef  # The datatype of RDF literals storing JSON content.
     PlainLiteral: URIRef  # The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2
     XMLLiteral: URIRef  # The datatype of XML literal values.
+    dirLangString: URIRef  # The datatype of directional language-tagged string values
     langString: URIRef  # The datatype of language-tagged string values
 
     _NS = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -36,6 +36,7 @@ __all__ = [
     "BNode",
     "Literal",
     "Variable",
+    "TripleTerm",
 ]
 import logging
 import math
@@ -525,17 +526,19 @@ class BNode(IdentifiedNode):
 class Literal(Identifier):
     """
 
-    RDF 1.1's Literals Section: http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal
+    RDF Literals: https://www.w3.org/TR/rdf12-concepts/#section-Graph-Literal
 
     Literals are used for values such as strings, numbers, and dates.
 
-    A literal in an RDF graph consists of two or three elements:
+    A literal in an RDF graph consists of two, three, or four elements:
 
     * a lexical form, being a Unicode string, which SHOULD be in Normal Form C
-    * a datatype IRI, being an IRI identifying a datatype that determines how the lexical form maps to a literal value, and
-    * if and only if the datatype IRI is `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`, a non-empty language tag. The language tag MUST be well-formed according to section 2.2.9 of `Tags for identifying languages <http://tools.ietf.org/html/bcp47>`_.
+    * a datatype IRI, being an IRI identifying a datatype that determines how the lexical form maps to a literal value
+    * if and only if the datatype IRI is ``rdf:langString`` or ``rdf:dirLangString``, a non-empty language tag as defined by `BCP47 <http://tools.ietf.org/html/bcp47>`_
+    * if and only if the datatype IRI is ``rdf:dirLangString``, a base direction (``"ltr"`` or ``"rtl"``) indicating the initial text direction for display
 
-    A literal is a language-tagged string if the third element is present. Lexical representations of language tags MAY be converted to lower case. The value space of language tags is always in lower case.
+    A literal is a *language-tagged string* if it has a language tag but no base direction.
+    A literal is a *directional language-tagged string* if it has both a language tag and a base direction.
 
     ---
 
@@ -636,7 +639,8 @@ class Literal(Identifier):
     # NOTE: _datatype should maybe be of type URIRef, and not optional.
     _datatype: Optional[URIRef]
     _ill_typed: Optional[bool]
-    __slots__ = ("_language", "_datatype", "_value", "_ill_typed")
+    _direction: Optional[str]
+    __slots__ = ("_language", "_datatype", "_value", "_ill_typed", "_direction")
 
     def __new__(
         cls,
@@ -644,18 +648,48 @@ class Literal(Identifier):
         lang: Optional[str] = None,
         datatype: Optional[str] = None,
         normalize: Optional[bool] = None,
+        direction: Optional[str] = None,
     ):
-        """Create a new Literal instance."""
+        """Create a new Literal instance.
+
+        Args:
+            lexical_or_value: The lexical form or a Python value to be
+                converted to a literal.
+            lang: An optional BCP47 language tag (e.g., ``"en"``).
+            datatype: An optional datatype IRI. Auto-detected from Python
+                types if not provided.
+            normalize: Whether to normalize the lexical form for known
+                XSD datatypes. Defaults to ``rdflib.NORMALIZE_LITERALS``.
+            direction: An optional base direction for directional
+                language-tagged strings. Must be ``"ltr"`` or ``"rtl"``.
+                Requires ``lang`` to also be set. When provided, the
+                datatype is automatically set to ``rdf:dirLangString``.
+        """
         if lang == "":
             lang = None  # no empty lang-tags in RDF
 
         normalize = normalize if normalize is not None else rdflib.NORMALIZE_LITERALS
 
+        if direction is not None:
+            if lang is None:
+                raise ValueError(
+                    "A Literal with a direction must also have a language tag."
+                )
+            if direction not in ("ltr", "rtl"):
+                raise ValueError(f"direction must be 'ltr' or 'rtl', got '{direction}'")
+
         if lang is not None and datatype is not None:
-            raise TypeError(
-                "A Literal can only have one of lang or datatype, "
-                "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
-            )
+            # Per RDF 1.2, rdf:langString and rdf:dirLangString are the datatypes
+            # for language-tagged and directional language-tagged strings respectively.
+            # These datatypes are allowed (and expected) to coexist with a language tag.
+            if str(datatype) not in (
+                _RDF_PFX + "langString",
+                _RDF_PFX + "dirLangString",
+            ):
+                raise TypeError(
+                    "A Literal can only have one of lang or datatype, "
+                    "per https://www.w3.org/TR/rdf12-concepts/#section-Graph-Literal"
+                )
 
         if lang is not None and not _is_valid_langtag(lang):
             raise ValueError(f"'{str(lang)}' is not a valid language tag!")
@@ -669,6 +703,8 @@ class Literal(Identifier):
             # create from another Literal instance
 
             lang = lang or lexical_or_value.language
+            if direction is None:
+                direction = lexical_or_value.direction
             if datatype is not None:
                 # override datatype
                 value = _castLexicalToPython(lexical_or_value, datatype)
@@ -723,6 +759,12 @@ class Literal(Identifier):
         inst._datatype = datatype
         inst._value = value
         inst._ill_typed = ill_typed
+        inst._direction = direction
+
+        # Auto-set datatype to rdf:dirLangString when direction is provided
+        # and no explicit datatype was given
+        if direction is not None and inst._datatype is None:
+            inst._datatype = _RDF_DIRLANGSTRING
 
         return inst
 
@@ -777,21 +819,39 @@ class Literal(Identifier):
     def datatype(self) -> Optional[URIRef]:
         return self._datatype
 
+    @property
+    def direction(self) -> Optional[str]:
+        """The base direction of this literal, or None.
+
+        For directional language-tagged strings (datatype rdf:dirLangString),
+        this is either ``"ltr"`` (left-to-right) or ``"rtl"`` (right-to-left).
+        For all other literals, this is None.
+        """
+        return self._direction
+
     def __reduce__(
         self,
-    ) -> Tuple[Type[Literal], Tuple[str, Union[str, None], Union[str, None]]]:
-        return (
-            Literal,
-            (str(self), self.language, self.datatype),
-        )
+    ) -> Tuple[
+        Type[Literal],
+        Tuple[str, Union[str, None], Union[str, None], None, Union[str, None]],
+    ]:
+        return Literal, (str(self), self.language, self.datatype, None, self._direction)
 
     def __getstate__(self) -> Tuple[None, Dict[str, Union[str, None]]]:
-        return (None, dict(language=self.language, datatype=self.datatype))
+        return (
+            None,
+            dict(
+                language=self.language,
+                datatype=self.datatype,
+                direction=self._direction,
+            ),
+        )
 
     def __setstate__(self, arg: Tuple[Any, Dict[str, Any]]) -> None:
         _, d = arg
         self._language = d["language"]
         self._datatype = d["datatype"]
+        self._direction = d.get("direction")
 
     def __add__(self, val: Any) -> Literal:
         """
@@ -1347,6 +1407,8 @@ class Literal(Identifier):
             res ^= hash(self._language.lower())
         if self._datatype is not None:
             res ^= hash(self._datatype)
+        if self._direction is not None:
+            res ^= hash(self._direction)
         return res
 
     def __eq__(self, other: Any) -> bool:
@@ -1402,6 +1464,7 @@ class Literal(Identifier):
                 self._datatype == other._datatype
                 and (self._language.lower() if self._language else None)
                 == (other._language.lower() if other._language else None)
+                and self._direction == other._direction
                 and str.__eq__(self, other)
             )
 
@@ -1716,6 +1779,8 @@ class Literal(Identifier):
 
         language = self.language
         if language:
+            if self._direction:
+                return f"{encoded}@{language}--{self._direction}"
             return f"{encoded}@{language}"
         elif datatype:
             return f"{encoded}^^{quoted_dt}"
@@ -1755,6 +1820,8 @@ class Literal(Identifier):
             args.append("lang=" + repr(self.language))
         if self.datatype is not None:
             args.append("datatype=" + repr(self.datatype))
+        if self.direction is not None:
+            args.append("direction=" + repr(self.direction))
         if self.__class__ == Literal:
             clsName = "rdflib.term.Literal"  # noqa: N806
         else:
@@ -1825,7 +1892,7 @@ def _writeXML(  # noqa: N802
 ) -> bytes:
     if isinstance(xmlnode, xml.dom.minidom.DocumentFragment):
         d = xml.dom.minidom.Document()
-        d.childNodes += xmlnode.childNodes
+        d.childNodes += list(xmlnode.childNodes)
         xmlnode = d
     s = xmlnode.toxml("utf-8")
     # for clean round-tripping, remove headers -- I have great and
@@ -1968,6 +2035,7 @@ _RDF_PFX = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
 _RDF_XMLLITERAL = URIRef(_RDF_PFX + "XMLLiteral")
 _RDF_HTMLLITERAL = URIRef(_RDF_PFX + "HTML")
+_RDF_DIRLANGSTRING = URIRef(_RDF_PFX + "dirLangString")
 
 _XSD_STRING = URIRef(_XSD_PFX + "string")
 _XSD_NORMALISED_STRING = URIRef(_XSD_PFX + "normalizedString")
@@ -2367,12 +2435,160 @@ class Variable(Identifier):
         return (Variable, (str(self),))
 
 
+class TripleTerm(Node):
+    """RDF 1.2 Triple Term.
+
+    A TripleTerm is an RDF triple used as an RDF term in the object position
+    of another triple. It consists of a subject (IRI or blank node), a
+    predicate (IRI), and an object (IRI, blank node, literal, or another
+    triple term).
+
+    Per the RDF 1.2 spec, triple terms can only appear in the **object**
+    position of a triple — never as subject or predicate.
+
+    A triple term denotes a proposition (the relationship described by its
+    components) without asserting it. To assert the proposition, the triple
+    must also appear as an asserted triple in the graph.
+
+    Example:
+        ```python
+        >>> from rdflib import URIRef, Literal, Namespace
+        >>> from rdflib.term import TripleTerm
+        >>> EX = Namespace("http://example.org/")
+        >>> tt = TripleTerm(EX.Alice, EX.name, Literal("Alice"))
+        >>> tt.n3()
+        '<<( <http://example.org/Alice> <http://example.org/name> "Alice" )>>'
+
+        ```
+
+    See: https://www.w3.org/TR/rdf12-concepts/#section-triple-terms
+    """
+
+    __slots__ = ("_subject", "_predicate", "_object")
+
+    def __init__(
+        self,
+        subject: Union[URIRef, BNode],
+        predicate: URIRef,
+        object: Union[URIRef, BNode, Literal, TripleTerm],
+    ) -> None:
+        if not isinstance(subject, (URIRef, BNode)):
+            raise TypeError(
+                f"subject must be a URIRef or BNode, got {type(subject).__name__}"
+            )
+        if not isinstance(predicate, URIRef):
+            raise TypeError(
+                f"predicate must be a URIRef, got {type(predicate).__name__}"
+            )
+        if not isinstance(object, (URIRef, BNode, Literal, TripleTerm)):
+            raise TypeError(
+                f"object must be a URIRef, BNode, Literal, or TripleTerm, "
+                f"got {type(object).__name__}"
+            )
+        self._subject = subject
+        self._predicate = predicate
+        self._object = object
+
+    @property
+    def subject(self) -> Union[URIRef, BNode]:
+        """The subject of this triple term (an IRI or blank node)."""
+        return self._subject
+
+    @property
+    def predicate(self) -> URIRef:
+        """The predicate of this triple term (an IRI)."""
+        return self._predicate
+
+    @property
+    def object(self) -> Union[URIRef, BNode, Literal, TripleTerm]:
+        """The object of this triple term."""
+        return self._object
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, TripleTerm):
+            return False
+        return (
+            self._subject == other._subject
+            and self._predicate == other._predicate
+            and self._object == other._object
+        )
+
+    def __hash__(self) -> int:
+        return hash((self._subject, self._predicate, self._object))
+
+    def __lt__(self, other: Any) -> bool:
+        # Note: SPARQL 1.2 defines no ordering between two triple terms.
+        # This implementation provides a component-wise (subject, predicate, object)
+        # ordering as a practical extension for sorting in Python.
+        if other is None:
+            return False
+        if isinstance(other, TripleTerm):
+            return (self._subject, self._predicate, self._object) < (
+                other._subject,
+                other._predicate,
+                other._object,
+            )
+        elif isinstance(other, Node):
+            return _ORDERING[type(self)] < _ORDERING[type(other)]
+        return NotImplemented
+
+    def __gt__(self, other: Any) -> bool:
+        if other is None:
+            return True
+        if isinstance(other, TripleTerm):
+            return (self._subject, self._predicate, self._object) > (
+                other._subject,
+                other._predicate,
+                other._object,
+            )
+        elif isinstance(other, Node):
+            return _ORDERING[type(self)] > _ORDERING[type(other)]
+        return NotImplemented
+
+    def __le__(self, other: Any) -> bool:
+        r = self.__lt__(other)
+        if r:
+            return True
+        return self == other
+
+    def __ge__(self, other: Any) -> bool:
+        r = self.__gt__(other)
+        if r:
+            return True
+        return self == other
+
+    def n3(self, namespace_manager: Optional[NamespaceManager] = None) -> str:
+        """Return the N3/Turtle 1.2 representation of this triple term.
+
+        The format is ``<<( subject predicate object )>>`` as defined
+        by the RDF 1.2 Turtle specification for triple terms.
+
+        Args:
+            namespace_manager: Optional namespace manager for abbreviating IRIs.
+
+        Returns:
+            A string in Turtle 1.2 triple term syntax.
+        """
+        s = self._subject.n3(namespace_manager)
+        p = self._predicate.n3(namespace_manager)
+        o = self._object.n3(namespace_manager)
+        return f"<<( {s} {p} {o} )>>"
+
+    def __getnewargs__(
+        self,
+    ) -> Tuple[Union[URIRef, BNode], URIRef, Union[URIRef, BNode, Literal, TripleTerm]]:
+        return (self._subject, self._predicate, self._object)
+
+    def __repr__(self) -> str:
+        return f"TripleTerm({self._subject!r}, {self._predicate!r}, {self._object!r})"
+
+
 # Nodes are ordered like this
-# See http://www.w3.org/TR/sparql11-query/#modOrderBy
+# See https://www.w3.org/TR/sparql12-query/#modOrderBy
 # we leave "space" for more subclasses of Node elsewhere
 # default-dict to grazefully fail for new subclasses
 _ORDERING: Dict[Type[Node], int] = defaultdict(int)
-_ORDERING.update({BNode: 10, Variable: 20, URIRef: 30, Literal: 40})
+_ORDERING.update({BNode: 10, Variable: 20, URIRef: 30, Literal: 40, TripleTerm: 50})
 
 
 def _isEqualXMLNode(  # noqa: N802

--- a/rdflib/util.py
+++ b/rdflib/util.py
@@ -182,6 +182,162 @@ def to_term(
         raise Exception(msg)
 
 
+def _find_n3_term_end(s: str, start: int) -> int:
+    """Find the end index (exclusive) of an N3 term starting at position `start`.
+
+    Handles IRIs (<...>), literals ("..." with optional @lang or ^^datatype),
+    blank nodes (_:...), triple terms (<<( ... )>>), and prefixed names.
+    """
+    n = len(s)
+    i = start
+
+    if s[i : i + 3] == "<<(":
+        # Triple term - find matching )>>
+        depth = 1
+        i += 3
+        while i < n and depth > 0:
+            if s[i : i + 3] == "<<(":
+                depth += 1
+                i += 3
+            elif s[i : i + 3] == ")>>":
+                depth -= 1
+                i += 3
+            elif s[i] == '"':
+                # Skip quoted string inside triple term
+                i = _skip_quoted_string(s, i)
+            else:
+                i += 1
+        return i
+    elif s[i] == "<":
+        # IRI - find matching >
+        i += 1
+        while i < n and s[i] != ">":
+            i += 1
+        return i + 1  # include the >
+    elif s[i] == '"':
+        # Literal - find end of quoted content + optional suffix
+        i = _skip_quoted_string(s, i)
+        # Check for @lang (possibly with --dir) or ^^datatype suffix
+        if i < n and s[i] == "@":
+            i += 1
+            while i < n and s[i] not in " \t\n\r":
+                i += 1
+        elif i < n and s[i : i + 2] == "^^":
+            i += 2
+            if i < n and s[i] == "<":
+                # Full IRI datatype
+                i += 1
+                while i < n and s[i] != ">":
+                    i += 1
+                i += 1  # include the >
+            else:
+                # Prefixed name datatype
+                while i < n and s[i] not in " \t\n\r":
+                    i += 1
+        return i
+    elif s[i : i + 2] == "_:":
+        # Blank node
+        i += 2
+        while i < n and s[i] not in " \t\n\r":
+            i += 1
+        return i
+    else:
+        # Prefixed name or other token
+        while i < n and s[i] not in " \t\n\r":
+            i += 1
+        return i
+
+
+def _skip_quoted_string(s: str, start: int) -> int:
+    """Skip past a quoted N3 string starting at `start`, returning the position
+    after the closing quote(s). Does not consume @lang or ^^datatype suffixes."""
+    n = len(s)
+    i = start
+    if s[i : i + 3] == '"""':
+        i += 3
+        while i < n:
+            if s[i] == "\\" and i + 1 < n:
+                i += 2  # skip escape sequence
+            elif s[i : i + 3] == '"""':
+                i += 3
+                return i
+            else:
+                i += 1
+        return i  # unterminated, return end
+    else:
+        i += 1  # skip opening "
+        while i < n:
+            if s[i] == "\\" and i + 1 < n:
+                i += 2  # skip escape sequence
+            elif s[i] == '"':
+                i += 1
+                return i
+            else:
+                i += 1
+        return i  # unterminated, return end
+
+
+def _split_n3_terms(s: str) -> List[str]:
+    """Split a whitespace-separated string of N3 terms into individual terms.
+
+    Used internally to parse the contents of a triple term ``<<( s p o )>>``.
+    """
+    terms: List[str] = []
+    i = 0
+    n = len(s)
+    while i < n and len(terms) < 3:
+        # Skip whitespace
+        while i < n and s[i] in " \t\n\r":
+            i += 1
+        if i >= n:
+            break
+        end = _find_n3_term_end(s, i)
+        terms.append(s[i:end])
+        i = end
+    return terms
+
+
+def _triple_term_from_n3(
+    s: str,
+    default: Optional[str] = None,
+    backend: Optional[str] = None,
+    nsm: Optional[rdflib.namespace.NamespaceManager] = None,
+) -> rdflib.term.Node:
+    """Parse an RDF 1.2 triple term from its N3 representation.
+
+    The expected format is ``<<( subject predicate object )>>`` as produced
+    by ``TripleTerm.n3()``.
+
+    Args:
+        s: The N3 string starting with ``<<(`` and ending with ``)>>``.
+        default: Default value (unused, for API consistency).
+        backend: Backend identifier (unused, for API consistency).
+        nsm: Optional namespace manager for resolving prefixed names.
+
+    Returns:
+        A ``TripleTerm`` instance.
+
+    Raises:
+        ValueError: If the string cannot be parsed as a valid triple term.
+    """
+    # Strip the outer <<( and )>> delimiters
+    if not (s.startswith("<<(") and s.endswith(")>>")):
+        raise ValueError(f"Invalid triple term syntax: {s!r}")
+
+    inner = s[3:-3].strip()
+    parts = _split_n3_terms(inner)
+    if len(parts) != 3:
+        raise ValueError(
+            f"Triple term must contain exactly 3 terms, got {len(parts)}: {s!r}"
+        )
+
+    subject = from_n3(parts[0], default, backend, nsm)
+    predicate = from_n3(parts[1], default, backend, nsm)
+    object_ = from_n3(parts[2], default, backend, nsm)
+
+    return rdflib.term.TripleTerm(subject, predicate, object_)  # type: ignore[arg-type]
+
+
 def from_n3(
     s: str,
     default: Optional[str] = None,
@@ -219,7 +375,10 @@ def from_n3(
     '''
     if not s:
         return default
-    if s.startswith("<"):
+    if s.startswith("<<("):
+        # RDF 1.2 Triple Term: <<( subject predicate object )>>
+        return _triple_term_from_n3(s, default, backend, nsm)
+    elif s.startswith("<"):
         # Hack: this should correctly handle strings with either native unicode
         # characters, or \u1234 unicode escapes.
         return rdflib.term.URIRef(
@@ -234,6 +393,7 @@ def from_n3(
         value = value[len(quotes) :]  # strip leading quotes
         datatype = None
         language = None
+        direction = None
 
         # as a given datatype overrules lang-tag check for it first
         dtoffset = rest.rfind("^^")
@@ -245,7 +405,17 @@ def from_n3(
             datatype = from_n3(rest[dtoffset + 2 :], default, backend, nsm)
         else:
             if rest.startswith("@"):
-                language = rest[1:]  # strip leading at sign
+                lang_str = rest[1:]  # strip leading at sign
+                # RDF 1.2: check for directional language tag (e.g., @ar--rtl)
+                if "--" in lang_str:
+                    lang_part, dir_part = lang_str.rsplit("--", 1)
+                    if dir_part in ("ltr", "rtl"):
+                        language = lang_part
+                        direction = dir_part
+                    else:
+                        language = lang_str
+                else:
+                    language = lang_str
 
         value = value.replace(r"\"", '"')
         # unicode-escape interprets \xhh as an escape sequence,
@@ -255,7 +425,7 @@ def from_n3(
         # characters, or \u1234 unicode escapes.
         value = value.encode("raw-unicode-escape").decode("unicode-escape")
         # type error: Argument 3 to "Literal" has incompatible type "Union[Node, str, None]"; expected "Optional[str]"
-        return rdflib.term.Literal(value, language, datatype)  # type: ignore[arg-type]
+        return rdflib.term.Literal(value, language, datatype, direction=direction)  # type: ignore[arg-type]
     elif s == "true" or s == "false":
         return rdflib.term.Literal(s == "true")
     elif (

--- a/test/test_compare/test_compare_triple_term.py
+++ b/test/test_compare/test_compare_triple_term.py
@@ -1,0 +1,873 @@
+"""Tests for graph isomorphism with TripleTerms (RDF 1.2).
+
+Tests that the compare module correctly handles TripleTerms
+in graph isomorphism checks, including blank nodes inside triple terms.
+"""
+
+from rdflib import BNode, Graph, Literal, Namespace
+from rdflib.compare import graph_diff, isomorphic, similar, to_canonical_graph
+from rdflib.term import TripleTerm
+
+EX = Namespace("http://example.org/")
+
+
+class TestIsomorphicWithTripleTerms:
+    """Test graph isomorphism with TripleTerms."""
+
+    def test_isomorphic_graphs_with_triple_term_objects(self):
+        """Two graphs with identical triple terms should be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        g1.add((EX.stmt1, EX.reifies, tt))
+        g2.add((EX.stmt1, EX.reifies, tt))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_graphs_different_triple_terms(self):
+        """Graphs with different triple terms should not be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt1 = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        tt2 = TripleTerm(EX.Alice, EX.knows, EX.Carol)
+
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_isomorphic_with_bnode_in_triple_term_subject(self):
+        """Graphs with BNodes in triple term subjects should be isomorphic
+        if the BNode mapping is consistent."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # g1: _:a is used in triple term subject and also as a regular subject
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        # g2: different bnode, same structure
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2, EX.type, EX.Person))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_with_inconsistent_bnode_in_triple_term(self):
+        """Graphs where BNode in triple term doesn't match graph-level usage
+        should not be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # g1: same bnode in triple term and as subject
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        # g2: DIFFERENT bnodes - one in triple term, different one as subject
+        b2 = BNode()
+        b3 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b3, EX.type, EX.Person))
+
+        assert not isomorphic(g1, g2)
+
+    def test_isomorphic_with_bnode_in_triple_term_object(self):
+        """Graphs with BNodes in triple term object position should be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(EX.Alice, EX.knows, b1)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.name, Literal("Bob")))
+
+        b2 = BNode()
+        tt2 = TripleTerm(EX.Alice, EX.knows, b2)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2, EX.name, Literal("Bob")))
+
+        assert isomorphic(g1, g2)
+
+    def test_isomorphic_with_nested_triple_terms(self):
+        """Graphs with nested triple terms should be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        inner_tt = TripleTerm(EX.Alice, EX.name, Literal("Alice"))
+        outer_tt = TripleTerm(EX.Bob, EX.believes, inner_tt)
+
+        g1.add((EX.stmt1, EX.reifies, outer_tt))
+        g2.add((EX.stmt1, EX.reifies, outer_tt))
+
+        assert isomorphic(g1, g2)
+
+    def test_isomorphic_nested_triple_term_with_bnodes(self):
+        """Graphs with BNodes in nested triple terms should be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        inner_tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        outer_tt1 = TripleTerm(EX.Bob, EX.believes, inner_tt1)
+        g1.add((EX.stmt1, EX.reifies, outer_tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        b2 = BNode()
+        inner_tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        outer_tt2 = TripleTerm(EX.Bob, EX.believes, inner_tt2)
+        g2.add((EX.stmt1, EX.reifies, outer_tt2))
+        g2.add((b2, EX.type, EX.Person))
+
+        assert isomorphic(g1, g2)
+
+
+class TestCanonicalGraphWithTripleTerms:
+    """Test canonical graph generation with TripleTerms."""
+
+    def test_canonical_graph_preserves_triple_terms(self):
+        """Canonical graph should preserve triple terms."""
+        g = Graph()
+        tt = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        g.add((EX.stmt1, EX.reifies, tt))
+
+        cg = to_canonical_graph(g)
+        triples = list(cg.triples((EX.stmt1, EX.reifies, None)))
+        assert len(triples) == 1
+        assert triples[0][2] == tt
+
+    def test_canonical_graph_with_bnode_in_triple_term(self):
+        """Canonical graph should remap BNodes inside triple terms."""
+        g = Graph()
+        b = BNode()
+        tt = TripleTerm(b, EX.name, Literal("Alice"))
+        g.add((EX.stmt1, EX.reifies, tt))
+        g.add((b, EX.type, EX.Person))
+
+        cg = to_canonical_graph(g)
+
+        # The canonical graph should have the same structure
+        assert len(cg) == 2
+
+        # The BNode should be consistently remapped
+        reify_triples = list(cg.triples((EX.stmt1, EX.reifies, None)))
+        assert len(reify_triples) == 1
+        canonical_tt = reify_triples[0][2]
+        assert isinstance(canonical_tt, TripleTerm)
+
+        # The BNode in the triple term should match the one used as subject
+        type_triples = list(cg.triples((None, EX.type, EX.Person)))
+        assert len(type_triples) == 1
+        canonical_bnode = type_triples[0][0]
+        assert canonical_tt.subject == canonical_bnode
+
+    def test_canonical_graph_deterministic(self):
+        """Two isomorphic graphs should produce the same canonical graph."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2, EX.type, EX.Person))
+
+        cg1 = to_canonical_graph(g1)
+        cg2 = to_canonical_graph(g2)
+
+        # Both canonical graphs should be identical (same triples)
+        assert set(cg1) == set(cg2)
+
+
+class TestIsomorphicWithDirectionalLiterals:
+    """Test graph isomorphism with directional language-tagged strings."""
+
+    def test_isomorphic_with_directional_literals(self):
+        """Graphs with same directional literals should be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        lit = Literal("مرحبا", lang="ar", direction="rtl")
+        g1.add((EX.greeting, EX.text, lit))
+        g2.add((EX.greeting, EX.text, lit))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_different_directions(self):
+        """Graphs with different directions should not be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        g1.add((EX.greeting, EX.text, Literal("hello", lang="en", direction="ltr")))
+        g2.add((EX.greeting, EX.text, Literal("hello", lang="en", direction="rtl")))
+
+        assert not isomorphic(g1, g2)
+
+    def test_non_isomorphic_direction_vs_no_direction(self):
+        """Graph with directional literal is not isomorphic to one without."""
+        g1 = Graph()
+        g2 = Graph()
+
+        g1.add((EX.greeting, EX.text, Literal("hello", lang="en", direction="ltr")))
+        g2.add((EX.greeting, EX.text, Literal("hello", lang="en")))
+
+        assert not isomorphic(g1, g2)
+
+
+class TestSimilarWithTripleTerms:
+    """Test the similar() function with TripleTerms (exercises _squash_bnodes)."""
+
+    def test_similar_graphs_with_triple_term_no_bnodes(self):
+        """similar() should return True for identical graphs with triple terms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        g1.add((EX.stmt1, EX.reifies, tt))
+        g2.add((EX.stmt1, EX.reifies, tt))
+
+        assert similar(g1, g2)
+
+    def test_similar_graphs_with_bnode_in_triple_term(self):
+        """similar() should treat different BNodes inside TripleTerms as equivalent."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2, EX.type, EX.Person))
+
+        assert similar(g1, g2)
+
+    def test_not_similar_different_triple_terms(self):
+        """similar() should return False for graphs with different triple terms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt1 = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        tt2 = TripleTerm(EX.Alice, EX.knows, EX.Carol)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not similar(g1, g2)
+
+    def test_similar_with_bnode_in_triple_term_object(self):
+        """similar() squashes BNodes in triple term object position."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(EX.Alice, EX.knows, b1)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(EX.Alice, EX.knows, b2)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert similar(g1, g2)
+
+    def test_similar_with_nested_triple_term_and_bnodes(self):
+        """similar() squashes BNodes in nested TripleTerms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        inner1 = TripleTerm(EX.Alice, EX.knows, b1)
+        outer1 = TripleTerm(EX.Bob, EX.believes, inner1)
+        g1.add((EX.stmt1, EX.reifies, outer1))
+
+        b2 = BNode()
+        inner2 = TripleTerm(EX.Alice, EX.knows, b2)
+        outer2 = TripleTerm(EX.Bob, EX.believes, inner2)
+        g2.add((EX.stmt1, EX.reifies, outer2))
+
+        assert similar(g1, g2)
+
+    def test_similar_embedded_only_bnodes(self):
+        """similar() handles BNodes that appear only inside TripleTerms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # BNodes only inside triple terms, never at graph level
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert similar(g1, g2)
+
+
+class TestGraphDiffWithTripleTerms:
+    """Test graph_diff() with TripleTerms."""
+
+    def test_graph_diff_identical_triple_terms(self):
+        """graph_diff of identical graphs with triple terms should show all in common."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        g1.add((EX.stmt1, EX.reifies, tt))
+        g2.add((EX.stmt1, EX.reifies, tt))
+
+        in_both, in_first, in_second = graph_diff(g1, g2)
+        assert len(in_both) == 1
+        assert len(in_first) == 0
+        assert len(in_second) == 0
+
+    def test_graph_diff_different_triple_terms(self):
+        """graph_diff should separate graphs with different triple terms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt1 = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        tt2 = TripleTerm(EX.Alice, EX.knows, EX.Carol)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        in_both, in_first, in_second = graph_diff(g1, g2)
+        assert len(in_both) == 0
+        assert len(in_first) == 1
+        assert len(in_second) == 1
+
+    def test_graph_diff_with_bnodes_in_triple_terms(self):
+        """graph_diff should correctly handle BNodes inside triple terms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # Isomorphic graphs with BNodes in triple terms
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1, EX.type, EX.Person))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2, EX.type, EX.Person))
+
+        in_both, in_first, in_second = graph_diff(g1, g2)
+        assert len(in_both) == 2
+        assert len(in_first) == 0
+        assert len(in_second) == 0
+
+    def test_graph_diff_partial_overlap_with_triple_terms(self):
+        """graph_diff with shared and unique triples involving triple terms."""
+        g1 = Graph()
+        g2 = Graph()
+
+        tt_shared = TripleTerm(EX.Alice, EX.knows, EX.Bob)
+        tt_only_g1 = TripleTerm(EX.Alice, EX.likes, EX.Carol)
+        tt_only_g2 = TripleTerm(EX.Alice, EX.likes, EX.Dave)
+
+        g1.add((EX.stmt1, EX.reifies, tt_shared))
+        g1.add((EX.stmt2, EX.reifies, tt_only_g1))
+
+        g2.add((EX.stmt1, EX.reifies, tt_shared))
+        g2.add((EX.stmt2, EX.reifies, tt_only_g2))
+
+        in_both, in_first, in_second = graph_diff(g1, g2)
+        assert len(in_both) == 1
+        assert len(in_first) == 1
+        assert len(in_second) == 1
+
+
+class TestEmbeddedOnlyBNodes:
+    """Test BNodes that appear exclusively inside TripleTerms and never at graph level.
+
+    This exercises the embedded-only BNode coloring logic: _record_triple_term_context,
+    the embedded_only vs graph_level_bnodes partitioning, and embedded_color_groups.
+    """
+
+    def test_isomorphic_embedded_only_bnode_in_subject(self):
+        """Graphs with BNodes only inside triple term subject (never at graph level)
+        should be isomorphic when structurally identical."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # BNode only appears inside the TripleTerm, not as a direct triple subject/object
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert isomorphic(g1, g2)
+
+    def test_isomorphic_embedded_only_bnode_in_object(self):
+        """Graphs with BNodes only inside triple term object (never at graph level)
+        should be isomorphic when structurally identical."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(EX.Alice, EX.knows, b1)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(EX.Alice, EX.knows, b2)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert isomorphic(g1, g2)
+
+    def test_canonical_graph_embedded_only_bnode(self):
+        """Canonical graph should produce deterministic output for embedded-only BNodes."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        cg1 = to_canonical_graph(g1)
+        cg2 = to_canonical_graph(g2)
+
+        assert set(cg1) == set(cg2)
+
+    def test_canonical_graph_embedded_only_bnode_has_canonical_id(self):
+        """Embedded-only BNodes should receive cb-prefixed canonical identifiers."""
+        g = Graph()
+        b = BNode()
+        tt = TripleTerm(b, EX.name, Literal("Alice"))
+        g.add((EX.stmt1, EX.reifies, tt))
+
+        cg = to_canonical_graph(g)
+        triples = list(cg.triples((EX.stmt1, EX.reifies, None)))
+        assert len(triples) == 1
+        canonical_tt = triples[0][2]
+        assert isinstance(canonical_tt, TripleTerm)
+        assert isinstance(canonical_tt.subject, BNode)
+        assert str(canonical_tt.subject).startswith("cb")
+
+    def test_embedded_only_bnode_with_additional_graph_triples(self):
+        """Embedded-only BNodes work correctly alongside graph-level non-bnode triples."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((EX.Alice, EX.type, EX.Person))
+        g1.add((EX.Bob, EX.knows, EX.Alice))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((EX.Alice, EX.type, EX.Person))
+        g2.add((EX.Bob, EX.knows, EX.Alice))
+
+        assert isomorphic(g1, g2)
+
+
+class TestMultipleEmbeddedOnlyBNodes:
+    """Test multiple distinct embedded-only BNodes in separate TripleTerms.
+
+    This exercises the embedded_color_groups logic that groups embedded-only
+    BNodes by their structural context.
+    """
+
+    def test_isomorphic_two_embedded_only_bnodes_same_context(self):
+        """Two embedded-only BNodes in identical structural contexts should be
+        isomorphic (same predicate/position)."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # Two triples each with an embedded-only bnode in subject of TripleTerm
+        # Same predicate and same surrounding terms = same context group
+        b1a = BNode()
+        b1b = BNode()
+        tt1a = TripleTerm(b1a, EX.name, Literal("Alice"))
+        tt1b = TripleTerm(b1b, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1a))
+        g1.add((EX.stmt2, EX.reifies, tt1b))
+
+        b2a = BNode()
+        b2b = BNode()
+        tt2a = TripleTerm(b2a, EX.name, Literal("Alice"))
+        tt2b = TripleTerm(b2b, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2a))
+        g2.add((EX.stmt2, EX.reifies, tt2b))
+
+        assert isomorphic(g1, g2)
+
+    def test_isomorphic_two_embedded_only_bnodes_different_contexts(self):
+        """Two embedded-only BNodes in different structural contexts (different
+        predicates in the TripleTerm) should still be isomorphic when structure matches.
+        """
+        g1 = Graph()
+        g2 = Graph()
+
+        b1a = BNode()
+        b1b = BNode()
+        # Different predicates inside the TripleTerms = different context groups
+        tt1a = TripleTerm(b1a, EX.name, Literal("Alice"))
+        tt1b = TripleTerm(b1b, EX.age, Literal(30))
+        g1.add((EX.stmt1, EX.reifies, tt1a))
+        g1.add((EX.stmt2, EX.reifies, tt1b))
+
+        b2a = BNode()
+        b2b = BNode()
+        tt2a = TripleTerm(b2a, EX.name, Literal("Alice"))
+        tt2b = TripleTerm(b2b, EX.age, Literal(30))
+        g2.add((EX.stmt1, EX.reifies, tt2a))
+        g2.add((EX.stmt2, EX.reifies, tt2b))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_embedded_only_bnodes_swapped_positions(self):
+        """Two graphs with embedded-only BNodes where one graph has BNode in subject
+        and the other has BNode in object should NOT be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        # BNode in subject position of the TripleTerm
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        # BNode in object position of the TripleTerm
+        tt2 = TripleTerm(EX.Alice, EX.name, b2)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_non_isomorphic_embedded_only_bnodes_different_predicates(self):
+        """Two graphs with embedded-only BNodes in same position but different
+        surrounding predicates should NOT be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.label, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_canonical_graph_distinguishes_embedded_only_bnodes(self):
+        """Canonical graph assigns distinct labels to embedded-only BNodes in
+        different structural contexts."""
+        g = Graph()
+
+        b1 = BNode()
+        b2 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        tt2 = TripleTerm(b2, EX.age, Literal(30))
+        g.add((EX.stmt1, EX.reifies, tt1))
+        g.add((EX.stmt2, EX.reifies, tt2))
+
+        cg = to_canonical_graph(g)
+        assert len(cg) == 2
+
+        # Extract canonical triple terms
+        reify1 = list(cg.triples((EX.stmt1, EX.reifies, None)))
+        reify2 = list(cg.triples((EX.stmt2, EX.reifies, None)))
+        assert len(reify1) == 1
+        assert len(reify2) == 1
+
+        ctt1 = reify1[0][2]
+        ctt2 = reify2[0][2]
+        assert isinstance(ctt1, TripleTerm)
+        assert isinstance(ctt2, TripleTerm)
+
+        # The two BNodes in different contexts should get different canonical IDs
+        assert ctt1.subject != ctt2.subject
+
+    def test_isomorphic_multiple_embedded_bnodes_in_one_triple_term(self):
+        """A TripleTerm with BNodes in both subject and object should be
+        handled correctly for isomorphism."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1s = BNode()
+        b1o = BNode()
+        tt1 = TripleTerm(b1s, EX.knows, b1o)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        # Give structure so they can be distinguished
+        g1.add((b1s, EX.type, EX.Person))
+        g1.add((b1o, EX.type, EX.Animal))
+
+        b2s = BNode()
+        b2o = BNode()
+        tt2 = TripleTerm(b2s, EX.knows, b2o)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((b2s, EX.type, EX.Person))
+        g2.add((b2o, EX.type, EX.Animal))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_multiple_embedded_bnodes_swapped_types(self):
+        """Two graphs where BNodes in subject/object of TripleTerm have swapped
+        types at graph level should NOT be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1s = BNode()
+        b1o = BNode()
+        tt1 = TripleTerm(b1s, EX.knows, b1o)
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((b1s, EX.type, EX.Person))
+        g1.add((b1o, EX.type, EX.Animal))
+
+        b2s = BNode()
+        b2o = BNode()
+        tt2 = TripleTerm(b2s, EX.knows, b2o)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        # Swapped: subject is Animal, object is Person
+        g2.add((b2s, EX.type, EX.Animal))
+        g2.add((b2o, EX.type, EX.Person))
+
+        assert not isomorphic(g1, g2)
+
+
+class TestDeeplyNestedTripleTermsWithEmbeddedBNodes:
+    """Test deeply nested TripleTerms with embedded-only BNodes.
+
+    Exercises recursion in _get_bnodes_from_term, _remap_triple_term,
+    and _record_triple_term_context for nested structures.
+    """
+
+    def test_isomorphic_deeply_nested_embedded_only_bnode(self):
+        """BNode in object of a nested TripleTerm (embedded-only) should be
+        handled correctly for isomorphism."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # Nested: outer has BNode in inner object position (embedded-only)
+        b1 = BNode()
+        inner1 = TripleTerm(EX.Alice, EX.knows, b1)
+        outer1 = TripleTerm(EX.Bob, EX.believes, inner1)
+        g1.add((EX.stmt1, EX.reifies, outer1))
+
+        b2 = BNode()
+        inner2 = TripleTerm(EX.Alice, EX.knows, b2)
+        outer2 = TripleTerm(EX.Bob, EX.believes, inner2)
+        g2.add((EX.stmt1, EX.reifies, outer2))
+
+        assert isomorphic(g1, g2)
+
+    def test_canonical_graph_deeply_nested_embedded_only_bnode(self):
+        """Canonical graph deterministically handles nested embedded-only BNodes."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        inner1 = TripleTerm(EX.Alice, EX.knows, b1)
+        outer1 = TripleTerm(EX.Bob, EX.believes, inner1)
+        g1.add((EX.stmt1, EX.reifies, outer1))
+
+        b2 = BNode()
+        inner2 = TripleTerm(EX.Alice, EX.knows, b2)
+        outer2 = TripleTerm(EX.Bob, EX.believes, inner2)
+        g2.add((EX.stmt1, EX.reifies, outer2))
+
+        cg1 = to_canonical_graph(g1)
+        cg2 = to_canonical_graph(g2)
+        assert set(cg1) == set(cg2)
+
+    def test_non_isomorphic_nested_different_inner_predicate(self):
+        """Nested TripleTerms with different inner predicates should not be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        inner1 = TripleTerm(EX.Alice, EX.knows, b1)
+        outer1 = TripleTerm(EX.Bob, EX.believes, inner1)
+        g1.add((EX.stmt1, EX.reifies, outer1))
+
+        b2 = BNode()
+        inner2 = TripleTerm(EX.Alice, EX.likes, b2)  # Different predicate
+        outer2 = TripleTerm(EX.Bob, EX.believes, inner2)
+        g2.add((EX.stmt1, EX.reifies, outer2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_isomorphic_double_nested_triple_term_with_bnode(self):
+        """Double-nested TripleTerm with BNode in deepest object position."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        innermost1 = TripleTerm(EX.Alice, EX.knows, b1)
+        middle1 = TripleTerm(EX.Bob, EX.believes, innermost1)
+        outer1 = TripleTerm(EX.Carol, EX.reports, middle1)
+        g1.add((EX.stmt1, EX.reifies, outer1))
+
+        b2 = BNode()
+        innermost2 = TripleTerm(EX.Alice, EX.knows, b2)
+        middle2 = TripleTerm(EX.Bob, EX.believes, innermost2)
+        outer2 = TripleTerm(EX.Carol, EX.reports, middle2)
+        g2.add((EX.stmt1, EX.reifies, outer2))
+
+        assert isomorphic(g1, g2)
+
+    def test_nested_embedded_only_bnode_alongside_graph_level_bnodes(self):
+        """Graph with both graph-level BNodes and embedded-only BNodes in nested
+        TripleTerms should be correctly isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # Graph-level bnode
+        gb1 = BNode()
+        g1.add((gb1, EX.type, EX.Statement))
+        # Embedded-only bnode in nested triple term
+        eb1 = BNode()
+        inner1 = TripleTerm(EX.Alice, EX.knows, eb1)
+        outer1 = TripleTerm(EX.Bob, EX.believes, inner1)
+        g1.add((gb1, EX.reifies, outer1))
+
+        gb2 = BNode()
+        g2.add((gb2, EX.type, EX.Statement))
+        eb2 = BNode()
+        inner2 = TripleTerm(EX.Alice, EX.knows, eb2)
+        outer2 = TripleTerm(EX.Bob, EX.believes, inner2)
+        g2.add((gb2, EX.reifies, outer2))
+
+        assert isomorphic(g1, g2)
+
+
+class TestNonIsomorphicEmbeddedOnlyBNodesStructuralContext:
+    """Test that embedded-only BNodes in different structural positions are
+    correctly discriminated.
+
+    This is the key behavioral test for _record_triple_term_context and the
+    embedded_color_groups grouping logic.
+    """
+
+    def test_non_isomorphic_different_graph_predicates(self):
+        """Embedded-only BNodes under different graph-level predicates should
+        produce non-isomorphic graphs if structure differs."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        # Different graph-level predicate
+        g2.add((EX.stmt1, EX.describes, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_non_isomorphic_different_graph_subjects(self):
+        """Same TripleTerm structure but under different graph subjects should not
+        be isomorphic."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt2, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_non_isomorphic_bnode_position_subject_vs_object(self):
+        """A BNode in TripleTerm subject vs object position should not be isomorphic
+        even when both are embedded-only."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        # BNode in subject position
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        # BNode in object position
+        tt2 = TripleTerm(EX.person, EX.name, b2)
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_non_isomorphic_same_position_different_surrounding_terms(self):
+        """Embedded-only BNodes with same position but different non-BNode terms
+        in the TripleTerm should produce non-isomorphic graphs."""
+        g1 = Graph()
+        g2 = Graph()
+
+        b1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+
+        b2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Bob"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+
+        assert not isomorphic(g1, g2)
+
+    def test_isomorphic_same_context_different_bnodes(self):
+        """Embedded-only BNodes with identical structural context should be
+        isomorphic regardless of BNode identity."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # Both have the exact same structure - only bnode identity differs
+        b1 = BNode("x")
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((EX.stmt1, EX.reifies, tt1))
+        g1.add((EX.stmt1, EX.type, EX.Reification))
+
+        b2 = BNode("y")
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((EX.stmt1, EX.reifies, tt2))
+        g2.add((EX.stmt1, EX.type, EX.Reification))
+
+        assert isomorphic(g1, g2)
+
+    def test_non_isomorphic_embedded_only_mixed_with_graph_level(self):
+        """Graph where one BNode is graph-level and another is embedded-only
+        vs graph where both appear at graph level."""
+        g1 = Graph()
+        g2 = Graph()
+
+        # g1: b1 is embedded-only, b_graph is graph-level
+        b1 = BNode()
+        b_graph1 = BNode()
+        tt1 = TripleTerm(b1, EX.name, Literal("Alice"))
+        g1.add((b_graph1, EX.reifies, tt1))
+        g1.add((b_graph1, EX.type, EX.Statement))
+
+        # g2: both BNodes appear at graph level (b2 also used as subject)
+        b2 = BNode()
+        b_graph2 = BNode()
+        tt2 = TripleTerm(b2, EX.name, Literal("Alice"))
+        g2.add((b_graph2, EX.reifies, tt2))
+        g2.add((b_graph2, EX.type, EX.Statement))
+        g2.add((b2, EX.type, EX.Person))  # Extra triple makes it non-iso
+
+        assert not isomorphic(g1, g2)

--- a/test/test_graph/test_graph_cbd.py
+++ b/test/test_graph/test_graph_cbd.py
@@ -4,7 +4,7 @@ import pytest
 
 from rdflib import Graph, Namespace
 from rdflib.namespace import RDF, RDFS
-from rdflib.term import Literal, URIRef
+from rdflib.term import BNode, Literal, URIRef
 from test.data import TEST_DATA_DIR
 from test.utils import BNodeHandling, GraphHelper
 
@@ -176,3 +176,99 @@ def test_cbd_target(rdfs_graph: Graph):
 
     assert result is target
     assert expected_result == set(result.triples((None, None, None)))
+
+
+def test_cbd_rdf12_reification():
+    """CBD Rule 3 includes RDF 1.2 reifiers linked via rdf:reifies."""
+    g = Graph()
+    g.add((EX.R1, EX.propOne, EX.P1))
+    g.add((EX.R1, EX.propTwo, EX.P2))
+
+    # Reify one of R1's triples using RDF 1.2 reification
+    reifier = g.reify(EX.R1, EX.propOne, EX.P1, reifier=EX.rei1)
+    # Add extra metadata on the reifier
+    g.add((reifier, EX.certainty, Literal("0.9")))
+    g.add((reifier, EX.source, EX.S1))
+
+    cbd = g.cbd(EX.R1)
+
+    # CBD should include: 2 triples about R1, 1 reifying triple, 2 reifier metadata
+    assert (EX.R1, EX.propOne, EX.P1) in cbd
+    assert (EX.R1, EX.propTwo, EX.P2) in cbd
+    assert (EX.rei1, EX.certainty, Literal("0.9")) in cbd
+    assert (EX.rei1, EX.source, EX.S1) in cbd
+    # The rdf:reifies triple about the reifier should also be included
+    assert len(list(cbd.triples((EX.rei1, RDF.reifies, None)))) == 1
+    assert len(cbd) == 5
+
+
+def test_cbd_rdf12_reification_multiple_reifiers():
+    """CBD Rule 3 includes multiple RDF 1.2 reifiers of the same triple."""
+    g = Graph()
+    g.add((EX.R1, EX.knows, EX.R2))
+
+    g.reify(EX.R1, EX.knows, EX.R2, reifier=EX.rei1)
+    g.add((EX.rei1, EX.source, EX.S1))
+
+    g.reify(EX.R1, EX.knows, EX.R2, reifier=EX.rei2)
+    g.add((EX.rei2, EX.source, EX.S2))
+
+    cbd = g.cbd(EX.R1)
+
+    # 1 triple about R1 + 2 reifiers * (1 rdf:reifies + 1 metadata) = 5
+    assert (EX.rei1, EX.source, EX.S1) in cbd
+    assert (EX.rei2, EX.source, EX.S2) in cbd
+    assert len(cbd) == 5
+
+
+def test_cbd_rdf12_reification_with_bnode_reifier():
+    """CBD Rule 3 follows BNode reifiers linked via rdf:reifies."""
+    g = Graph()
+    g.add((EX.R1, EX.propOne, EX.P1))
+
+    # Reify with a blank node reifier
+    reifier = g.reify(EX.R1, EX.propOne, EX.P1)
+    g.add((reifier, EX.source, EX.S1))
+
+    cbd = g.cbd(EX.R1)
+
+    # 1 triple about R1 + 1 rdf:reifies + 1 metadata on bnode reifier = 3
+    assert (EX.R1, EX.propOne, EX.P1) in cbd
+    assert (reifier, EX.source, EX.S1) in cbd
+    assert len(cbd) == 3
+
+
+def test_cbd_rdf12_reification_reifier_with_bnode_object():
+    """CBD Rule 3 recursively follows BNodes in reifier descriptions."""
+    g = Graph()
+    g.add((EX.R1, EX.propOne, EX.P1))
+
+    reifier = g.reify(EX.R1, EX.propOne, EX.P1, reifier=EX.rei1)
+    bn = BNode()
+    g.add((reifier, EX.details, bn))
+    g.add((bn, EX.note, Literal("important")))
+
+    cbd = g.cbd(EX.R1)
+
+    # 1 R1 triple + 1 rdf:reifies + 1 reifier->bnode + 1 bnode detail = 4
+    assert (EX.R1, EX.propOne, EX.P1) in cbd
+    assert (reifier, EX.details, bn) in cbd
+    assert (bn, EX.note, Literal("important")) in cbd
+    assert len(cbd) == 4
+
+
+def test_cbd_rdf12_reification_no_false_match():
+    """CBD Rule 3 does not include reifiers of triples not in the CBD."""
+    g = Graph()
+    g.add((EX.R1, EX.propOne, EX.P1))
+
+    # Reify a triple about R2 (not R1)
+    g.reify(EX.R2, EX.propOne, EX.P1, reifier=EX.rei1)
+    g.add((EX.rei1, EX.source, EX.S1))
+
+    cbd = g.cbd(EX.R1)
+
+    # Only R1's own triple should be present
+    assert len(cbd) == 1
+    assert (EX.R1, EX.propOne, EX.P1) in cbd
+    assert (EX.rei1, EX.source, EX.S1) not in cbd

--- a/test/test_graph/test_reify.py
+++ b/test/test_graph/test_reify.py
@@ -1,0 +1,124 @@
+"""Tests for the Graph.reify() method (RDF 1.2 reification)."""
+
+from __future__ import annotations
+
+from rdflib import Graph, Literal, Namespace
+from rdflib.namespace import RDF
+from rdflib.term import BNode, TripleTerm
+
+EX = Namespace("http://example.org/")
+
+
+def test_reify_returns_bnode_by_default() -> None:
+    """reify() with no reifier argument returns a BNode."""
+    g = Graph()
+    reifier = g.reify(EX.alice, EX.knows, EX.bob)
+    assert isinstance(reifier, BNode)
+
+
+def test_reify_with_explicit_uriref_reifier() -> None:
+    """reify() with an explicit URIRef reifier uses that URI."""
+    g = Graph()
+    reifier = g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.reifier1)
+    assert reifier == EX.reifier1
+
+
+def test_reify_with_explicit_bnode_reifier() -> None:
+    """reify() with an explicit BNode reifier uses that BNode."""
+    g = Graph()
+    bn = BNode("myreifier")
+    reifier = g.reify(EX.alice, EX.knows, EX.bob, reifier=bn)
+    assert reifier == bn
+
+
+def test_reify_asserted_false_default() -> None:
+    """By default (asserted=False), only the reifying triple is added."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob)
+    assert len(g) == 1
+    assert (EX.alice, EX.knows, EX.bob) not in g
+
+
+def test_reify_asserted_true() -> None:
+    """With asserted=True, both the reifying triple and original are added."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob, asserted=True)
+    assert len(g) == 2
+    assert (EX.alice, EX.knows, EX.bob) in g
+
+
+def test_reifying_triple_uses_rdf_reifies() -> None:
+    """The reifying triple uses RDF.reifies as predicate."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1)
+    triples = list(g.triples((EX.r1, RDF.reifies, None)))
+    assert len(triples) == 1
+    assert triples[0][1] == RDF.reifies
+
+
+def test_reifying_triple_object_is_triple_term() -> None:
+    """The object of the reifying triple is a TripleTerm."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1)
+    triples = list(g.triples((EX.r1, RDF.reifies, None)))
+    obj = triples[0][2]
+    assert isinstance(obj, TripleTerm)
+
+
+def test_reifying_triple_term_components() -> None:
+    """The TripleTerm in the reifying triple has correct components."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1)
+    triples = list(g.triples((EX.r1, RDF.reifies, None)))
+    tt = triples[0][2]
+    assert isinstance(tt, TripleTerm)
+    assert tt.subject == EX.alice
+    assert tt.predicate == EX.knows
+    assert tt.object == EX.bob
+
+
+def test_reifying_triple_with_literal_object() -> None:
+    """Reification works when the original triple has a Literal object."""
+    g = Graph()
+    lit = Literal("Alice", lang="en")
+    g.reify(EX.alice, EX.name, lit, reifier=EX.r1)
+    triples = list(g.triples((EX.r1, RDF.reifies, None)))
+    tt = triples[0][2]
+    assert isinstance(tt, TripleTerm)
+    assert tt.object == lit
+
+
+def test_reify_return_value_is_reifier() -> None:
+    """reify() returns the reifier node."""
+    g = Graph()
+    reifier = g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1)
+    assert reifier == EX.r1
+
+
+def test_reify_return_value_auto_bnode() -> None:
+    """reify() with no reifier returns the auto-generated BNode."""
+    g = Graph()
+    reifier = g.reify(EX.alice, EX.knows, EX.bob)
+    triples = list(g.triples((reifier, RDF.reifies, None)))
+    assert len(triples) == 1
+
+
+def test_multiple_reifications_same_triple() -> None:
+    """The same triple can be reified multiple times with different reifiers."""
+    g = Graph()
+    r1 = g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1)
+    r2 = g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r2)
+    assert r1 != r2
+    assert len(g) == 2
+    assert len(list(g.triples((EX.r1, RDF.reifies, None)))) == 1
+    assert len(list(g.triples((EX.r2, RDF.reifies, None)))) == 1
+
+
+def test_reify_asserted_true_with_multiple_reifiers() -> None:
+    """Multiple reifications with asserted=True only add the original once."""
+    g = Graph()
+    g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r1, asserted=True)
+    g.reify(EX.alice, EX.knows, EX.bob, reifier=EX.r2, asserted=True)
+    # 2 reifying triples + 1 original (deduplicated)
+    assert len(g) == 3
+    assert (EX.alice, EX.knows, EX.bob) in g

--- a/test/test_graph/test_skolemize_triple_term.py
+++ b/test/test_graph/test_skolemize_triple_term.py
@@ -1,0 +1,145 @@
+"""Tests for skolemization and de-skolemization with TripleTerms."""
+
+from __future__ import annotations
+
+import re
+
+from rdflib import Graph, Namespace, URIRef
+from rdflib.namespace import RDF
+from rdflib.term import BNode, Literal, TripleTerm
+
+EX = Namespace("http://example.org/")
+
+SKOLEM_PATTERN = re.compile(r"^https://rdflib\.github\.io/\.well-known/genid/rdflib/")
+
+
+def _is_skolem_uri(node: object) -> bool:
+    return isinstance(node, URIRef) and SKOLEM_PATTERN.match(str(node)) is not None
+
+
+def test_skolemize_bnode_in_triple_term() -> None:
+    """Skolemize replaces BNodes in TripleTerm subject and object positions."""
+    g = Graph()
+    bn_s = BNode()
+    bn_o = BNode()
+
+    # TripleTerm with BNode subject only
+    tt_subj = TripleTerm(bn_s, EX.predicate, EX.object)
+    g.add((EX.r1, RDF.reifies, tt_subj))
+
+    # TripleTerm with BNode object only
+    tt_obj = TripleTerm(EX.subject, EX.predicate, bn_o)
+    g.add((EX.r2, RDF.reifies, tt_obj))
+
+    # TripleTerm with no BNodes (should be unchanged)
+    tt_plain = TripleTerm(EX.subject, EX.predicate, EX.object)
+    g.add((EX.r3, RDF.reifies, tt_plain))
+
+    skolemized = g.skolemize()
+    assert len(skolemized) == 3
+
+    # Check BNode subject was skolemized
+    r1_triples = list(skolemized.triples((EX.r1, RDF.reifies, None)))
+    tt1 = r1_triples[0][2]
+    assert isinstance(tt1, TripleTerm)
+    assert _is_skolem_uri(tt1.subject)
+    assert tt1.predicate == EX.predicate
+    assert tt1.object == EX.object
+
+    # Check BNode object was skolemized
+    r2_triples = list(skolemized.triples((EX.r2, RDF.reifies, None)))
+    tt2 = r2_triples[0][2]
+    assert isinstance(tt2, TripleTerm)
+    assert tt2.subject == EX.subject
+    assert _is_skolem_uri(tt2.object)
+
+    # Check no-BNode TripleTerm is unchanged
+    r3_triples = list(skolemized.triples((EX.r3, RDF.reifies, None)))
+    tt3 = r3_triples[0][2]
+    assert isinstance(tt3, TripleTerm)
+    assert tt3.subject == EX.subject
+    assert tt3.object == EX.object
+
+
+def test_deskolemize_reverses_skolemization() -> None:
+    """De-skolemize restores BNodes inside TripleTerms after skolemization."""
+    g = Graph()
+    bn = BNode()
+    tt = TripleTerm(bn, EX.predicate, EX.object)
+    g.add((EX.reifier, RDF.reifies, tt))
+
+    deskolemized = g.skolemize().de_skolemize()
+    assert len(deskolemized) == 1
+
+    triples = list(deskolemized.triples((EX.reifier, RDF.reifies, None)))
+    obj = triples[0][2]
+    assert isinstance(obj, TripleTerm)
+    assert isinstance(obj.subject, BNode)
+    assert obj.predicate == EX.predicate
+    assert obj.object == EX.object
+
+    # Also test BNode in object position roundtrips
+    g2 = Graph()
+    bn2 = BNode()
+    tt2 = TripleTerm(EX.subject, EX.predicate, bn2)
+    g2.add((EX.reifier, RDF.reifies, tt2))
+
+    deskolemized2 = g2.skolemize().de_skolemize()
+    triples2 = list(deskolemized2.triples((EX.reifier, RDF.reifies, None)))
+    obj2 = triples2[0][2]
+    assert isinstance(obj2, TripleTerm)
+    assert isinstance(obj2.object, BNode)
+
+
+def test_skolemize_nested_triple_term() -> None:
+    """Skolemize/de-skolemize handles nested TripleTerms with BNodes."""
+    g = Graph()
+    bn = BNode()
+    inner_tt = TripleTerm(bn, EX.innerPred, EX.innerObj)
+    outer_tt = TripleTerm(EX.outerSubj, EX.outerPred, inner_tt)
+    g.add((EX.reifier, RDF.reifies, outer_tt))
+
+    # Skolemize
+    skolemized = g.skolemize()
+    triples = list(skolemized.triples((EX.reifier, RDF.reifies, None)))
+    obj = triples[0][2]
+    assert isinstance(obj, TripleTerm)
+    inner = obj.object
+    assert isinstance(inner, TripleTerm)
+    assert _is_skolem_uri(inner.subject)
+    assert inner.predicate == EX.innerPred
+
+    # De-skolemize
+    deskolemized = skolemized.de_skolemize()
+    triples_d = list(deskolemized.triples((EX.reifier, RDF.reifies, None)))
+    obj_d = triples_d[0][2]
+    assert isinstance(obj_d, TripleTerm)
+    inner_d = obj_d.object
+    assert isinstance(inner_d, TripleTerm)
+    assert isinstance(inner_d.subject, BNode)
+
+
+def test_skolemize_shared_bnode_graph_and_triple_term() -> None:
+    """A BNode used both as graph subject and inside a TripleTerm gets the same skolem URI."""
+    g = Graph()
+    bn = BNode()
+    tt = TripleTerm(bn, EX.predicate, EX.object)
+    g.add((bn, EX.name, Literal("Alice")))
+    g.add((EX.reifier, RDF.reifies, tt))
+
+    skolemized = g.skolemize()
+    assert len(skolemized) == 2
+
+    # Get the skolem URI from the graph-level triple
+    name_triples = list(skolemized.triples((None, EX.name, Literal("Alice"))))
+    skolem_node = name_triples[0][0]
+    assert _is_skolem_uri(skolem_node)
+
+    # Get the skolem URI from inside the TripleTerm
+    reify_triples = list(skolemized.triples((EX.reifier, RDF.reifies, None)))
+    tt_obj = reify_triples[0][2]
+    assert isinstance(tt_obj, TripleTerm)
+    assert _is_skolem_uri(tt_obj.subject)
+
+    # Same BNode → same skolem URI
+    assert skolem_node == tt_obj.subject

--- a/test/test_literal/test_direction.py
+++ b/test/test_literal/test_direction.py
@@ -1,0 +1,337 @@
+"""Tests for the RDF 1.2 Literal direction feature (rdf:dirLangString)."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib.namespace import RDF
+
+EX = Namespace("http://example.org/")
+
+
+# --- Construction ---
+
+
+def test_construction_ltr() -> None:
+    """Literal can be constructed with direction='ltr'."""
+    lit = Literal("hello", lang="en", direction="ltr")
+    assert str(lit) == "hello"
+    assert lit.language == "en"
+    assert lit.direction == "ltr"
+
+
+def test_construction_rtl() -> None:
+    """Literal can be constructed with direction='rtl'."""
+    lit = Literal("مرحبا", lang="ar", direction="rtl")
+    assert str(lit) == "مرحبا"
+    assert lit.language == "ar"
+    assert lit.direction == "rtl"
+
+
+def test_construction_no_direction() -> None:
+    """Literal without direction has direction=None."""
+    lit = Literal("hello", lang="en")
+    assert lit.direction is None
+
+
+# --- Validation ---
+
+
+def test_direction_requires_lang() -> None:
+    """Direction without lang raises ValueError."""
+    with pytest.raises(ValueError, match="must also have a language tag"):
+        Literal("hello", direction="ltr")
+
+
+def test_direction_requires_lang_even_with_datatype() -> None:
+    """Direction without lang raises ValueError even if datatype is given."""
+    with pytest.raises(ValueError, match="must also have a language tag"):
+        Literal("hello", datatype=RDF.dirLangString, direction="ltr")
+
+
+def test_direction_must_be_ltr_or_rtl() -> None:
+    """Direction must be 'ltr' or 'rtl'; other values raise ValueError."""
+    with pytest.raises(ValueError, match="must be 'ltr' or 'rtl'"):
+        Literal("hello", lang="en", direction="up")
+
+
+def test_direction_must_be_ltr_or_rtl_empty_string() -> None:
+    """Empty string direction raises ValueError."""
+    with pytest.raises(ValueError, match="must be 'ltr' or 'rtl'"):
+        Literal("hello", lang="en", direction="")
+
+
+def test_direction_must_be_ltr_or_rtl_case_sensitive() -> None:
+    """Direction is case-sensitive; 'LTR' is invalid."""
+    with pytest.raises(ValueError, match="must be 'ltr' or 'rtl'"):
+        Literal("hello", lang="en", direction="LTR")
+
+
+# --- Datatype auto-setting ---
+
+
+def test_datatype_auto_set_to_dir_lang_string() -> None:
+    """Datatype is auto-set to rdf:dirLangString when direction is provided."""
+    lit = Literal("hello", lang="en", direction="ltr")
+    assert lit.datatype == RDF.dirLangString
+
+
+def test_datatype_without_direction_is_none() -> None:
+    """Without direction, a lang-tagged literal has datatype None (rdflib convention)."""
+    lit = Literal("hello", lang="en")
+    assert lit.datatype is None
+
+
+# --- Equality ---
+
+
+def test_equality_same_direction() -> None:
+    """Literals with same text, lang, and direction are equal."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="ltr")
+    assert l1 == l2
+
+
+def test_equality_different_direction() -> None:
+    """Literals with different direction are not equal."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="rtl")
+    assert l1 != l2
+
+
+def test_equality_direction_vs_no_direction() -> None:
+    """Literal with direction is not equal to one without direction."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en")
+    assert l1 != l2
+
+
+def test_equality_no_direction_vs_direction() -> None:
+    """Literal without direction is not equal to one with direction (symmetric)."""
+    l1 = Literal("hello", lang="en")
+    l2 = Literal("hello", lang="en", direction="rtl")
+    assert l1 != l2
+
+
+def test_equality_same_text_different_lang_same_direction() -> None:
+    """Same text and direction but different lang are not equal."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="fr", direction="ltr")
+    assert l1 != l2
+
+
+# --- Hashing ---
+
+
+def test_hash_consistent_with_equality() -> None:
+    """Equal literals with direction have the same hash."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="ltr")
+    assert hash(l1) == hash(l2)
+
+
+def test_hash_different_direction() -> None:
+    """Literals with different direction (likely) have different hashes."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="rtl")
+    # Not strictly guaranteed, but extremely likely
+    assert hash(l1) != hash(l2)
+
+
+def test_hash_direction_vs_no_direction() -> None:
+    """Literal with direction has different hash from one without."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en")
+    # Not strictly guaranteed, but extremely likely
+    assert hash(l1) != hash(l2)
+
+
+def test_hash_usable_in_set() -> None:
+    """Literals with direction can be used in sets with proper deduplication."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="ltr")
+    l3 = Literal("hello", lang="en", direction="rtl")
+    l4 = Literal("hello", lang="en")
+    s = {l1, l2, l3, l4}
+    assert len(s) == 3
+
+
+def test_hash_usable_as_dict_key() -> None:
+    """Literals with direction work as dict keys."""
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="ltr")
+    d = {l1: "value"}
+    assert d[l2] == "value"
+
+
+# --- n3() output ---
+
+
+def test_n3_ltr() -> None:
+    """n3() outputs 'text'@lang--ltr format."""
+    lit = Literal("hello", lang="en", direction="ltr")
+    assert lit.n3() == '"hello"@en--ltr'
+
+
+def test_n3_rtl() -> None:
+    """n3() outputs 'text'@lang--rtl format."""
+    lit = Literal("مرحبا", lang="ar", direction="rtl")
+    assert lit.n3() == '"مرحبا"@ar--rtl'
+
+
+def test_n3_without_direction() -> None:
+    """n3() without direction does not include --dir suffix."""
+    lit = Literal("hello", lang="en")
+    assert lit.n3() == '"hello"@en'
+    assert "--" not in lit.n3()
+
+
+# --- repr() ---
+
+
+def test_repr_shows_direction() -> None:
+    """repr() includes direction when present."""
+    lit = Literal("hello", lang="en", direction="ltr")
+    r = repr(lit)
+    assert "direction=" in r
+    assert "'ltr'" in r
+
+
+def test_repr_no_direction() -> None:
+    """repr() does not show direction when not present."""
+    lit = Literal("hello", lang="en")
+    r = repr(lit)
+    assert "direction" not in r
+
+
+# --- Use in a Graph ---
+
+
+def test_literal_with_direction_in_graph() -> None:
+    """Literal with direction can be added to and retrieved from a Graph."""
+    g = Graph()
+    lit = Literal("hello", lang="en", direction="ltr")
+    g.add((EX.subject, EX.label, lit))
+    assert len(g) == 1
+
+    triples = list(g.triples((EX.subject, EX.label, None)))
+    assert len(triples) == 1
+    retrieved = triples[0][2]
+    assert isinstance(retrieved, Literal)
+    assert retrieved.direction == "ltr"
+    assert retrieved == lit
+
+
+def test_different_directions_are_distinct_in_graph() -> None:
+    """Literals with different directions are distinct triples in a Graph."""
+    g = Graph()
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="rtl")
+    l3 = Literal("hello", lang="en")
+    g.add((EX.subject, EX.label, l1))
+    g.add((EX.subject, EX.label, l2))
+    g.add((EX.subject, EX.label, l3))
+    assert len(g) == 3
+
+
+def test_same_direction_deduplicates_in_graph() -> None:
+    """Adding the same literal with direction twice doesn't duplicate."""
+    g = Graph()
+    l1 = Literal("hello", lang="en", direction="ltr")
+    l2 = Literal("hello", lang="en", direction="ltr")
+    g.add((EX.subject, EX.label, l1))
+    g.add((EX.subject, EX.label, l2))
+    assert len(g) == 1
+
+
+# --- Explicit datatype with lang (RDF 1.2 spec compliance) ---
+
+
+def test_explicit_dir_lang_string_datatype_with_lang() -> None:
+    """Explicit datatype=rdf:dirLangString with lang and direction is allowed."""
+    lit = Literal("hello", lang="en", datatype=RDF.dirLangString, direction="ltr")
+    assert lit.language == "en"
+    assert lit.direction == "ltr"
+    assert lit.datatype == RDF.dirLangString
+
+
+def test_explicit_lang_string_datatype_with_lang() -> None:
+    """Explicit datatype=rdf:langString with lang is allowed (no TypeError)."""
+    lit = Literal("hello", lang="en", datatype=RDF.langString)
+    assert lit.language == "en"
+    assert lit.datatype == RDF.langString
+
+
+def test_explicit_non_lang_datatype_with_lang_raises() -> None:
+    """Explicit non-lang datatype with lang raises TypeError."""
+    with pytest.raises(TypeError, match="can only have one of lang or datatype"):
+        Literal("hello", lang="en", datatype=URIRef("http://example.org/mytype"))
+
+
+# --- Pickling ---
+
+
+def test_pickle_roundtrip_ltr() -> None:
+    """Literal with direction='ltr' survives pickle/unpickle."""
+    lit = Literal("hello", lang="en", direction="ltr")
+    pickled = pickle.dumps(lit)
+    unpickled = pickle.loads(pickled)
+    assert unpickled == lit
+    assert unpickled.language == "en"
+    assert unpickled.direction == "ltr"
+    assert unpickled.datatype == RDF.dirLangString
+
+
+def test_pickle_roundtrip_rtl() -> None:
+    """Literal with direction='rtl' survives pickle/unpickle."""
+    lit = Literal("مرحبا", lang="ar", direction="rtl")
+    pickled = pickle.dumps(lit)
+    unpickled = pickle.loads(pickled)
+    assert unpickled == lit
+    assert unpickled.language == "ar"
+    assert unpickled.direction == "rtl"
+    assert unpickled.datatype == RDF.dirLangString
+
+
+def test_pickle_roundtrip_no_direction() -> None:
+    """Literal without direction still pickles correctly (no regression)."""
+    lit = Literal("hello", lang="en")
+    pickled = pickle.dumps(lit)
+    unpickled = pickle.loads(pickled)
+    assert unpickled == lit
+    assert unpickled.language == "en"
+    assert unpickled.direction is None
+
+
+# --- Copy construction ---
+
+
+def test_copy_construction_preserves_direction() -> None:
+    """Constructing a Literal from another directional Literal preserves direction."""
+    original = Literal("hello", lang="en", direction="ltr")
+    copy = Literal(original)
+    assert copy == original
+    assert copy.language == "en"
+    assert copy.direction == "ltr"
+    assert copy.datatype == RDF.dirLangString
+
+
+def test_copy_construction_preserves_rtl_direction() -> None:
+    """Constructing a Literal from an RTL directional Literal preserves direction."""
+    original = Literal("مرحبا", lang="ar", direction="rtl")
+    copy = Literal(original)
+    assert copy == original
+    assert copy.language == "ar"
+    assert copy.direction == "rtl"
+
+
+def test_copy_construction_no_direction_no_regression() -> None:
+    """Constructing a Literal from a lang-tagged Literal without direction works."""
+    original = Literal("hello", lang="en")
+    copy = Literal(original)
+    assert copy == original
+    assert copy.language == "en"
+    assert copy.direction is None

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -134,6 +134,7 @@ def test_definednamespace_dir():
         RDF.language,
         RDF.object,
         RDF.predicate,
+        RDF.reifies,
         RDF.rest,
         RDF.subject,
         RDF.type,
@@ -149,6 +150,7 @@ def test_definednamespace_dir():
         RDF.JSON,
         RDF.PlainLiteral,
         RDF.XMLLiteral,
+        RDF.dirLangString,
         RDF.langString,
     ]
 

--- a/test/test_namespace/test_definednamespace_dir.py
+++ b/test/test_namespace/test_definednamespace_dir.py
@@ -11,6 +11,7 @@ def test_definednamespace_dir():
         RDF.language,
         RDF.object,
         RDF.predicate,
+        RDF.reifies,
         RDF.rest,
         RDF.subject,
         RDF.type,
@@ -26,6 +27,7 @@ def test_definednamespace_dir():
         RDF.JSON,
         RDF.PlainLiteral,
         RDF.XMLLiteral,
+        RDF.dirLangString,
         RDF.langString,
     ]
 

--- a/test/test_term/test_triple_term.py
+++ b/test/test_term/test_triple_term.py
@@ -1,0 +1,373 @@
+"""Tests for the RDF 1.2 TripleTerm class."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib.namespace import RDF
+from rdflib.term import BNode, TripleTerm
+
+EX = Namespace("http://example.org/")
+
+
+# --- Construction ---
+
+
+def test_construction_uriref_subject_and_object() -> None:
+    """TripleTerm can be constructed with URIRef subject, predicate, and object."""
+    tt = TripleTerm(EX.subject, EX.predicate, EX.object)
+    assert tt.subject == EX.subject
+    assert tt.predicate == EX.predicate
+    assert tt.object == EX.object
+
+
+def test_construction_bnode_subject() -> None:
+    """TripleTerm can be constructed with a BNode subject."""
+    bn = BNode()
+    tt = TripleTerm(bn, EX.predicate, EX.object)
+    assert tt.subject == bn
+    assert isinstance(tt.subject, BNode)
+
+
+def test_construction_literal_object() -> None:
+    """TripleTerm can be constructed with a Literal object."""
+    lit = Literal("hello", lang="en")
+    tt = TripleTerm(EX.subject, EX.predicate, lit)
+    assert tt.object == lit
+    assert isinstance(tt.object, Literal)
+
+
+def test_construction_bnode_object() -> None:
+    """TripleTerm can be constructed with a BNode object."""
+    bn = BNode()
+    tt = TripleTerm(EX.subject, EX.predicate, bn)
+    assert tt.object == bn
+    assert isinstance(tt.object, BNode)
+
+
+def test_construction_nested_triple_term_as_object() -> None:
+    """TripleTerm can be constructed with another TripleTerm as object."""
+    inner = TripleTerm(EX.s2, EX.p2, EX.o2)
+    outer = TripleTerm(EX.subject, EX.predicate, inner)
+    assert outer.object == inner
+    assert isinstance(outer.object, TripleTerm)
+
+
+# --- Invalid construction ---
+
+
+def test_invalid_literal_as_subject() -> None:
+    """Literal as subject raises TypeError."""
+    with pytest.raises(TypeError, match="subject must be"):
+        TripleTerm(Literal("bad"), EX.predicate, EX.object)  # type: ignore[arg-type]
+
+
+def test_invalid_bnode_as_predicate() -> None:
+    """BNode as predicate raises TypeError."""
+    with pytest.raises(TypeError, match="predicate must be"):
+        TripleTerm(EX.subject, BNode(), EX.object)  # type: ignore[arg-type]
+
+
+def test_invalid_literal_as_predicate() -> None:
+    """Literal as predicate raises TypeError."""
+    with pytest.raises(TypeError, match="predicate must be"):
+        TripleTerm(EX.subject, Literal("bad"), EX.object)  # type: ignore[arg-type]
+
+
+def test_invalid_string_as_subject() -> None:
+    """Plain string as subject raises TypeError."""
+    with pytest.raises(TypeError, match="subject must be"):
+        TripleTerm("http://example.org/s", EX.predicate, EX.object)  # type: ignore[arg-type]
+
+
+def test_invalid_int_as_object() -> None:
+    """Integer as object raises TypeError."""
+    with pytest.raises(TypeError, match="object must be"):
+        TripleTerm(EX.subject, EX.predicate, 42)  # type: ignore[arg-type]
+
+
+# --- Equality ---
+
+
+def test_equality_same_components() -> None:
+    """TripleTerms with same components are equal."""
+    tt1 = TripleTerm(EX.s, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt1 == tt2
+
+
+def test_equality_different_subject() -> None:
+    """TripleTerms with different subjects are not equal."""
+    tt1 = TripleTerm(EX.s1, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s2, EX.p, EX.o)
+    assert tt1 != tt2
+
+
+def test_equality_different_predicate() -> None:
+    """TripleTerms with different predicates are not equal."""
+    tt1 = TripleTerm(EX.s, EX.p1, EX.o)
+    tt2 = TripleTerm(EX.s, EX.p2, EX.o)
+    assert tt1 != tt2
+
+
+def test_equality_different_object() -> None:
+    """TripleTerms with different objects are not equal."""
+    tt1 = TripleTerm(EX.s, EX.p, EX.o1)
+    tt2 = TripleTerm(EX.s, EX.p, EX.o2)
+    assert tt1 != tt2
+
+
+def test_equality_not_equal_to_uriref() -> None:
+    """TripleTerm is not equal to a URIRef."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt != EX.s
+
+
+def test_equality_not_equal_to_literal() -> None:
+    """TripleTerm is not equal to a Literal."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt != Literal("hello")
+
+
+def test_equality_not_equal_to_none() -> None:
+    """TripleTerm is not equal to None."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt != None  # noqa: E711
+
+
+# --- Hashing ---
+
+
+def test_hash_equal_triple_terms() -> None:
+    """Equal TripleTerms have the same hash."""
+    tt1 = TripleTerm(EX.s, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s, EX.p, EX.o)
+    assert hash(tt1) == hash(tt2)
+
+
+def test_hash_different_triple_terms() -> None:
+    """Different TripleTerms have different hashes."""
+    tt1 = TripleTerm(EX.s1, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s2, EX.p, EX.o)
+    assert hash(tt1) != hash(tt2)
+
+
+# --- Ordering ---
+
+
+def test_ordering_same_type_by_subject() -> None:
+    """TripleTerms are ordered component-wise; subject first."""
+    tt1 = TripleTerm(EX.a, EX.p, EX.o)
+    tt2 = TripleTerm(EX.b, EX.p, EX.o)
+    assert tt1 < tt2
+    assert tt2 > tt1
+
+
+def test_ordering_same_type_by_predicate() -> None:
+    """When subjects are equal, ordering is by predicate."""
+    tt1 = TripleTerm(EX.s, EX.a, EX.o)
+    tt2 = TripleTerm(EX.s, EX.b, EX.o)
+    assert tt1 < tt2
+
+
+def test_ordering_same_type_by_object() -> None:
+    """When subject and predicate are equal, ordering is by object."""
+    tt1 = TripleTerm(EX.s, EX.p, EX.a)
+    tt2 = TripleTerm(EX.s, EX.p, EX.b)
+    assert tt1 < tt2
+
+
+def test_ordering_le_ge() -> None:
+    """Test <= and >= operators."""
+    tt1 = TripleTerm(EX.s, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s, EX.p, EX.o)
+    tt3 = TripleTerm(EX.s2, EX.p, EX.o)
+    assert tt1 <= tt2
+    assert tt1 >= tt2
+    assert tt1 <= tt3
+    assert tt3 >= tt1
+
+
+def test_ordering_cross_type_gt_uriref() -> None:
+    """TripleTerm > URIRef in cross-type ordering."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt > EX.something
+
+
+def test_ordering_cross_type_gt_literal() -> None:
+    """TripleTerm > Literal in cross-type ordering."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt > Literal("hello")
+
+
+def test_ordering_cross_type_gt_bnode() -> None:
+    """TripleTerm > BNode in cross-type ordering."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt > BNode()
+
+
+def test_ordering_cross_type_lt_none_is_false() -> None:
+    """TripleTerm < None is False."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert not (tt < None)
+
+
+def test_ordering_cross_type_gt_none_is_true() -> None:
+    """TripleTerm > None is True."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    assert tt > None
+
+
+# --- n3() output ---
+
+
+def test_n3_basic() -> None:
+    """n3() produces <<( <s> <p> <o> )>> format."""
+    tt = TripleTerm(
+        URIRef("http://example.org/s"),
+        URIRef("http://example.org/p"),
+        URIRef("http://example.org/o"),
+    )
+    expected = (
+        "<<( <http://example.org/s> <http://example.org/p> <http://example.org/o> )>>"
+    )
+    assert tt.n3() == expected
+
+
+def test_n3_with_literal_object() -> None:
+    """n3() with a Literal object."""
+    tt = TripleTerm(EX.s, EX.p, Literal("hello"))
+    n3_str = tt.n3()
+    assert n3_str.startswith("<<( ")
+    assert n3_str.endswith(" )>>")
+    assert '"hello"' in n3_str
+
+
+def test_n3_with_bnode_subject() -> None:
+    """n3() with a BNode subject."""
+    bn = BNode("abc123")
+    tt = TripleTerm(bn, EX.p, EX.o)
+    n3_str = tt.n3()
+    assert "_:abc123" in n3_str
+
+
+def test_n3_with_namespace_manager() -> None:
+    """n3() with a namespace_manager uses prefixed names."""
+    g = Graph()
+    g.bind("ex", EX)
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    n3_str = tt.n3(namespace_manager=g.namespace_manager)
+    assert "ex:" in n3_str
+    assert n3_str.startswith("<<( ")
+    assert n3_str.endswith(" )>>")
+
+
+def test_n3_nested_triple_term() -> None:
+    """n3() with a nested TripleTerm as object."""
+    inner = TripleTerm(EX.s2, EX.p2, EX.o2)
+    outer = TripleTerm(EX.s, EX.p, inner)
+    n3_str = outer.n3()
+    # Should contain nested <<( ... )>>
+    assert n3_str.count("<<(") == 2
+    assert n3_str.count(")>>") == 2
+
+
+# --- repr() ---
+
+
+def test_repr() -> None:
+    """repr() produces a readable representation."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    r = repr(tt)
+    assert r.startswith("TripleTerm(")
+    assert "rdflib.term.URIRef" in r
+    assert "http://example.org/s" in r
+
+
+# --- Pickling ---
+
+
+def test_pickle_roundtrip() -> None:
+    """TripleTerm survives pickle/unpickle."""
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    pickled = pickle.dumps(tt)
+    unpickled = pickle.loads(pickled)
+    assert tt == unpickled
+    assert tt.subject == unpickled.subject
+    assert tt.predicate == unpickled.predicate
+    assert tt.object == unpickled.object
+
+
+def test_pickle_roundtrip_with_literal() -> None:
+    """TripleTerm with Literal object survives pickle/unpickle."""
+    lit = Literal("hello", lang="en")
+    tt = TripleTerm(EX.s, EX.p, lit)
+    pickled = pickle.dumps(tt)
+    unpickled = pickle.loads(pickled)
+    assert tt == unpickled
+    assert unpickled.object == lit
+
+
+def test_pickle_roundtrip_with_bnode() -> None:
+    """TripleTerm with BNode subject survives pickle/unpickle."""
+    bn = BNode("fixed_id")
+    tt = TripleTerm(bn, EX.p, EX.o)
+    pickled = pickle.dumps(tt)
+    unpickled = pickle.loads(pickled)
+    assert tt == unpickled
+
+
+def test_pickle_roundtrip_nested() -> None:
+    """Nested TripleTerm survives pickle/unpickle."""
+    inner = TripleTerm(EX.s2, EX.p2, EX.o2)
+    outer = TripleTerm(EX.s, EX.p, inner)
+    pickled = pickle.dumps(outer)
+    unpickled = pickle.loads(pickled)
+    assert outer == unpickled
+    assert isinstance(unpickled.object, TripleTerm)
+
+
+# --- Use in a Graph ---
+
+
+def test_use_in_graph_as_object() -> None:
+    """TripleTerm can be added to a Graph as an object."""
+    g = Graph()
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    g.add((EX.reifier, RDF.reifies, tt))
+    assert len(g) == 1
+    triples = list(g.triples((EX.reifier, RDF.reifies, None)))
+    assert len(triples) == 1
+    assert triples[0][2] == tt
+
+
+def test_use_in_graph_multiple_triple_terms() -> None:
+    """Multiple TripleTerms can coexist in a Graph."""
+    g = Graph()
+    tt1 = TripleTerm(EX.s1, EX.p1, EX.o1)
+    tt2 = TripleTerm(EX.s2, EX.p2, EX.o2)
+    g.add((EX.r1, RDF.reifies, tt1))
+    g.add((EX.r2, RDF.reifies, tt2))
+    assert len(g) == 2
+
+
+def test_use_in_graph_deduplication() -> None:
+    """Adding the same triple with same TripleTerm object twice doesn't duplicate."""
+    g = Graph()
+    tt = TripleTerm(EX.s, EX.p, EX.o)
+    g.add((EX.reifier, RDF.reifies, tt))
+    g.add((EX.reifier, RDF.reifies, tt))
+    assert len(g) == 1
+
+
+def test_use_in_graph_equal_triple_terms_deduplicate() -> None:
+    """Adding equal TripleTerms (different instances) doesn't duplicate."""
+    g = Graph()
+    tt1 = TripleTerm(EX.s, EX.p, EX.o)
+    tt2 = TripleTerm(EX.s, EX.p, EX.o)
+    g.add((EX.reifier, RDF.reifies, tt1))
+    g.add((EX.reifier, RDF.reifies, tt2))
+    assert len(g) == 1

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -345,6 +345,157 @@ class TestUtilTermConvert:
         literal_str = str(util.from_n3(f'"{string}"'))
         assert literal_str == f"{string}"
 
+    def test_util_from_n3_triple_term_basic(self):
+        """Test parsing a basic triple term with IRIs and a literal."""
+        s = '<<( <http://example.org/Alice> <http://example.org/name> "Alice" )>>'
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert res.subject == URIRef("http://example.org/Alice")
+        assert res.predicate == URIRef("http://example.org/name")
+        assert res.object == Literal("Alice")
+
+    def test_util_from_n3_triple_term_all_iris(self):
+        """Test parsing a triple term where all components are IRIs."""
+        s = "<<( <http://example.org/s> <http://example.org/p> <http://example.org/o> )>>"
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert res.subject == URIRef("http://example.org/s")
+        assert res.predicate == URIRef("http://example.org/p")
+        assert res.object == URIRef("http://example.org/o")
+
+    def test_util_from_n3_triple_term_with_bnode(self):
+        """Test parsing a triple term with a blank node subject."""
+        s = "<<( _:b1 <http://example.org/knows> <http://example.org/Bob> )>>"
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert isinstance(res.subject, BNode)
+        assert res.predicate == URIRef("http://example.org/knows")
+        assert res.object == URIRef("http://example.org/Bob")
+
+    def test_util_from_n3_triple_term_with_lang_literal(self):
+        """Test parsing a triple term with a language-tagged literal."""
+        s = '<<( <http://example.org/Alice> <http://example.org/name> "Alice"@en )>>'
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert res.object == Literal("Alice", lang="en")
+
+    def test_util_from_n3_triple_term_with_typed_literal(self):
+        """Test parsing a triple term with a datatype literal."""
+        s = '<<( <http://example.org/Bob> <http://example.org/age> "30"^^<http://www.w3.org/2001/XMLSchema#integer> )>>'
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert res.object == Literal(
+            "30", datatype=URIRef("http://www.w3.org/2001/XMLSchema#integer")
+        )
+
+    def test_util_from_n3_triple_term_nested(self):
+        """Test parsing a nested triple term."""
+        s = '<<( <http://example.org/Alice> <http://example.org/believes> <<( <http://example.org/Bob> <http://example.org/age> "30"^^<http://www.w3.org/2001/XMLSchema#integer> )>> )>>'
+        res = util.from_n3(s)
+        from rdflib.term import TripleTerm
+
+        assert isinstance(res, TripleTerm)
+        assert isinstance(res.object, TripleTerm)
+        inner = res.object
+        assert inner.subject == URIRef("http://example.org/Bob")
+        assert inner.predicate == URIRef("http://example.org/age")
+        assert inner.object == Literal(
+            "30", datatype=URIRef("http://www.w3.org/2001/XMLSchema#integer")
+        )
+
+    def test_util_from_n3_triple_term_roundtrip(self):
+        """Test that from_n3(tt.n3()) round-trips correctly."""
+        from rdflib.term import TripleTerm
+
+        tt = TripleTerm(
+            URIRef("http://example.org/Alice"),
+            URIRef("http://example.org/name"),
+            Literal("Alice"),
+        )
+        assert util.from_n3(tt.n3()) == tt
+        assert util.from_n3(tt.n3()).n3() == tt.n3()
+
+    def test_util_from_n3_directional_lang_string_rtl(self):
+        """Test parsing a directional language-tagged literal (RTL)."""
+        s = '"مرحبا"@ar--rtl'
+        res = util.from_n3(s)
+        assert isinstance(res, Literal)
+        assert str(res) == "مرحبا"
+        assert res.language == "ar"
+        assert res.direction == "rtl"
+
+    def test_util_from_n3_directional_lang_string_ltr(self):
+        """Test parsing a directional language-tagged literal (LTR)."""
+        s = '"Hello"@en--ltr'
+        res = util.from_n3(s)
+        assert isinstance(res, Literal)
+        assert str(res) == "Hello"
+        assert res.language == "en"
+        assert res.direction == "ltr"
+
+    def test_util_from_n3_directional_lang_string_roundtrip(self):
+        """Test that from_n3(lit.n3()) round-trips for directional literals."""
+        lit = Literal("مرحبا", lang="ar", direction="rtl")
+        result = util.from_n3(lit.n3())
+        assert result == lit
+        assert result.direction == "rtl"
+        assert result.language == "ar"
+        assert result.n3() == lit.n3()
+
+    def test_util_from_n3_directional_lang_complex_tag(self):
+        """Test directional literal with a complex BCP47 language tag."""
+        s = '"你好"@zh-Hant--ltr'
+        res = util.from_n3(s)
+        assert isinstance(res, Literal)
+        assert res.language == "zh-Hant"
+        assert res.direction == "ltr"
+
+    def test_util_from_n3_lang_without_direction(self):
+        """Test that a normal language tag without -- is still parsed correctly."""
+        s = '"hello"@en'
+        res = util.from_n3(s)
+        assert isinstance(res, Literal)
+        assert res.language == "en"
+        assert res.direction is None
+
+    def test_util_from_n3_triple_term_with_dir_literal(self):
+        """Test triple term containing a directional language-tagged literal."""
+        from rdflib.term import TripleTerm
+
+        s = '<<( <http://example.org/Alice> <http://example.org/greeting> "مرحبا"@ar--rtl )>>'
+        res = util.from_n3(s)
+        assert isinstance(res, TripleTerm)
+        assert isinstance(res.object, Literal)
+        assert res.object.direction == "rtl"
+        assert res.object.language == "ar"
+
+    def test_util_from_n3_triple_term_invalid_too_few_terms(self):
+        """Test that a triple term with fewer than 3 terms raises ValueError."""
+        with pytest.raises(ValueError, match="exactly 3 terms"):
+            util.from_n3("<<( <http://example.org/s> )>>")
+
+    def test_util_from_n3_triple_term_with_escaped_literal(self):
+        """Test triple term with a literal containing escaped characters."""
+        from rdflib.term import TripleTerm
+
+        tt = TripleTerm(
+            URIRef("http://example.org/Alice"),
+            URIRef("http://example.org/says"),
+            Literal('She said "hello"'),
+        )
+        result = util.from_n3(tt.n3())
+        assert result == tt
+
 
 @pytest.mark.parametrize(
     ["params", "default", "expected_result"],


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

# Summary of changes

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

Adds the first chunk of RDF 1.2 support, as I didn't see any other PRs looking to do so. 

This does **not** include parser, serializer, or SPARQL engine changes. It focuses exclusively on the data model and related utilities.

### What's included

- **Triple Terms**: A new `TripleTerm(Node)` class representing an RDF triple used as a term in the object position of another triple. Supports equality, hashing, ordering, n3 serialization (`<<( s p o )>>`), pickling, and nesting.
- **Directional Language-Tagged Strings**: A  `direction` parameter (`"ltr"` / `"rtl"`) is added to `Literal` for RDF 1.2 directional language-tagged strings. When set, the datatype is automatically `rdf:dirLangString` and `n3()` outputs the `@lang--dir` syntax.
- **RDF Namespace updates**: Adds `rdf:reifies` (property) and `rdf:dirLangString` (datatype) to the RDF DefinedNamespace.
- **`Graph.reify()` helper**: Convenience method that creates a `(reifier, rdf:reifies, <<( s p o )>>)` triple, with optional assertion of the underlying triple (conceptually similar to Turtle 1.2's annotation syntax).
- **Graph utility updates**: `skolemize()` / `de_skolemize()` recursively transform BNodes inside TripleTerms. `cbd()` follows BNodes embedded in TripleTerms and discovers RDF 1.2 reifiers linked via `rdf:reifies`.
- **`util.from_n3()` parsing**: `from_n3()` now round-trips both triple terms (`<<( s p o )>>` syntax, including nested triple terms) and directional language-tagged strings (`"text"@lang--dir`). A tokenizer handles quoted literals with escapes, IRIs, blank nodes, and recursive triple term delimiters within the inner content.
- **Isomorphism / canonicalization**: `compare.py` updated to enable graph diff and isomorphism checks to work when Triple Terms are used.

***NOTE: I am not super familiar with the `compare` module and am not confident the changes I made are fully correct. The tests (existing and new) pass but someone should look at it more closely.***

### Out of scope

Parsers, serializers, and SPARQL engine.


# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [x] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

