### PR TITLE
fix failing workflow - bump go-task/setup-task version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -72,7 +72,9 @@ jobs:
           distribution: "temurin"
           java-version: "17"
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v3
+          with:
+            version: 3.x
       - name: Run preparation
         if: ${{ matrix.PREPARATION }}
         shell: bash
@@ -139,7 +141,9 @@ jobs:
         run: |
           pip install -r devtools/requirements-poetry.in
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v3
+          with:
+            version: 3.x
       - name: Run task
         shell: bash
         run: |


### PR DESCRIPTION
bump go-task/setup-task version from (failing) v1 to latest default of v3.x, as advised on [go-task/setup-task repos README](https://github.com/go-task/setup-task)

- [✅] Checked that there aren't other open pull requests for  the same change.
- [❌] Checked that all tests and type checking passes.
- [✅] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
