### PR TITLE
Apply a constant FILTER whose value is Python-falsy (e.g. FILTER(false))

### DIFF
--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -383,10 +383,6 @@ def translateGroupGraphPattern(graphPattern: CompValue) -> CompValue:
                 "Unknown part in GroupGraphPattern: %s - %s" % (type(p), p.name)
             )
 
-    # ``filters`` is None when there were no FILTERs, otherwise it is the
-    # (possibly constant) filter expression. Test for presence explicitly: a
-    # constant expression whose value is Python-falsy (e.g. ``FILTER(false)``)
-    # must still produce a Filter node rather than being silently dropped.
     if filters is not None:
         G = Filter(expr=filters, p=G)
 

--- a/rdflib/plugins/sparql/algebra.py
+++ b/rdflib/plugins/sparql/algebra.py
@@ -383,7 +383,11 @@ def translateGroupGraphPattern(graphPattern: CompValue) -> CompValue:
                 "Unknown part in GroupGraphPattern: %s - %s" % (type(p), p.name)
             )
 
-    if filters:
+    # ``filters`` is None when there were no FILTERs, otherwise it is the
+    # (possibly constant) filter expression. Test for presence explicitly: a
+    # constant expression whose value is Python-falsy (e.g. ``FILTER(false)``)
+    # must still produce a Filter node rather than being silently dropped.
+    if filters is not None:
         G = Filter(expr=filters, p=G)
 
     # Mark this graph pattern as translated

--- a/test/test_sparql/test_nested_filters.py
+++ b/test/test_sparql/test_nested_filters.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import logging
 from typing import Set, Tuple
 
+import pytest
+
 from rdflib import Graph, URIRef
 from rdflib.query import ResultRow
 
@@ -346,3 +348,43 @@ WHERE {
         computed.add((result[0], result[1], result[2]))
 
     assert expected == computed
+
+
+@pytest.mark.parametrize(
+    ("filter_expr", "expected"),
+    [
+        # A FILTER with a constant, Python-falsy effective boolean value must
+        # eliminate every solution (SPARQL 1.1 section 17.2), so the ASK is
+        # false. These were silently dropped from the algebra before the fix.
+        ("false", False),
+        ("0", False),
+        ("0.0", False),
+        ('""', False),
+        # Truthy constants keep the (single, empty) solution.
+        ("true", True),
+        ("1", True),
+        # Non-constant expressions were already handled and must stay correct.
+        ("1 = 2", False),
+        ("1 = 1", True),
+    ],
+)
+def test_constant_filter_ask(filter_expr: str, expected: bool) -> None:
+    # Regression test for https://github.com/RDFLib/rdflib/issues/3381
+    query = "ASK WHERE { FILTER(%s) }" % filter_expr
+    assert Graph().query(query).askAnswer is expected
+
+
+@pytest.mark.parametrize(
+    ("filter_expr", "expected_rows"),
+    [
+        ("false", 0),
+        ('""', 0),
+        ("1 = 2", 0),
+        ("true", 1),
+        ("1", 1),
+    ],
+)
+def test_constant_filter_select_rowcount(filter_expr: str, expected_rows: int) -> None:
+    # A dropped constant FILTER also leaks rows into SELECT results.
+    query = "SELECT ?s WHERE { BIND(1 AS ?s) FILTER(%s) }" % filter_expr
+    assert len(list(Graph().query(query))) == expected_rows


### PR DESCRIPTION
Fixes #3381.

### The bug

A `FILTER` whose expression is a single constant with a false effective boolean value — but which is *also* Python-falsy — is silently discarded, so the filter never applies:

```python
from rdflib import Graph
Graph().query("ASK WHERE { FILTER(false) }").askAnswer   # -> True   (should be False)
```

Affected: `FILTER(false)`, `FILTER(0)`, `FILTER(0.0)`, `FILTER("")`. It also corrupts `SELECT` — `SELECT ?s WHERE { BIND(1 AS ?s) FILTER(false) }` returns one row instead of zero. By contrast `FILTER(1 = 2)` (a non-constant expression) and two stacked `FILTER(false) FILTER(false)` already behave correctly, which is what makes the single-constant case stand out.

Per SPARQL 1.1 §17.2, the effective boolean value of `"false"^^xsd:boolean` is `false`, so the FILTER eliminates every solution and the ASK must be `False`.

### Root cause

In `translateGroupGraphPattern` (`rdflib/plugins/sparql/algebra.py`):

```python
filters = collectAndRemoveFilters(graphPattern.part)
...
if filters:                       # truthiness of an Expr, not presence
    G = Filter(expr=filters, p=G)
```

`collectAndRemoveFilters` returns `None` only when there are no filters; otherwise it returns `and_(*filters)`, which for a *single* filter returns the bare expression object. When that lone expression is a constant `Literal` that is Python-falsy (`bool(Literal(False)) is False`, `bool(Literal(0)) is False`, `bool(Literal("")) is False`), `if filters:` is `False`, so the `Filter` node is never built and the constraint disappears from the algebra. (Multiple filters produce an `And`, which is always truthy — hence only the single-constant case was affected.)

### The fix

The value is `Optional[Expr]`, so test for presence rather than truthiness:

```python
if filters is not None:
    G = Filter(expr=filters, p=G)
```

### Tests

`test_constant_filter_ask` parametrizes ASK over the Python-falsy constants (`false`, `0`, `0.0`, `""` → must be `False`), the truthy constants (`true`, `1` → `True`), and the non-constant expressions that already worked (`1 = 2` → `False`, `1 = 1` → `True`). `test_constant_filter_select_rowcount` asserts the corresponding SELECT row counts. The Python-falsy cases fail on `main` (ASK `True`, SELECT leaks a row) and pass with the fix.

`test/test_sparql/` stays green (442 passed; the one pre-existing `xpassed` is unrelated, confirmed present without this change), and the W3C compliance suites (`test_sparql10_w3c.py`, `test_sparql11_w3c.py`) pass (863 passed). `ruff check` and `black` clean.
