### PR TITLE
Add RDF 1.2 TripleTerm core model

### DIFF
--- a/docs/rdf_terms.md
+++ b/docs/rdf_terms.md
@@ -1,13 +1,13 @@
 # RDF terms in rdflib
 
-Terms are the kinds of objects that can appear in a RDFLib's graph's triples. Those that are part of core RDF concepts are: `IRIs`, `Blank Node` and `Literal`, the latter consisting of a literal value and either a [datatype](https://www.w3.org/TR/xmlschema-2/#built-in-datatypes) or an [RFC 3066](https://tools.ietf.org/html/rfc3066) language tag.
+Terms are the kinds of objects that can appear in RDFLib graph triples. RDF 1.2 core terms are `IRIs`, `Blank Nodes`, `Literals`, and `Triple Terms`. A literal consists of a lexical value and either a [datatype](https://www.w3.org/TR/xmlschema-2/#built-in-datatypes) or an [RFC 3066](https://tools.ietf.org/html/rfc3066) language tag.
 
 !!! info "Origins"
     RDFLib's class for representing IRIs/URIs is called "URIRef" because, at the time it was implemented, that was what the then current RDF specification called URIs/IRIs. We preserve that class name but refer to the RDF object as "IRI".
 
 ## Class hierarchy
 
-All terms in RDFLib are subclasses of the [`Identifier`][rdflib.term.Identifier] class. A class diagram of the various terms is:
+All RDFLib terms are subclasses of [`Node`][rdflib.term.Node]. The established string-backed term classes are subclasses of [`Identifier`][rdflib.term.Identifier], while [`TripleTerm`][rdflib.term.TripleTerm] is a direct `Node` subclass. A class diagram of the string-backed terms is:
 
 ![Term Class Hierarchy](_static/term_class_hierarchy.svg)
 
@@ -17,7 +17,7 @@ The set of such Terms depends on whether or not the store is formula-aware. Stor
 
 ## Python Classes
 
-The three main RDF objects - *IRI*, *Blank Node* and *Literal* are represented in RDFLib by these three main Python classes:
+IRIs, blank nodes, literals, and triple terms are represented by RDFLib's `URIRef`, `BNode`, `Literal`, and `TripleTerm` classes.
 
 ### URIRef
 
@@ -53,6 +53,22 @@ rdflib.term.BNode('AFwALAKU0')
 >>> bn.n3()  # doctest: +SKIP
 '_:AFwALAKU0'
 ```
+
+### Triple terms
+
+An RDF 1.2 triple term represents a proposition without asserting it. RDFLib's [`TripleTerm`][rdflib.term.TripleTerm] is immutable and may be used in the object position of an asserted triple. Its subject is an IRI or blank node, its predicate is an IRI, and its object may be an IRI, blank node, literal, or nested triple term.
+
+```python
+>>> from rdflib import Graph, Namespace, RDF, TripleTerm
+>>> EX = Namespace("http://example.org/")
+>>> term = TripleTerm(EX.alice, EX.knows, EX.bob)
+>>> graph = Graph()
+>>> _ = graph.add((EX.statement, RDF.reifies, term))
+>>> term.n3()
+'<<( <http://example.org/alice> <http://example.org/knows> <http://example.org/bob> )>>'
+```
+
+Triple terms may be objects of predicates other than `rdf:reifies`. RDF 1.1 serializers reject them; RDF 1.2 parser and serializer support is provided separately.
 
 ### Literals
 

--- a/rdflib/__init__.py
+++ b/rdflib/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "IdentifiedNode",
     "Literal",
     "Node",
+    "TripleTerm",
     "Variable",
     "Namespace",
     "Dataset",
@@ -200,7 +201,15 @@ from rdflib.namespace import (
     XSD,
     Namespace,
 )
-from rdflib.term import BNode, IdentifiedNode, Literal, Node, URIRef, Variable
+from rdflib.term import (
+    BNode,
+    IdentifiedNode,
+    Literal,
+    Node,
+    TripleTerm,
+    URIRef,
+    Variable,
+)
 
 from rdflib import plugin, query, util  # isort:skip
 from rdflib.container import *  # isort:skip # noqa: F403

--- a/rdflib/graph.py
+++ b/rdflib/graph.py
@@ -319,6 +319,7 @@ from rdflib.term import (
     Literal,
     Node,
     RDFLibGenid,
+    TripleTerm,
     URIRef,
 )
 
@@ -627,6 +628,7 @@ class Graph(Node):
         assert isinstance(s, Node), "Subject %s must be an rdflib term" % (s,)
         assert isinstance(p, Node), "Predicate %s must be an rdflib term" % (p,)
         assert isinstance(o, Node), "Object %s must be an rdflib term" % (o,)
+        _validate_triple_term_positions(s, p, o)
         self.__store.add((s, p, o), self, quoted=False)
         return self
 
@@ -2993,6 +2995,7 @@ class QuotedGraph(Graph):
         assert isinstance(s, Node), "Subject %s must be an rdflib term" % (s,)
         assert isinstance(p, Node), "Predicate %s must be an rdflib term" % (p,)
         assert isinstance(o, Node), "Object %s must be an rdflib term" % (o,)
+        _validate_triple_term_positions(s, p, o)
 
         self.store.add((s, p, o), self, quoted=True)
         return self
@@ -3309,6 +3312,13 @@ class ReadOnlyGraphAggregate(ConjunctiveGraph):
         raise UnSupportedAggregateOperation()
 
 
+def _validate_triple_term_positions(s: Node, p: Node, o: Node) -> None:
+    if isinstance(s, TripleTerm):
+        raise TypeError("TripleTerm cannot be used as an RDF subject")
+    if isinstance(p, TripleTerm):
+        raise TypeError("TripleTerm cannot be used as an RDF predicate")
+
+
 @overload
 def _assertnode(*terms: Node) -> te.Literal[True]: ...
 
@@ -3320,6 +3330,9 @@ def _assertnode(*terms: Any) -> bool: ...
 def _assertnode(*terms: Any) -> bool:
     for t in terms:
         assert isinstance(t, Node), "Term %s must be an rdflib term" % (t,)
+    if len(terms) == 3:
+        s, p, o = terms
+        _validate_triple_term_positions(s, p, o)
     return True
 
 

--- a/rdflib/namespace/_RDF.py
+++ b/rdflib/namespace/_RDF.py
@@ -27,6 +27,7 @@ class RDF(DefinedNamespace):
     language: URIRef  # The language component of a CompoundLiteral.
     object: URIRef  # The object of the subject RDF statement.
     predicate: URIRef  # The predicate of the subject RDF statement.
+    reifies: URIRef  # Relates a reifier to the triple term it reifies.
     rest: URIRef  # The rest of the subject RDF list after the first item.
     subject: URIRef  # The subject of the subject RDF statement.
     type: URIRef  # The subject is an instance of a class.

--- a/rdflib/namespace/_RDFS.py
+++ b/rdflib/namespace/_RDFS.py
@@ -30,6 +30,7 @@ class RDFS(DefinedNamespace):
     ContainerMembershipProperty: URIRef  # The class of container membership properties, rdf:_1, rdf:_2, ...,                     all of which are sub-properties of 'member'.
     Datatype: URIRef  # The class of RDF datatypes.
     Literal: URIRef  # The class of literal values, eg. textual strings and integers.
+    Proposition: URIRef  # The class of RDF propositions.
     Resource: URIRef  # The class resource, everything.
 
     _NS = Namespace("http://www.w3.org/2000/01/rdf-schema#")

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -11,7 +11,7 @@ from typing import IO, Any, Callable, List, Optional, Type, Union, cast
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset, Graph
 from rdflib.namespace import RDF, XSD
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, IdentifiedNode, Literal, URIRef
 
 try:
@@ -119,6 +119,7 @@ class HextuplesSerializer(Serializer):
                     stream.write(hl if _HAS_ORJSON else hl.encode())
 
     def _hex_line(self, triple, context_str: Union[bytes, str]):
+        _check_rdf1_1_triple(triple)
         if isinstance(
             triple[0], (URIRef, BNode)
         ):  # exclude QuotedGraph and other objects

--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -41,7 +41,7 @@ from typing import IO, Any, Dict, List, Optional
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Graph, _ObjectType
 from rdflib.namespace import RDF, XSD
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, URIRef
 
 from ..shared.jsonld.context import UNDEF, Context
@@ -225,8 +225,13 @@ class Converter:
 
     def from_graph(self, graph: Graph):
         nodemap: Dict[Any, Any] = {}
+        subjects = set()
 
-        for s in set(graph.subjects()):
+        for triple in graph:
+            _check_rdf1_1_triple(triple)
+            subjects.add(triple[0])
+
+        for s in subjects:
             ## only iri:s and unreferenced (rest will be promoted to top if needed)
             if isinstance(s, URIRef) or (
                 isinstance(s, BNode) and not any(graph.subjects(None, s))
@@ -253,6 +258,7 @@ class Converter:
         nodemap[node_id] = node
 
         for p, o in graph.predicate_objects(s):
+            _check_rdf1_1_triple((s, p, o))
             # type error: Argument 3 to "add_to_node" of "Converter" has incompatible type "Node"; expected "IdentifiedNode"
             # type error: Argument 4 to "add_to_node" of "Converter" has incompatible type "Node"; expected "Identifier"
             self.add_to_node(graph, s, p, o, node, nodemap)  # type: ignore[arg-type]

--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Graph
 from rdflib.plugins.serializers.nt import _quoteLiteral
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import Literal
 
 __all__ = ["NQuadsSerializer"]
@@ -47,6 +47,7 @@ class NQuadsSerializer(Serializer):
 
 
 def _nq_row(triple, context):
+    _check_rdf1_1_triple(triple)
     graph_name = context.n3() if context and context != DATASET_DEFAULT_GRAPH_ID else ""
     if isinstance(triple[2], Literal):
         return "%s %s %s %s .\n" % (

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -5,7 +5,7 @@ import warnings
 from typing import IO, TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from rdflib.graph import Graph
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import Literal
 
 if TYPE_CHECKING:
@@ -56,6 +56,7 @@ class NT11Serializer(NTSerializer):
 
 
 def _nt_row(triple: _TripleType) -> str:
+    _check_rdf1_1_triple(triple)
     if isinstance(triple[2], Literal):
         return "%s %s %s .\n" % (
             triple[0].n3(),

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -9,7 +9,7 @@ from rdflib.graph import Graph
 from rdflib.namespace import RDF, RDFS, Namespace  # , split_uri
 from rdflib.plugins.parsers.RDFVOC import RDFVOC
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_term
 from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, Node, URIRef
 from rdflib.util import first, more_than
 
@@ -30,6 +30,7 @@ class XMLSerializer(Serializer):
         bindings: Dict[str, URIRef] = {}
 
         for predicate in set(store.predicates()):
+            _check_rdf1_1_term(predicate)
             # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
             prefix, namespace, name = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
             bindings[prefix] = URIRef(namespace)
@@ -98,6 +99,7 @@ class XMLSerializer(Serializer):
         del self.__serialized
 
     def subject(self, subject: Identifier, depth: int = 1) -> None:
+        _check_rdf1_1_term(subject)
         if subject not in self.__serialized:
             self.__serialized[subject] = 1
 
@@ -127,6 +129,7 @@ class XMLSerializer(Serializer):
     def predicate(
         self, predicate: Identifier, object: Identifier, depth: int = 1
     ) -> None:
+        _check_rdf1_1_term(object)
         write = self.write
         indent = "  " * depth
         qname = self.store.namespace_manager.qname_strict(predicate)
@@ -201,6 +204,7 @@ class PrettyXMLSerializer(Serializer):
         )
 
         for predicate in possible:
+            _check_rdf1_1_term(predicate)
             # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
             prefix, namespace, local = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
             namespaces[prefix] = namespace
@@ -249,6 +253,7 @@ class PrettyXMLSerializer(Serializer):
         self.__serialized = None  # type: ignore[assignment]
 
     def subject(self, subject: Identifier, depth: int = 1):
+        _check_rdf1_1_term(subject)
         store = self.store
         writer = self.writer
 
@@ -307,6 +312,7 @@ class PrettyXMLSerializer(Serializer):
     def predicate(
         self, predicate: Identifier, object: Identifier, depth: int = 1
     ) -> None:
+        _check_rdf1_1_term(object)
         writer = self.writer
         store = self.store
         writer.push(predicate)

--- a/rdflib/plugins/serializers/trix.py
+++ b/rdflib/plugins/serializers/trix.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.namespace import Namespace
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["TriXSerializer"]
@@ -69,6 +69,7 @@ class TriXSerializer(Serializer):
         self.writer.pop()
 
     def _writeTriple(self, triple):  # noqa: N802
+        _check_rdf1_1_triple(triple)
         self.writer.push(TRIXNS["triple"])
         for component in triple:
             if isinstance(component, URIRef):

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -26,7 +26,7 @@ from typing import (
 from rdflib.exceptions import Error
 from rdflib.graph import Graph
 from rdflib.namespace import RDF, RDFS
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, Literal, Node, URIRef
 
 _StrT = TypeVar("_StrT", bound=str)
@@ -107,6 +107,7 @@ class RecursiveSerializer(Serializer):
             self.preprocessTriple(triple)
 
     def preprocessTriple(self, spo: _TripleType) -> None:
+        _check_rdf1_1_triple(spo)
         s, p, o = spo
         self._references[o] += 1
         self._subjects[s] = True

--- a/rdflib/serializer.py
+++ b/rdflib/serializer.py
@@ -13,9 +13,10 @@ under [`rdflib.plugins.serializers`][rdflib.plugins.serializers].
 
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Iterable, Optional, TypeVar, Union
 
-from rdflib.term import URIRef
+from rdflib.exceptions import Error
+from rdflib.term import Node, TripleTerm, URIRef
 
 if TYPE_CHECKING:
     from rdflib.graph import Graph
@@ -24,6 +25,16 @@ if TYPE_CHECKING:
 __all__ = ["Serializer"]
 
 _StrT = TypeVar("_StrT", bound=str)
+
+
+def _check_rdf1_1_term(term: Node) -> None:
+    if isinstance(term, TripleTerm):
+        raise Error("TripleTerm requires an RDF 1.2 serializer")
+
+
+def _check_rdf1_1_triple(triple: Iterable[Node]) -> None:
+    for term in triple:
+        _check_rdf1_1_term(term)
 
 
 class Serializer:

--- a/rdflib/store.py
+++ b/rdflib/store.py
@@ -178,7 +178,7 @@ class Store:
     def node_pickler(self) -> NodePickler:
         if self.__node_pickler is None:
             from rdflib.graph import Graph, QuotedGraph
-            from rdflib.term import BNode, Literal, URIRef, Variable
+            from rdflib.term import BNode, Literal, TripleTerm, URIRef, Variable
 
             self.__node_pickler = np = NodePickler()
             np.register(self, "S")
@@ -187,6 +187,7 @@ class Store:
             np.register(Literal, "L")
             np.register(Graph, "G")
             np.register(QuotedGraph, "Q")
+            np.register(TripleTerm, "T")
             np.register(Variable, "V")
         return self.__node_pickler
 

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -35,6 +35,7 @@ __all__ = [
     "URIRef",
     "BNode",
     "Literal",
+    "TripleTerm",
     "Variable",
 ]
 import logging
@@ -1140,7 +1141,7 @@ class Literal(Identifier):
         2. Incompatible datatypes are ordered by their datatype URIs
         3. Literals with language tags are ordered by their language tags
         4. Plain literals come before xsd:string literals
-        5. In the node order: None < BNode < URIRef < Literal
+        5. In the implementation node order: None < BNode < URIRef < Literal < TripleTerm
 
         Example:
             ```python
@@ -1236,7 +1237,7 @@ class Literal(Identifier):
             return False  # they are the same
 
         elif isinstance(other, Node):
-            return True  # Literal are the greatest!
+            return _ORDERING[type(self)] > _ORDERING[type(other)]
         else:
             return NotImplemented  # we can only compare to nodes
 
@@ -1249,7 +1250,7 @@ class Literal(Identifier):
             except TypeError:
                 return NotImplemented
         if isinstance(other, Node):
-            return False  # all nodes are less-than Literals
+            return _ORDERING[type(self)] < _ORDERING[type(other)]
 
         return NotImplemented
 
@@ -2334,6 +2335,147 @@ def bind(
         _GenericPythonToXSDRules.append((pythontype, (lexicalizer, datatype)))
 
 
+_TripleTermSubject = Union[URIRef, BNode]
+_TripleTermObject = Union[URIRef, BNode, Literal, "TripleTerm"]
+
+
+class TripleTerm(Node):
+    """An immutable RDF 1.2 triple term.
+
+    A triple term represents a proposition without asserting it. Its subject
+    must be an IRI or blank node, its predicate must be an IRI, and its object
+    may be an IRI, blank node, literal, or another triple term.
+
+    Triple terms can be used only in the object position of asserted RDF
+    triples.
+
+    Example:
+        ```python
+        >>> from rdflib import Literal, Namespace, TripleTerm
+        >>> EX = Namespace("http://example.org/")
+        >>> term = TripleTerm(EX.Alice, EX.name, Literal("Alice"))
+        >>> term.n3()
+        '<<( <http://example.org/Alice> <http://example.org/name> "Alice" )>>'
+
+        ```
+
+    See: https://www.w3.org/TR/rdf12-concepts/#section-triple-terms
+    """
+
+    __slots__ = ("_triple", "_hash")
+    _triple: Tuple[_TripleTermSubject, URIRef, _TripleTermObject]
+    _hash: int
+
+    def __init__(
+        self,
+        subject: _TripleTermSubject,
+        predicate: URIRef,
+        object: _TripleTermObject,
+    ) -> None:
+        if not isinstance(subject, (URIRef, BNode)):
+            raise TypeError(
+                "TripleTerm subject must be URIRef or BNode, "
+                f"got {type(subject).__name__}"
+            )
+        if not isinstance(predicate, URIRef):
+            raise TypeError(
+                f"TripleTerm predicate must be URIRef, got {type(predicate).__name__}"
+            )
+        if not isinstance(object, (URIRef, BNode, Literal, TripleTerm)):
+            raise TypeError(
+                "TripleTerm object must be URIRef, BNode, Literal, or TripleTerm, "
+                f"got {type(object).__name__}"
+            )
+
+        triple: Tuple[_TripleTermSubject, URIRef, _TripleTermObject] = (
+            subject,
+            predicate,
+            object,
+        )
+        super().__setattr__("_triple", triple)
+        super().__setattr__("_hash", hash(triple))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("TripleTerm is immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("TripleTerm is immutable")
+
+    @property
+    def subject(self) -> _TripleTermSubject:
+        """The IRI or blank-node subject of this triple term."""
+        return self._triple[0]
+
+    @property
+    def predicate(self) -> URIRef:
+        """The IRI predicate of this triple term."""
+        return self._triple[1]
+
+    @property
+    def object(self) -> _TripleTermObject:
+        """The object of this triple term."""
+        return self._triple[2]
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, TripleTerm):
+            return False
+        return self._triple == other._triple
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def __lt__(self, other: Any) -> bool:
+        if other is None:
+            return False
+        if isinstance(other, TripleTerm):
+            return _triple_term_ordering_key(self) < _triple_term_ordering_key(other)
+        if isinstance(other, Node):
+            return _ORDERING[type(self)] < _ORDERING[type(other)]
+        return NotImplemented
+
+    def __gt__(self, other: Any) -> bool:
+        if other is None:
+            return True
+        if isinstance(other, TripleTerm):
+            return _triple_term_ordering_key(self) > _triple_term_ordering_key(other)
+        if isinstance(other, Node):
+            return _ORDERING[type(self)] > _ORDERING[type(other)]
+        return NotImplemented
+
+    def __le__(self, other: Any) -> bool:
+        result = self.__lt__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        if result:
+            return True
+        return self == other
+
+    def __ge__(self, other: Any) -> bool:
+        result = self.__gt__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        if result:
+            return True
+        return self == other
+
+    def n3(self, namespace_manager: Optional[NamespaceManager] = None) -> str:
+        """Return the RDF 1.2 ``<<( subject predicate object )>>`` syntax."""
+        subject = self.subject.n3(namespace_manager=namespace_manager)
+        predicate = self.predicate.n3(namespace_manager=namespace_manager)
+        object = self.object.n3(namespace_manager=namespace_manager)
+        return f"<<( {subject} {predicate} {object} )>>"
+
+    def __reduce__(
+        self,
+    ) -> Tuple[Type[TripleTerm], Tuple[_TripleTermSubject, URIRef, _TripleTermObject]]:
+        return TripleTerm, self._triple
+
+    def __repr__(self) -> str:
+        return f"TripleTerm({self.subject!r}, {self.predicate!r}, {self.object!r})"
+
+
 class Variable(Identifier):
     """
     A Variable - this is used for querying, or in Formula aware
@@ -2367,12 +2509,39 @@ class Variable(Identifier):
         return (Variable, (str(self),))
 
 
-# Nodes are ordered like this
-# See http://www.w3.org/TR/sparql11-query/#modOrderBy
+# Python implementation ordering used by RDFLib's internal sorting.
+# Existing term ranks follow http://www.w3.org/TR/sparql11-query/#modOrderBy.
+# The TripleTerm rank is deterministic implementation behavior, not RDF or
+# SPARQL semantic ordering.
 # we leave "space" for more subclasses of Node elsewhere
 # default-dict to grazefully fail for new subclasses
 _ORDERING: Dict[Type[Node], int] = defaultdict(int)
-_ORDERING.update({BNode: 10, Variable: 20, URIRef: 30, Literal: 40})
+_ORDERING.update({BNode: 10, Variable: 20, URIRef: 30, Literal: 40, TripleTerm: 50})
+
+
+def _term_ordering_key(term: Node) -> Tuple[Any, ...]:
+    """Return a deterministic implementation-ordering key for an RDF term."""
+    term_type = type(term)
+    type_key = (term_type.__module__, term_type.__qualname__)
+
+    if isinstance(term, TripleTerm):
+        value: Any = _triple_term_ordering_key(term)
+    elif isinstance(term, Literal):
+        value = (
+            str(term),
+            (term.language or "").lower(),
+            term.datatype is not None,
+            str(term.datatype) if term.datatype is not None else "",
+        )
+    else:
+        value = str(term)
+
+    return (_ORDERING[term_type], type_key, value)
+
+
+def _triple_term_ordering_key(term: TripleTerm) -> Tuple[Tuple[Any, ...], ...]:
+    """Return the recursive implementation-ordering key for a triple term."""
+    return tuple(_term_ordering_key(component) for component in term._triple)
 
 
 def _isEqualXMLNode(  # noqa: N802

--- a/test/test_graph/test_graph_triple_term.py
+++ b/test/test_graph/test_graph_triple_term.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import pytest
+
+from rdflib import RDF, BNode, Dataset, Graph, Namespace, TripleTerm
+from rdflib.graph import QuotedGraph
+
+EX = Namespace("http://example.org/")
+
+
+def test_memory_store_add_query_contains_and_remove() -> None:
+    graph = Graph()
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+    triple = (EX.reifier, RDF.reifies, term)
+
+    graph.add(triple)
+
+    assert triple in graph
+    assert list(graph.triples((EX.reifier, RDF.reifies, term))) == [triple]
+    assert list(graph.triples((None, RDF.reifies, term))) == [triple]
+    assert list(graph.triples((EX.reifier, None, None))) == [triple]
+
+    graph.remove(triple)
+
+    assert triple not in graph
+    assert len(graph) == 0
+
+
+def test_arbitrary_predicate_is_allowed() -> None:
+    graph = Graph()
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+    triple = (EX.resource, EX.references_proposition, term)
+
+    graph.add(triple)
+
+    assert triple in graph
+
+
+def test_equal_triple_terms_are_the_same_store_key() -> None:
+    graph = Graph()
+    first = TripleTerm(EX.subject, EX.predicate, EX.object)
+    second = TripleTerm(EX.subject, EX.predicate, EX.object)
+
+    graph.add((EX.resource, EX.predicate, first))
+    graph.add((EX.resource, EX.predicate, second))
+
+    assert len(graph) == 1
+    assert (EX.resource, EX.predicate, second) in graph
+
+
+def test_nested_triple_term_with_bnodes() -> None:
+    graph = Graph()
+    inner = TripleTerm(BNode("subject"), EX.inner_predicate, BNode("object"))
+    outer = TripleTerm(EX.outer_subject, EX.outer_predicate, inner)
+    triple = (EX.resource, EX.references_proposition, outer)
+
+    graph.add(triple)
+
+    assert list(graph.objects(EX.resource, EX.references_proposition)) == [outer]
+    assert list(graph.triples((None, None, outer))) == [triple]
+
+
+@pytest.mark.parametrize("position", ["subject", "predicate"])
+def test_graph_add_rejects_invalid_position(position: str) -> None:
+    graph = Graph()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    triple = (
+        (term, EX.predicate, EX.object)
+        if position == "subject"
+        else (EX.subject, term, EX.object)
+    )
+
+    with pytest.raises(
+        TypeError, match=f"TripleTerm cannot be used as an RDF {position}"
+    ):
+        graph.add(triple)
+
+    assert len(graph) == 0
+
+
+def test_triple_term_subject_pattern_returns_no_results() -> None:
+    graph = Graph()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    graph.add((EX.subject, EX.predicate, term))
+
+    assert list(graph.triples((term, None, None))) == []
+
+
+def test_graph_addn_accepts_object() -> None:
+    graph = Graph()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    triple = (EX.subject, EX.predicate, term)
+
+    graph.addN([(*triple, graph)])
+
+    assert triple in graph
+
+
+@pytest.mark.parametrize("position", ["subject", "predicate"])
+def test_graph_addn_rejects_invalid_position(position: str) -> None:
+    graph = Graph()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    triple = (
+        (term, EX.predicate, EX.object)
+        if position == "subject"
+        else (EX.subject, term, EX.object)
+    )
+
+    with pytest.raises(
+        TypeError, match=f"TripleTerm cannot be used as an RDF {position}"
+    ):
+        graph.addN([(*triple, graph)])
+
+    assert len(graph) == 0
+
+
+def test_dataset_add_and_addn() -> None:
+    dataset = Dataset()
+    direct = TripleTerm(EX.subject, EX.predicate, EX.object)
+    nested = TripleTerm(EX.outer_subject, EX.outer_predicate, direct)
+
+    dataset.add((EX.first, EX.references_proposition, direct))
+    dataset.addN(
+        [
+            (
+                EX.second,
+                EX.references_proposition,
+                nested,
+                dataset.default_graph,
+            )
+        ]
+    )
+
+    assert (EX.first, EX.references_proposition, direct) in dataset.default_graph
+    assert (EX.second, EX.references_proposition, nested) in dataset.default_graph
+
+
+@pytest.mark.parametrize("method", ["add", "addN"])
+@pytest.mark.parametrize("position", ["subject", "predicate"])
+def test_dataset_rejects_invalid_position(method: str, position: str) -> None:
+    dataset = Dataset()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    triple = (
+        (term, EX.predicate, EX.object)
+        if position == "subject"
+        else (EX.subject, term, EX.object)
+    )
+
+    with pytest.raises(
+        TypeError, match=f"TripleTerm cannot be used as an RDF {position}"
+    ):
+        if method == "add":
+            dataset.add(triple)
+        else:
+            dataset.addN([(*triple, dataset.default_graph)])
+
+    assert len(dataset) == 0
+
+
+def test_quoted_graph_accepts_triple_term_as_object() -> None:
+    store = Graph().store
+    graph = QuotedGraph(store, BNode("formula"))
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+
+    graph.add((EX.subject, EX.predicate, term))
+
+    assert (EX.subject, EX.predicate, term) in graph
+
+
+@pytest.mark.parametrize("position", ["subject", "predicate"])
+def test_quoted_graph_rejects_invalid_position(position: str) -> None:
+    store = Graph().store
+    graph = QuotedGraph(store, BNode("formula"))
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    triple = (
+        (term, EX.predicate, EX.object)
+        if position == "subject"
+        else (EX.subject, term, EX.object)
+    )
+
+    with pytest.raises(
+        TypeError, match=f"TripleTerm cannot be used as an RDF {position}"
+    ):
+        graph.add(triple)
+
+    assert len(graph) == 0

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -134,6 +134,7 @@ def test_definednamespace_dir():
         RDF.language,
         RDF.object,
         RDF.predicate,
+        RDF.reifies,
         RDF.rest,
         RDF.subject,
         RDF.type,

--- a/test/test_namespace/test_definednamespace_dir.py
+++ b/test/test_namespace/test_definednamespace_dir.py
@@ -1,4 +1,4 @@
-from rdflib import RDF
+from rdflib import RDF, RDFS, URIRef
 
 
 def test_definednamespace_dir():
@@ -11,6 +11,7 @@ def test_definednamespace_dir():
         RDF.language,
         RDF.object,
         RDF.predicate,
+        RDF.reifies,
         RDF.rest,
         RDF.subject,
         RDF.type,
@@ -33,3 +34,11 @@ def test_definednamespace_dir():
 
     for value in values:
         assert value in x
+
+
+def test_rdf12_namespace_terms() -> None:
+    assert RDF.reifies == URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies")
+    assert RDFS.Proposition == URIRef(
+        "http://www.w3.org/2000/01/rdf-schema#Proposition"
+    )
+    assert RDFS.Proposition in dir(RDFS)

--- a/test/test_serializers/test_triple_term_safety.py
+++ b/test/test_serializers/test_triple_term_safety.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from rdflib import Dataset, Graph, Namespace, TripleTerm
+from rdflib.exceptions import Error
+
+EX = Namespace("http://example.org/")
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    [
+        "xml",
+        "pretty-xml",
+        "n3",
+        "turtle",
+        "longturtle",
+        "nt",
+        "nt11",
+        "json-ld",
+        "hext",
+    ],
+)
+def test_rdf11_graph_serializers_reject_triple_term(format_name: str) -> None:
+    graph = Graph()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    graph.add((EX.subject, EX.predicate, term))
+
+    with pytest.raises(Error, match="TripleTerm requires an RDF 1.2 serializer"):
+        graph.serialize(format=format_name)
+
+
+@pytest.mark.parametrize("format_name", ["nquads", "trix", "trig", "patch"])
+def test_rdf11_dataset_serializers_reject_triple_term(format_name: str) -> None:
+    dataset = Dataset()
+    term = TripleTerm(EX.embedded_subject, EX.embedded_predicate, EX.embedded_object)
+    dataset.add((EX.subject, EX.predicate, term, dataset.graph(EX.graph)))
+
+    with pytest.raises(Error, match="TripleTerm requires an RDF 1.2 serializer"):
+        dataset.serialize(format=format_name)

--- a/test/test_store/test_nodepickler.py
+++ b/test/test_store/test_nodepickler.py
@@ -1,7 +1,10 @@
 import pickle
 
+from rdflib import BNode, Graph, Namespace, TripleTerm
 from rdflib.store import NodePickler
 from rdflib.term import Literal
+
+EX = Namespace("http://example.org/")
 
 # same as nt/more_literals.nt
 cases = [
@@ -46,3 +49,18 @@ class TestUtil:
         np2 = pickle.loads(dump)
         assert np._ids == np2._ids
         assert np._objects == np2._objects
+
+    def test_store_node_pickler_triple_term_round_trip(self):
+        node_pickler = Graph().store.node_pickler
+        term = TripleTerm(
+            BNode("outer"),
+            EX.outer_predicate,
+            TripleTerm(EX.inner_subject, EX.inner_predicate, BNode("inner")),
+        )
+
+        restored = node_pickler.loads(node_pickler.dumps(term))
+
+        assert node_pickler._objects["T"] is TripleTerm
+        assert restored == term
+        assert isinstance(restored.object, TripleTerm)
+        assert restored.object.object == BNode("inner")

--- a/test/test_term/test_triple_term.py
+++ b/test/test_term/test_triple_term.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+import rdflib
+from rdflib import BNode, Graph, Literal, Namespace, TripleTerm, URIRef, Variable
+from rdflib.term import Node
+
+EX = Namespace("http://example.org/")
+
+
+def test_public_exports() -> None:
+    assert rdflib.TripleTerm is TripleTerm
+    assert "TripleTerm" in rdflib.__all__
+    assert "TripleTerm" in rdflib.term.__all__
+
+
+@pytest.mark.parametrize("subject", [EX.subject, BNode("subject")])
+@pytest.mark.parametrize(
+    "object_",
+    [
+        EX.object,
+        BNode("object"),
+        Literal("object"),
+        TripleTerm(EX.inner_subject, EX.inner_predicate, EX.inner_object),
+    ],
+)
+def test_construction_and_properties(subject: Node, object_: Node) -> None:
+    term = TripleTerm(subject, EX.predicate, object_)  # type: ignore[arg-type]
+
+    assert term.subject == subject
+    assert term.predicate == EX.predicate
+    assert term.object == object_
+    assert isinstance(term, Node)
+    assert not isinstance(term, str)
+    assert not isinstance(term, tuple)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("subject", EX.other),
+        ("predicate", EX.other),
+        ("object", EX.other),
+        ("_triple", (EX.other, EX.predicate, EX.object)),
+        ("_hash", 0),
+        ("extra", EX.other),
+    ],
+)
+def test_immutable(attribute: str, value: object) -> None:
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+
+    with pytest.raises(AttributeError, match="TripleTerm is immutable"):
+        setattr(term, attribute, value)
+
+
+def test_attributes_cannot_be_deleted() -> None:
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+
+    with pytest.raises(AttributeError, match="TripleTerm is immutable"):
+        del term._triple
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [Literal("subject"), Variable("subject"), "subject", 1],
+)
+def test_invalid_subject(subject: object) -> None:
+    with pytest.raises(
+        TypeError,
+        match=f"TripleTerm subject must be URIRef or BNode, got {type(subject).__name__}",
+    ):
+        TripleTerm(subject, EX.predicate, EX.object)  # type: ignore[arg-type]
+
+
+def test_triple_term_is_invalid_as_embedded_subject() -> None:
+    inner = TripleTerm(EX.subject, EX.predicate, EX.object)
+
+    with pytest.raises(TypeError, match="TripleTerm subject must be URIRef or BNode"):
+        TripleTerm(inner, EX.predicate, EX.object)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [BNode("predicate"), Literal("predicate"), Variable("predicate"), "predicate"],
+)
+def test_invalid_predicate(predicate: object) -> None:
+    with pytest.raises(
+        TypeError,
+        match=f"TripleTerm predicate must be URIRef, got {type(predicate).__name__}",
+    ):
+        TripleTerm(EX.subject, predicate, EX.object)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("object_", [Variable("object"), Graph(), "object", 1])
+def test_invalid_object(object_: object) -> None:
+    with pytest.raises(
+        TypeError,
+        match=f"TripleTerm object must be URIRef, BNode, Literal, or TripleTerm, got {type(object_).__name__}",
+    ):
+        TripleTerm(EX.subject, EX.predicate, object_)  # type: ignore[arg-type]
+
+
+def test_structural_equality_and_hashing() -> None:
+    first = TripleTerm(EX.subject, EX.predicate, Literal("object", lang="en"))
+    second = TripleTerm(EX.subject, EX.predicate, Literal("object", lang="EN"))
+    different = TripleTerm(EX.subject, EX.predicate, Literal("different"))
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert first != different
+    assert len({first, second, different}) == 2
+    assert first != (EX.subject, EX.predicate, Literal("object", lang="en"))
+
+
+def test_nested_structural_equality_and_hashing() -> None:
+    first = TripleTerm(
+        EX.outer_subject,
+        EX.outer_predicate,
+        TripleTerm(BNode("shared"), EX.inner_predicate, BNode("object")),
+    )
+    second = TripleTerm(
+        EX.outer_subject,
+        EX.outer_predicate,
+        TripleTerm(BNode("shared"), EX.inner_predicate, BNode("object")),
+    )
+
+    assert first == second
+    assert hash(first) == hash(second)
+
+
+def test_deterministic_recursive_ordering() -> None:
+    nested = TripleTerm(EX.inner_subject, EX.inner_predicate, EX.inner_object)
+    terms = [
+        TripleTerm(EX.b, EX.p, EX.o),
+        TripleTerm(EX.a, EX.q, EX.o),
+        TripleTerm(EX.a, EX.p, nested),
+        TripleTerm(BNode("subject"), EX.p, EX.o),
+        TripleTerm(EX.a, EX.p, Literal("object")),
+        TripleTerm(EX.a, EX.p, EX.o),
+    ]
+
+    assert sorted(terms) == [
+        terms[3],
+        terms[5],
+        terms[4],
+        terms[2],
+        terms[1],
+        terms[0],
+    ]
+
+
+def test_ordering_interoperates_with_existing_node_ranks() -> None:
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+    existing_nodes = [BNode("b"), Variable("v"), URIRef(EX.node), Literal("literal")]
+
+    for node in existing_nodes:
+        assert node < term
+        assert term > node
+        assert not node > term
+        assert not term < node
+
+    assert term > None
+    assert not term < None
+    assert sorted([term, *existing_nodes])[-1] == term  # type: ignore[type-var]
+
+
+def test_n3() -> None:
+    term = TripleTerm(EX.subject, EX.predicate, Literal("object", lang="en"))
+
+    assert term.n3() == (
+        '<<( <http://example.org/subject> <http://example.org/predicate> "object"@en )>>'
+    )
+
+
+def test_n3_propagates_namespace_manager_recursively() -> None:
+    graph = Graph()
+    graph.bind("ex", EX)
+    inner = TripleTerm(EX.inner_subject, EX.inner_predicate, EX.inner_object)
+    outer = TripleTerm(EX.outer_subject, EX.outer_predicate, inner)
+
+    assert outer.n3(graph.namespace_manager) == (
+        "<<( ex:outer_subject ex:outer_predicate "
+        "<<( ex:inner_subject ex:inner_predicate ex:inner_object )>> )>>"
+    )
+
+
+def test_repr_and_str() -> None:
+    term = TripleTerm(EX.subject, EX.predicate, EX.object)
+    expected = (
+        "TripleTerm(rdflib.term.URIRef('http://example.org/subject'), "
+        "rdflib.term.URIRef('http://example.org/predicate'), "
+        "rdflib.term.URIRef('http://example.org/object'))"
+    )
+
+    assert repr(term) == expected
+    assert str(term) == expected
+
+
+def test_pickle_round_trip_with_nested_term_and_bnodes() -> None:
+    term = TripleTerm(
+        BNode("outer"),
+        EX.outer_predicate,
+        TripleTerm(EX.inner_subject, EX.inner_predicate, BNode("inner")),
+    )
+
+    restored = pickle.loads(pickle.dumps(term, protocol=pickle.HIGHEST_PROTOCOL))
+
+    assert restored == term
+    assert hash(restored) == hash(term)
+    assert isinstance(restored.object, TripleTerm)
+    assert restored.object.object == BNode("inner")


### PR DESCRIPTION
Part of #3524

# Summary of changes

This is PR 1 from the RDF 1.2 tracking plan. It introduces the core data model for RDF 1.2 triple terms while preserving existing RDF 1.1 behavior.

- Add a truly immutable `TripleTerm(Node)` with strict position validation, nested triple-term support, structural equality and hashing, deterministic ordering, `n3()` rendering, repr, and pickle support.
- Export `TripleTerm` from `rdflib` and add `rdf:reifies` plus `rdfs:Proposition` to the generated namespace classes.
- Integrate triple terms with Graph placement checks, Store behavior, and NodePickler persistence.
- Make existing RDF 1.1 serializers reject triple terms with a clear error instead of silently emitting RDF 1.2 syntax or producing invalid output.
- Add focused tests and minimum public documentation.

No backwards-incompatible behavior is intended. Existing RDF 1.1 terms retain their construction, comparison, graph, store, parser, and serializer behavior.

## Scope boundary

This pull request deliberately does **not** add directional language-tagged strings, parser changes, RDF 1.2 serializer plugins, canonicalization or isomorphism changes, skolemization changes, `Graph.reify()`, CBD changes, `from_n3()` RDF 1.2 parsing, SPARQL changes, or other later work tracked in #3524.

The implementation was informed by the sound core ideas in #3447, but keeps the model immutable, adds `rdfs:Proposition`, centralizes RDF 1.1 serializer safety checks, and limits this PR to the first independently reviewable unit.

## Validation

- `uv run pytest test/test_term/test_triple_term.py test/test_graph/test_graph_triple_term.py test/test_serializers/test_triple_term_safety.py test/test_store/test_nodepickler.py test/test_namespace/test_definednamespace.py test/test_namespace/test_definednamespace_dir.py`
  - 214 passed
- Ruff on all changed Python files
  - all checks passed
- Black check on all changed Python files
  - 20 files unchanged
- mypy with `--follow-imports=silent` on all 14 changed source modules
  - no issues found

A repository-wide pytest run was also attempted. It reached 4,623 passed, 1,752 skipped, 118 expected failures, and 31 unexpected passes before being stopped during an external SSL wait; two unrelated setup errors in `test/test_misc/test_plugins.py` reported that the environment did not provide the `no_cover` fixture. The focused and broader related suites completed successfully.

# Checklist

- [x] Reviewed the overlapping work in #3447 and limited this PR to the independently reviewable core model described in #3524.
- [x] Relevant tests, formatting, linting, and scoped type checking pass.
- [x] Created #3524 to discuss the public API change and coordinate the staged implementation.
- [x] Considered adding an example in `./examples`; focused API documentation is more appropriate for this core-only change.
- [x] Added or updated tests that fail without the change.
- [x] Updated relevant documentation to avoid inaccuracies.
- [x] Considered adding additional documentation.
- [x] Enabled maintainers to update the PR branch.
