### PR TITLE
fix: pass flags to re.sub in SPARQL REPLACE

### DIFF
--- a/rdflib/plugins/sparql/operators.py
+++ b/rdflib/plugins/sparql/operators.py
@@ -254,7 +254,7 @@ def Builtin_REPLACE(expr: Expr, ctx) -> Literal:
         # @@FIXME@@ either datatype OR lang, NOT both
 
     return Literal(
-        re.sub(str(pattern), replacement, text, cFlag),
+        re.sub(str(pattern), replacement, text, flags=cFlag),
         datatype=text.datatype,
         lang=text.language,
     )

--- a/test/test_sparql/test_functions.py
+++ b/test/test_sparql/test_functions.py
@@ -91,6 +91,8 @@ EG = Namespace("https://example.com/")
         (r'regex("Alice", "^ali", "i")', Literal(True)),
         (r'regex("Bob", "^ali", "i")', Literal(False)),
         (r'replace("abcd", "b", "Z")', Literal("aZcd")),
+        (r'replace("abab", "B", "Z", "i")', Literal("aZaZ")),
+        (r'replace("abab", "B.", "Z", "i")', Literal("aZb")),
         (r"abs(-1.5)", Literal("1.5", datatype=XSD.decimal)),
         (r"round(2.4999)", Literal("2", datatype=XSD.decimal)),
         (r"round(2.5)", Literal("3", datatype=XSD.decimal)),


### PR DESCRIPTION

# Summary of changes

Fixes #3511.

`Builtin_REPLACE` calculated the correct regular-expression flags but passed them as the fourth positional argument to `re.sub()`. Python interprets that argument as `count`, so flags were ignored and replacements could be silently capped.

The fix passes the value using `flags=cFlag` in operators.py.

Added regression tests covering the SPARQL 1.1 examples in test_functions.py based on the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#func-replace):

- `replace("abab", "B", "Z", "i")` → `aZaZ`
- `replace("abab", "B.", "Z", "i")` → `aZb`

This is backwards-compatible and does not change the public API. No documentation update is needed because this restores the behavior already specified by SPARQL 1.1.

# Checklist

- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- [x] Added regression tests that fail without the change.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to maintainers.
