### PR TITLE
Add Support for Store-Level Property Path Evaluation

### DIFF
--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -434,6 +434,27 @@ __all__ = [
 _TCArgT = TypeVar("_TCArgT")
 
 
+def _eval_path_fallback(
+    store: Store,
+    path: Path,
+    subj: Optional[_SubjectType],
+    obj: Optional[_ObjectType],
+    context: _ContextType,
+) -> Generator[Tuple[_SubjectType, _ObjectType], None, None]:
+    """Try store-level path evaluation, falling back to Path.eval().
+
+    Attempts to delegate path evaluation to the store via
+    store.eval_path(). If the store raises NotImplementedError
+    (indicating it does not support path evaluation, or does not
+    support the specific path type), falls back to RDFLib's built-in
+    path evaluation via path.eval().
+    """
+    try:
+        yield from store.eval_path(path, subj, obj, context=context)
+    except NotImplementedError:
+        yield from path.eval(context, subj, obj)
+
+
 # Graph is a node because technically a formula-aware graph
 # take a Graph as subject or object, but we usually use QuotedGraph for that.
 class Graph(Node):
@@ -687,7 +708,7 @@ class Graph(Node):
         """
         s, p, o = triple
         if isinstance(p, Path):
-            for _s, _o in p.eval(self, s, o):
+            for _s, _o in _eval_path_fallback(self.__store, p, s, o, self):
                 yield _s, p, _o
         else:
             for (_s, _p, _o), cg in self.__store.triples((s, p, o), context=self):
@@ -2347,7 +2368,7 @@ class ConjunctiveGraph(Graph):
             if context is None:
                 context = self
 
-            for s, o in p.eval(context, s, o):
+            for s, o in _eval_path_fallback(self.store, p, s, o, context):
                 yield s, p, o
         else:
             for (s, p, o), cg in self.store.triples((s, p, o), context=context):

--- a/rdflib/plugins/stores/sparqlstore.py
+++ b/rdflib/plugins/stores/sparqlstore.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Graph
+from rdflib.paths import Path
 from rdflib.plugins.stores.regexmatching import NATIVE_REGEX
 from rdflib.store import Store
 from rdflib.term import BNode, Identifier, Node, URIRef, Variable
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
         _QuadType,
         _TripleChoiceType,
         _TriplePatternType,
+        _TripleSelectorType,
         _SubjectType,
         _PredicateType,
         _ObjectType,
@@ -53,10 +55,10 @@ ORDERBY = "ORDER BY"
 
 BNODE_IDENT_PATTERN = re.compile(r"(?P<label>_\:[^\s]+)")
 
-_NodeToSparql = Callable[["Node"], str]
+_NodeToSparql = Callable[[Union["Node", "Path"]], str]
 
 
-def _node_to_sparql(node: Node) -> str:
+def _node_to_sparql(node: Union[Node, Path]) -> str:
     if isinstance(node, BNode):
         raise Exception(
             "SPARQLStore does not support BNodes! "
@@ -292,7 +294,26 @@ class SPARQLStore(SPARQLConnector, Store):
         del a_graph.OFFSET
         ```
         """
+        for s, p, o in self._query_spo(spo, context):
+            yield (
+                s,
+                p,
+                o,
+            ), None  # why is the context here not the passed in graph 'context'?
 
+    def _query_spo(
+        self,
+        spo: _TripleSelectorType,
+        context: Optional[_ContextType] = None,
+    ) -> Iterator[Tuple[Any, ...]]:
+        """Build and execute a SPARQL query for the given (s, p, o) pattern.
+
+        This is the shared implementation used by both triples() and
+        eval_path(). It accepts Path objects in the predicate position
+        (which are serialized via n3() into SPARQL property path syntax).
+
+        Yields (s, p, o) tuples of resolved result values.
+        """
         s, p, o = spo
 
         vars = []
@@ -367,10 +388,10 @@ class SPARQLStore(SPARQLConnector, Store):
                     row.get(s, s),  # type: ignore[call-overload]
                     row.get(p, p),  # type: ignore[call-overload]
                     row.get(o, o),  # type: ignore[call-overload]
-                ), None  # why is the context here not the passed in graph 'context'?
+                )
         else:
             if result.askAnswer:
-                yield (s, p, o), None
+                yield (s, p, o)
 
     def triples_choices(
         self,
@@ -392,6 +413,22 @@ class SPARQLStore(SPARQLConnector, Store):
         triples.
         """
         raise NotImplementedError("Triples choices currently not supported")
+
+    def eval_path(
+        self,
+        path: Path,
+        subj: Optional[_SubjectType] = None,
+        obj: Optional[_ObjectType] = None,
+        context: Optional[_ContextType] = None,
+    ) -> Iterator[Tuple[_SubjectType, _ObjectType]]:
+        """Evaluate a property path via SPARQL.
+
+        Constructs a single SPARQL query with the path in the predicate
+        position (using path.n3()), rather than decomposing the path into
+        multiple individual queries.
+        """
+        for s, _, o in self._query_spo((subj, path, obj), context=context):
+            yield s, o
 
     def __len__(self, context: Optional[_ContextType] = None) -> int:
         if not self.sparql11:

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -40,11 +40,14 @@ if TYPE_CHECKING:
     from rdflib.graph import (
         Graph,
         _ContextType,
+        _ObjectType,
         _QuadType,
+        _SubjectType,
         _TripleChoiceType,
         _TriplePatternType,
         _TripleType,
     )
+    from rdflib.paths import Path
     from rdflib.plugins.sparql.sparql import Query, Update
     from rdflib.query import Result
     from rdflib.term import Identifier, Node, URIRef
@@ -429,6 +432,37 @@ class Store:
         context-aware stores.)
         """
 
+        raise NotImplementedError
+
+    # Optional path evaluation
+
+    def eval_path(
+        self,
+        path: Path,
+        subj: Optional[_SubjectType] = None,
+        obj: Optional[_ObjectType] = None,
+        context: Optional[_ContextType] = None,
+    ) -> Iterator[Tuple[_SubjectType, _ObjectType]]:
+        """Evaluate a property path, yielding (subject, object) pairs.
+
+        Stores that support native path evaluation should override this
+        method. The default implementation raises NotImplementedError,
+        causing the caller to fall back to RDFLib's built-in path
+        evaluation via Path.eval().
+
+        Args:
+            path: The property path to evaluate.
+            subj: The subject to match, or None for unbound.
+            obj: The object to match, or None for unbound.
+            context: The graph context for graph-aware stores.
+
+        Returns:
+            An iterator of (subject, object) tuples connected by the path.
+
+        Raises:
+            NotImplementedError: If the store does not support path evaluation
+                (or does not support the specific path type given).
+        """
         raise NotImplementedError
 
     # Optional Namespace methods

--- a/test/test_store/test_store_eval_path.py
+++ b/test/test_store/test_store_eval_path.py
@@ -1,0 +1,192 @@
+"""Tests for Store.eval_path() and the fallback mechanism in Graph.triples()."""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional, Tuple
+
+import pytest
+
+from rdflib import Graph, URIRef
+from rdflib.graph import _ContextType, _ObjectType, _SubjectType
+from rdflib.namespace import RDF, RDFS
+from rdflib.paths import Path, SequencePath, ZeroOrMore
+from rdflib.plugins.stores.memory import Memory
+from rdflib.store import Store
+
+# --- Test 1: Base Store raises NotImplementedError ---
+
+
+def test_store_eval_path_raises_not_implemented() -> None:
+    """The base Store.eval_path() raises NotImplementedError."""
+    store = Store()
+    path = RDF.type / RDFS.subClassOf
+    with pytest.raises(NotImplementedError):
+        list(store.eval_path(path, subj=None, obj=None, context=None))
+
+
+# --- Test 2: Fallback mechanism ---
+
+
+def test_fallback_to_path_eval() -> None:
+    """When the store does not implement eval_path, Graph.triples() falls
+    back to Path.eval() and returns correct results."""
+    g = Graph()
+    a = URIRef("http://example.org/A")
+    b = URIRef("http://example.org/B")
+    c = URIRef("http://example.org/C")
+
+    g.add((a, RDF.type, b))
+    g.add((b, RDFS.subClassOf, c))
+
+    path = RDF.type / RDFS.subClassOf
+    results = set(g.triples((a, path, None)))
+    assert (a, path, c) in results
+
+
+def test_fallback_alternative_path() -> None:
+    """Fallback works for AlternativePath."""
+    g = Graph()
+    a = URIRef("http://example.org/A")
+    b = URIRef("http://example.org/B")
+    c = URIRef("http://example.org/C")
+
+    g.add((a, RDF.type, b))
+    g.add((a, RDFS.subClassOf, c))
+
+    path = RDF.type | RDFS.subClassOf
+    results = {(s, o) for s, p, o in g.triples((a, path, None))}
+    assert (a, b) in results
+    assert (a, c) in results
+
+
+def test_fallback_mulpath() -> None:
+    """Fallback works for MulPath (transitive closure)."""
+    g = Graph()
+    a = URIRef("http://example.org/A")
+    b = URIRef("http://example.org/B")
+    c = URIRef("http://example.org/C")
+
+    g.add((a, RDFS.subClassOf, b))
+    g.add((b, RDFS.subClassOf, c))
+
+    path = RDFS.subClassOf * ZeroOrMore  # type: ignore[operator]
+    results = {(s, o) for s, p, o in g.triples((a, path, None))}
+    # ZeroOrMore includes the start node itself and transitive closure
+    assert (a, a) in results
+    assert (a, b) in results
+    assert (a, c) in results
+
+
+# --- Test 3: Store-level dispatch ---
+
+
+class PathAwareStore(Memory):
+    """A mock store that implements eval_path with known results."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.eval_path_called = False
+        self.eval_path_args = None
+
+    def eval_path(
+        self,
+        path: Path,
+        subj: Optional[_SubjectType] = None,
+        obj: Optional[_ObjectType] = None,
+        context: Optional[_ContextType] = None,
+    ) -> Iterator[Tuple[_SubjectType, _ObjectType]]:
+        self.eval_path_called = True
+        self.eval_path_args = (path, subj, obj)
+        # Return a known result to verify dispatch
+        yield (
+            URIRef("http://example.org/store_subj"),
+            URIRef("http://example.org/store_obj"),
+        )
+
+
+def test_store_dispatch_eval_path() -> None:
+    """When the store implements eval_path, Graph.triples() uses it
+    instead of Path.eval()."""
+    store = PathAwareStore()
+    g = Graph(store=store)
+
+    path = RDF.type / RDFS.subClassOf
+    results = list(g.triples((None, path, None)))
+
+    assert store.eval_path_called
+    assert len(results) == 1
+    s, p, o = results[0]
+    assert s == URIRef("http://example.org/store_subj")
+    assert p == path
+    assert o == URIRef("http://example.org/store_obj")
+
+
+def test_store_dispatch_passes_correct_args() -> None:
+    """eval_path receives the correct path, subject, and object."""
+    store = PathAwareStore()
+    g = Graph(store=store)
+
+    subj = URIRef("http://example.org/s")
+    obj = URIRef("http://example.org/o")
+    path = RDF.type / RDFS.subClassOf
+
+    list(g.triples((subj, path, obj)))
+
+    assert store.eval_path_args == (path, subj, obj)
+
+
+# --- Test 4: Partial support (NotImplementedError for specific path types) ---
+
+
+class PartialPathStore(Memory):
+    """A store that only supports SequencePath, raises NotImplementedError
+    for other path types."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.eval_path_called = False
+
+    def eval_path(
+        self,
+        path: Path,
+        subj: Optional[_SubjectType] = None,
+        obj: Optional[_ObjectType] = None,
+        context: Optional[_ContextType] = None,
+    ) -> Iterator[Tuple[_SubjectType, _ObjectType]]:
+        if not isinstance(path, SequencePath):
+            raise NotImplementedError(f"Path type {type(path).__name__} not supported")
+        self.eval_path_called = True
+        yield (URIRef("http://example.org/seq_s"), URIRef("http://example.org/seq_o"))
+
+
+def test_partial_support_supported_path() -> None:
+    """A store that supports SequencePath returns its own results."""
+    store = PartialPathStore()
+    g = Graph(store=store)
+
+    path = RDF.type / RDFS.subClassOf
+    results = list(g.triples((None, path, None)))
+
+    assert store.eval_path_called
+    assert len(results) == 1
+    assert results[0][0] == URIRef("http://example.org/seq_s")
+
+
+def test_partial_support_unsupported_path_falls_back() -> None:
+    """A store that doesn't support MulPath falls back to Path.eval()."""
+    store = PartialPathStore()
+    g = Graph(store=store)
+
+    a = URIRef("http://example.org/A")
+    b = URIRef("http://example.org/B")
+    c = URIRef("http://example.org/C")
+    g.add((a, RDFS.subClassOf, b))
+    g.add((b, RDFS.subClassOf, c))
+
+    path = RDFS.subClassOf * ZeroOrMore  # type: ignore[operator]
+    results = {(s, o) for s, p, o in g.triples((a, path, None))}
+
+    # Should have fallen back to Path.eval and gotten real results
+    assert not store.eval_path_called
+    assert (a, b) in results
+    assert (a, c) in results

--- a/test/test_store/test_store_sparqlstore.py
+++ b/test/test_store/test_store_sparqlstore.py
@@ -12,6 +12,7 @@ import pytest
 
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import FOAF, RDF, RDFS, XMLNS, XSD
+from rdflib.paths import ZeroOrMore
 from rdflib.plugins.stores.sparqlconnector import SPARQLConnector
 from test.utils import helper
 from test.utils.http import MethodName, MockHTTPResponse
@@ -525,3 +526,158 @@ class TestSPARQLMock:
 
         for _, uri in graph.namespaces():
             assert query.count(f"<{uri}>") == 1
+
+
+class TestSPARQLStoreEvalPath:
+    """Test that SPARQLStore.eval_path() sends a single SPARQL query
+    with the property path in the predicate position."""
+
+    httpmock: ServedBaseHTTPServerMock
+
+    def setup_method(self) -> None:
+        self.httpmock = ServedBaseHTTPServerMock()
+        self.graph = Graph(store="SPARQLStore")
+        self.graph.open(f"{self.httpmock.url}/sparql", create=True)
+
+    def teardown_method(self) -> None:
+        self.graph.close()
+        self.httpmock.stop()
+
+    def _sparql_xml_response(self, bindings: list) -> bytes:
+        """Build a SPARQL XML results response with the given bindings.
+
+        Each binding is a dict of variable name -> URI string.
+        """
+        rows = ""
+        for binding in bindings:
+            row_parts = ""
+            for var, uri in binding.items():
+                row_parts += f'<binding name="{var}"><uri>{uri}</uri></binding>'
+            rows += f"<result>{row_parts}</result>"
+
+        variables = ""
+        if bindings:
+            for var in bindings[0]:
+                variables += f'<variable name="{var}"/>'
+
+        return (
+            f'<sparql xmlns="http://www.w3.org/2005/sparql-results#">'
+            f"<head>{variables}</head>"
+            f"<results>{rows}</results>"
+            f"</sparql>"
+        ).encode()
+
+    def test_eval_path_sequence(self) -> None:
+        """eval_path with a SequencePath sends a single SPARQL query."""
+        response_body = self._sparql_xml_response(
+            [
+                {"s": "http://example.org/A", "o": "http://example.org/C"},
+            ]
+        )
+        self.httpmock.responses[MethodName.GET].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                response_body,
+                {"Content-Type": ["application/sparql-results+xml"]},
+            )
+        )
+
+        path = RDF.type / RDFS.subClassOf
+        results = list(self.graph.triples((None, path, None)))
+
+        assert len(results) == 1
+        s, p, o = results[0]
+        assert s == URIRef("http://example.org/A")
+        assert o == URIRef("http://example.org/C")
+
+        # Verify only ONE request was made (not decomposed into multiple)
+        assert self.httpmock.mocks[MethodName.GET].call_count == 1
+        req = self.httpmock.requests[MethodName.GET].pop(0)
+        query_str = req.path_query["query"][0]
+        # The query should contain the property path
+        assert "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>" in query_str
+        assert "<http://www.w3.org/2000/01/rdf-schema#subClassOf>" in query_str
+        assert "/" in query_str  # sequence path operator
+
+    def test_eval_path_with_bound_subject(self) -> None:
+        """eval_path with a bound subject sends the subject in the query."""
+        response_body = self._sparql_xml_response(
+            [
+                {"o": "http://example.org/C"},
+            ]
+        )
+        self.httpmock.responses[MethodName.GET].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                response_body,
+                {"Content-Type": ["application/sparql-results+xml"]},
+            )
+        )
+
+        subj = URIRef("http://example.org/A")
+        path = RDF.type / RDFS.subClassOf
+        results = list(self.graph.triples((subj, path, None)))
+
+        assert len(results) == 1
+        s, p, o = results[0]
+        assert s == URIRef("http://example.org/A")
+        assert o == URIRef("http://example.org/C")
+
+        # Verify query contains the bound subject
+        req = self.httpmock.requests[MethodName.GET].pop(0)
+        query_str = req.path_query["query"][0]
+        assert "<http://example.org/A>" in query_str
+
+    def test_eval_path_mulpath(self) -> None:
+        """eval_path with a MulPath (ZeroOrMore) sends * in the query."""
+        response_body = self._sparql_xml_response(
+            [
+                {"s": "http://example.org/A", "o": "http://example.org/B"},
+                {"s": "http://example.org/A", "o": "http://example.org/C"},
+            ]
+        )
+        self.httpmock.responses[MethodName.GET].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                response_body,
+                {"Content-Type": ["application/sparql-results+xml"]},
+            )
+        )
+
+        path = RDFS.subClassOf * ZeroOrMore  # type: ignore[operator]
+        results = list(self.graph.triples((None, path, None)))
+
+        assert len(results) == 2
+        # Only one HTTP request for the entire path
+        assert self.httpmock.mocks[MethodName.GET].call_count == 1
+        req = self.httpmock.requests[MethodName.GET].pop(0)
+        query_str = req.path_query["query"][0]
+        assert "*" in query_str
+
+    def test_eval_path_alternative(self) -> None:
+        """eval_path with an AlternativePath sends | in the query."""
+        response_body = self._sparql_xml_response(
+            [
+                {"s": "http://example.org/A", "o": "http://example.org/B"},
+            ]
+        )
+        self.httpmock.responses[MethodName.GET].append(
+            MockHTTPResponse(
+                200,
+                "OK",
+                response_body,
+                {"Content-Type": ["application/sparql-results+xml"]},
+            )
+        )
+
+        path = RDF.type | RDFS.subClassOf
+        results = list(self.graph.triples((None, path, None)))
+
+        assert len(results) == 1
+        assert self.httpmock.mocks[MethodName.GET].call_count == 1
+        req = self.httpmock.requests[MethodName.GET].pop(0)
+        query_str = req.path_query["query"][0]
+        assert "|" in query_str


### PR DESCRIPTION
<!--
Thank you for your contribution to this project. This project has no formal
funding or full-time maintainers, and relies entirely on independent
contributors to keep it alive and relevant.

This pull request template includes some guidelines intended to help
contributors, not to deter contributions. While we prefer that PRs follow our
guidelines, we will not reject PRs solely on the basis that they do not, though
we may take longer to process them as in most cases the remaining work will
have to be done by someone else.

If you have any questions regarding our guidelines, submit the PR as is
and ask.

More detailed guidelines for pull requests are provided in our [developers
guide](https://github.com/RDFLib/rdflib/blob/main/docs/developers.rst).

PRs that are smaller in size and scope will be reviewed and merged quicker, so
please consider if your PR could be split up into more than one independent part
before submitting it, no PR is too small. The maintainers of this project may
also split up larger PRs into smaller, more manageable PRs, if they deem it
necessary.

PRs should be reviewed and approved by at least two people other than the author
using GitHub's review system before being merged. This is less important for bug
fixes and changes that don't impact runtime behaviour, but more important for
changes that expand the RDFLib public API. Reviews are open to anyone, so please
consider reviewing other open pull requests, as this will also free up the
capacity required for your PR to be reviewed.
-->

## Summary

This adds a `Store.eval_path()` method that allows store implementations to natively evaluate RDFLib property paths, with a transparent fallback to the existing `Path.eval()` behavior for stores that don't implement it. This also adds a concrete implementation of this new method for the `SPARQLStore` as it's a fairly trivial change.

## Motivation

Property path evaluation currently happens entirely at the Graph level. When a user calls `graph.triples((subj, path, obj))`, the Graph detects the path predicate and delegates to `Path.eval()`, which recursively decomposes the path into individual triple pattern lookups. At each leaf step, it calls back into `graph.triples()` with a simple URI predicate, which finally hits `store.triples()`.

This means the store can never see the path as a whole. It only receives individual triple patterns one at a time. For stores that _could_ natively evaluate property paths, this is extremely inefficient. For example:

- **SPARQLStore**: Each `store.triples()` call during path evaluation becomes a separate HTTP request to the SPARQL endpoint, when a single SPARQL query with a property path expression would suffice.

- **oxrdflib and other RDF-native stores**: Each leaf-level call round-trips across some boundary (Python to Rust and back in this case), when the backing engine could evaluate the entire path in one operation.

## Design

This is a fairly simple feature:

- `Store.eval_path()` raises `NotImplementedError` by default (consistent with how `Store.query()` and `Store.update()` handle optional features).
- `Graph.triples()` and `ConjunctiveGraph.triples()` uses a path evaluation helper method that includes a try/except block and falls back to the current `Path.eval()` behavior if `NotImplementedError` is raised.
- Stores that support path evaluation can override the method. 
- Stores that only support _some_ path types can raise `NotImplementedError` for the unsupported ones, and the fallback handles it gracefully although with reduced performance (e.g. Ontop currently doesn't support variable length paths).
- Note that `ReadOnlyGraphAggregate` is left unchanged because it aggregates multiple graphs potentially backed by different stores, and paths may span graphs.

## SPARQLStore Implementation

The SPARQLStore implementation is trivial because `Path.n3()` already produces valid SPARQL property path syntax and the existing query-building approach simply calls the `n3()` method of whatever is provided in the predicate position. The existing query-building logic in `triples()` has been extracted into a helper that both `triples()` and `eval_path()` share. This helper accepts Path objects in the predicate position, whereas the `triples()` method does not.

## Backwards Compatibility

This change is fully backwards compatible:

- Existing stores that don't implement `eval_path` are unaffected as the `NotImplementedError` fallback preserves current behavior exactly.
- Existing code using paths continues to work identically.
- No new dependencies or breaking API changes.
- Store implementers can opt in to path evaluation at their own pace.

<!--
Briefly explain what changes the pull request is making and why. Ideally, this
should cover all changes in the pull request, as the changes will be reviewed
against this summary to ensure that the PR does not include unintended changes.

Please also explicitly state if the PR makes any changes that are not backwards
compatible.
-->

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [x] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [x] Added or updated tests that fail without the change.
  - [x] Updated relevant documentation to avoid inaccuracies.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.

