### PR TITLE
Add RDF 1.2 directional language-tagged strings

### DIFF
--- a/docs/rdf_terms.md
+++ b/docs/rdf_terms.md
@@ -71,6 +71,21 @@ name = Literal("Nicholas", lang="en")  # the name 'Nicholas', as an English stri
 imie = Literal("Mikołaj", lang="pl")  # the Polish version of the name 'Nicholas'
 ```
 
+RDF 1.2 also defines directional language-tagged strings. Pass `direction="ltr"`
+or `direction="rtl"` together with a non-empty language tag:
+
+```python
+greeting = Literal("hello", lang="en", direction="ltr")
+powitanie = Literal("مرحبا", lang="ar", direction="rtl")
+
+assert greeting.datatype == RDF.dirLangString
+assert greeting.n3() == '"hello"@en--ltr'
+```
+
+Direction is part of literal identity, comparison, and hashing. Existing RDF
+1.1 serializers reject directional literals rather than dropping this metadata;
+RDF 1.2 syntax plugin support is outside this core change.
+
 Special literal types indicated by use of a custom IRI for a literal's `datatype` value, for example the [GeoSPARQL RDF standard](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html#_geometry_serializations) invents a custom datatype, `geoJSONLiteral` to indicate [GeoJSON geometry serlializations](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html#_rdfs_datatype_geogeojsonliteral) like this:
 
 ```python

--- a/rdflib/namespace/_RDF.py
+++ b/rdflib/namespace/_RDF.py
@@ -46,6 +46,7 @@ class RDF(DefinedNamespace):
     JSON: URIRef  # The datatype of RDF literals storing JSON content.
     PlainLiteral: URIRef  # The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2
     XMLLiteral: URIRef  # The datatype of XML literal values.
+    dirLangString: URIRef  # The datatype of directional language-tagged string values.
     langString: URIRef  # The datatype of language-tagged string values
 
     _NS = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")

--- a/rdflib/plugins/serializers/hext.py
+++ b/rdflib/plugins/serializers/hext.py
@@ -11,7 +11,7 @@ from typing import IO, Any, Callable, List, Optional, Type, Union, cast
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Dataset, Graph
 from rdflib.namespace import RDF, XSD
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, IdentifiedNode, Literal, URIRef
 
 try:
@@ -119,6 +119,7 @@ class HextuplesSerializer(Serializer):
                     stream.write(hl if _HAS_ORJSON else hl.encode())
 
     def _hex_line(self, triple, context_str: Union[bytes, str]):
+        _check_rdf1_1_triple(triple)
         if isinstance(
             triple[0], (URIRef, BNode)
         ):  # exclude QuotedGraph and other objects

--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -41,7 +41,7 @@ from typing import IO, Any, Dict, List, Optional
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Graph, _ObjectType
 from rdflib.namespace import RDF, XSD
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, URIRef
 
 from ..shared.jsonld.context import UNDEF, Context
@@ -225,6 +225,9 @@ class Converter:
 
     def from_graph(self, graph: Graph):
         nodemap: Dict[Any, Any] = {}
+
+        for triple in graph:
+            _check_rdf1_1_triple(triple)
 
         for s in set(graph.subjects()):
             ## only iri:s and unreferenced (rest will be promoted to top if needed)

--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Graph
 from rdflib.plugins.serializers.nt import _quoteLiteral
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import Literal
 
 __all__ = ["NQuadsSerializer"]
@@ -47,6 +47,7 @@ class NQuadsSerializer(Serializer):
 
 
 def _nq_row(triple, context):
+    _check_rdf1_1_triple(triple)
     graph_name = context.n3() if context and context != DATASET_DEFAULT_GRAPH_ID else ""
     if isinstance(triple[2], Literal):
         return "%s %s %s %s .\n" % (

--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -5,7 +5,7 @@ import warnings
 from typing import IO, TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from rdflib.graph import Graph
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import Literal
 
 if TYPE_CHECKING:
@@ -56,6 +56,7 @@ class NT11Serializer(NTSerializer):
 
 
 def _nt_row(triple: _TripleType) -> str:
+    _check_rdf1_1_triple(triple)
     if isinstance(triple[2], Literal):
         return "%s %s %s .\n" % (
             triple[0].n3(),

--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -9,7 +9,7 @@ from rdflib.graph import Graph
 from rdflib.namespace import RDF, RDFS, Namespace  # , split_uri
 from rdflib.plugins.parsers.RDFVOC import RDFVOC
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_term
 from rdflib.term import BNode, IdentifiedNode, Identifier, Literal, Node, URIRef
 from rdflib.util import first, more_than
 
@@ -30,6 +30,7 @@ class XMLSerializer(Serializer):
         bindings: Dict[str, URIRef] = {}
 
         for predicate in set(store.predicates()):
+            _check_rdf1_1_term(predicate)
             # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
             prefix, namespace, name = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
             bindings[prefix] = URIRef(namespace)
@@ -98,6 +99,7 @@ class XMLSerializer(Serializer):
         del self.__serialized
 
     def subject(self, subject: Identifier, depth: int = 1) -> None:
+        _check_rdf1_1_term(subject)
         if subject not in self.__serialized:
             self.__serialized[subject] = 1
 
@@ -127,6 +129,7 @@ class XMLSerializer(Serializer):
     def predicate(
         self, predicate: Identifier, object: Identifier, depth: int = 1
     ) -> None:
+        _check_rdf1_1_term(object)
         write = self.write
         indent = "  " * depth
         qname = self.store.namespace_manager.qname_strict(predicate)
@@ -201,6 +204,7 @@ class PrettyXMLSerializer(Serializer):
         )
 
         for predicate in possible:
+            _check_rdf1_1_term(predicate)
             # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
             prefix, namespace, local = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
             namespaces[prefix] = namespace
@@ -249,6 +253,7 @@ class PrettyXMLSerializer(Serializer):
         self.__serialized = None  # type: ignore[assignment]
 
     def subject(self, subject: Identifier, depth: int = 1):
+        _check_rdf1_1_term(subject)
         store = self.store
         writer = self.writer
 
@@ -307,6 +312,7 @@ class PrettyXMLSerializer(Serializer):
     def predicate(
         self, predicate: Identifier, object: Identifier, depth: int = 1
     ) -> None:
+        _check_rdf1_1_term(object)
         writer = self.writer
         store = self.store
         writer.push(predicate)

--- a/rdflib/plugins/serializers/trix.py
+++ b/rdflib/plugins/serializers/trix.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 from rdflib.graph import ConjunctiveGraph, Graph
 from rdflib.namespace import Namespace
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, Literal, URIRef
 
 __all__ = ["TriXSerializer"]
@@ -69,6 +69,7 @@ class TriXSerializer(Serializer):
         self.writer.pop()
 
     def _writeTriple(self, triple):  # noqa: N802
+        _check_rdf1_1_triple(triple)
         self.writer.push(TRIXNS["triple"])
         for component in triple:
             if isinstance(component, URIRef):

--- a/rdflib/plugins/serializers/turtle.py
+++ b/rdflib/plugins/serializers/turtle.py
@@ -26,7 +26,7 @@ from typing import (
 from rdflib.exceptions import Error
 from rdflib.graph import Graph
 from rdflib.namespace import RDF, RDFS
-from rdflib.serializer import Serializer
+from rdflib.serializer import Serializer, _check_rdf1_1_triple
 from rdflib.term import BNode, Literal, Node, URIRef
 
 _StrT = TypeVar("_StrT", bound=str)
@@ -107,6 +107,7 @@ class RecursiveSerializer(Serializer):
             self.preprocessTriple(triple)
 
     def preprocessTriple(self, spo: _TripleType) -> None:
+        _check_rdf1_1_triple(spo)
         s, p, o = spo
         self._references[o] += 1
         self._subjects[s] = True

--- a/rdflib/serializer.py
+++ b/rdflib/serializer.py
@@ -13,9 +13,10 @@ under [`rdflib.plugins.serializers`][rdflib.plugins.serializers].
 
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Iterable, Optional, TypeVar, Union
 
-from rdflib.term import URIRef
+from rdflib.exceptions import Error
+from rdflib.term import Literal, Node, URIRef
 
 if TYPE_CHECKING:
     from rdflib.graph import Graph
@@ -24,6 +25,19 @@ if TYPE_CHECKING:
 __all__ = ["Serializer"]
 
 _StrT = TypeVar("_StrT", bound=str)
+
+
+def _check_rdf1_1_term(term: Node) -> None:
+    if isinstance(term, Literal) and term.direction is not None:
+        raise Error(
+            "Directional language-tagged Literal requires an RDF 1.2-capable "
+            "serializer"
+        )
+
+
+def _check_rdf1_1_triple(triple: Iterable[Node]) -> None:
+    for term in triple:
+        _check_rdf1_1_term(term)
 
 
 class Serializer:

--- a/rdflib/term.py
+++ b/rdflib/term.py
@@ -5,7 +5,8 @@ that are core to RDF:
 
 * [Blank Nodes][rdflib.term.BNode] - Blank Nodes
 * [URI References][rdflib.term.URIRef] - URI References
-* [Literals][rdflib.term.Literal] - Literals (which consist of a literal value, datatype and language tag)
+* [Literals][rdflib.term.Literal] - Literals (which consist of a literal value,
+  datatype, language tag, and optional base direction)
 
 Those that extend the RDF model into N3:
 
@@ -525,15 +526,16 @@ class BNode(IdentifiedNode):
 class Literal(Identifier):
     """
 
-    RDF 1.1's Literals Section: http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal
+    RDF 1.2 Literals Section: https://www.w3.org/TR/rdf12-concepts/#section-Graph-Literal
 
     Literals are used for values such as strings, numbers, and dates.
 
-    A literal in an RDF graph consists of two or three elements:
+    A literal in an RDF graph consists of two, three, or four elements:
 
     * a lexical form, being a Unicode string, which SHOULD be in Normal Form C
     * a datatype IRI, being an IRI identifying a datatype that determines how the lexical form maps to a literal value, and
     * if and only if the datatype IRI is `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`, a non-empty language tag. The language tag MUST be well-formed according to section 2.2.9 of `Tags for identifying languages <http://tools.ietf.org/html/bcp47>`_.
+    * if the datatype IRI is `http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString`, a base direction of `ltr` or `rtl`; this also requires a non-empty language tag.
 
     A literal is a language-tagged string if the third element is present. Lexical representations of language tags MAY be converted to lower case. The value space of language tags is always in lower case.
 
@@ -636,7 +638,8 @@ class Literal(Identifier):
     # NOTE: _datatype should maybe be of type URIRef, and not optional.
     _datatype: Optional[URIRef]
     _ill_typed: Optional[bool]
-    __slots__ = ("_language", "_datatype", "_value", "_ill_typed")
+    _direction: Optional[str]
+    __slots__ = ("_language", "_datatype", "_value", "_ill_typed", "_direction")
 
     def __new__(
         cls,
@@ -644,6 +647,7 @@ class Literal(Identifier):
         lang: Optional[str] = None,
         datatype: Optional[str] = None,
         normalize: Optional[bool] = None,
+        direction: Optional[str] = None,
     ):
         """Create a new Literal instance."""
         if lang == "":
@@ -651,14 +655,23 @@ class Literal(Identifier):
 
         normalize = normalize if normalize is not None else rdflib.NORMALIZE_LITERALS
 
+        if direction is not None and direction not in ("ltr", "rtl"):
+            raise ValueError("Literal direction must be 'ltr' or 'rtl'")
+
         if lang is not None and datatype is not None:
-            raise TypeError(
-                "A Literal can only have one of lang or datatype, "
-                "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
-            )
+            if not (
+                direction is not None and str(datatype) == str(_RDF_DIR_LANG_STRING)
+            ):
+                raise TypeError(
+                    "A Literal can only have one of lang or datatype, "
+                    "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
+                )
 
         if lang is not None and not _is_valid_langtag(lang):
             raise ValueError(f"'{str(lang)}' is not a valid language tag!")
+
+        if direction is not None and datatype is None:
+            datatype = _RDF_DIR_LANG_STRING
 
         if datatype is not None:
             datatype = URIRef(datatype)
@@ -669,6 +682,8 @@ class Literal(Identifier):
             # create from another Literal instance
 
             lang = lang or lexical_or_value.language
+            if direction is None:
+                direction = lexical_or_value.direction
             if datatype is not None:
                 # override datatype
                 value = _castLexicalToPython(lexical_or_value, datatype)
@@ -702,8 +717,22 @@ class Literal(Identifier):
             datatype = rdflib.util._coalesce(datatype, _datatype)
             if _value is not None:
                 lexical_or_value = _value
-            if datatype is not None:
+            if datatype is not None and datatype != _RDF_DIR_LANG_STRING:
                 lang = None
+
+        if direction is not None:
+            if not lang:
+                raise ValueError("Literal direction requires a non-empty language tag")
+            if datatype is not None and datatype != _RDF_DIR_LANG_STRING:
+                raise TypeError(
+                    "A directional language-tagged Literal must use "
+                    "rdf:dirLangString"
+                )
+            datatype = _RDF_DIR_LANG_STRING
+            value = None
+            ill_typed = None
+        elif datatype == _RDF_DIR_LANG_STRING:
+            raise TypeError("rdf:dirLangString requires a language tag and direction")
 
         if isinstance(lexical_or_value, bytes):
             lexical_or_value = lexical_or_value.decode("utf-8")
@@ -723,8 +752,22 @@ class Literal(Identifier):
         inst._datatype = datatype
         inst._value = value
         inst._ill_typed = ill_typed
+        inst._direction = direction
 
         return inst
+
+    def _new_with_metadata(self, lexical_or_value: Any) -> Literal:
+        if self.direction is not None:
+            return Literal(
+                lexical_or_value,
+                lang=self.language,
+                direction=self.direction,
+            )
+        return Literal(
+            lexical_or_value,
+            datatype=self.datatype,
+            lang=self.language,
+        )
 
     def normalize(self) -> Literal:
         """
@@ -748,7 +791,7 @@ class Literal(Identifier):
         """
 
         if self.value is not None:
-            return Literal(self.value, datatype=self.datatype, lang=self.language)
+            return self._new_with_metadata(self.value)
         else:
             return self
 
@@ -777,21 +820,45 @@ class Literal(Identifier):
     def datatype(self) -> Optional[URIRef]:
         return self._datatype
 
+    @property
+    def direction(self) -> Optional[str]:
+        """The base direction of this literal, if present."""
+        return self._direction
+
     def __reduce__(
         self,
-    ) -> Tuple[Type[Literal], Tuple[str, Union[str, None], Union[str, None]]]:
+    ) -> Tuple[Type[Literal], Tuple[Any, ...]]:
+        if self.direction is not None:
+            return (
+                Literal,
+                (
+                    str(self),
+                    self.language,
+                    self.datatype,
+                    None,
+                    self.direction,
+                ),
+            )
         return (
             Literal,
             (str(self), self.language, self.datatype),
         )
 
     def __getstate__(self) -> Tuple[None, Dict[str, Union[str, None]]]:
-        return (None, dict(language=self.language, datatype=self.datatype))
+        return (
+            None,
+            dict(
+                language=self.language,
+                datatype=self.datatype,
+                direction=self.direction,
+            ),
+        )
 
     def __setstate__(self, arg: Tuple[Any, Dict[str, Any]]) -> None:
         _, d = arg
         self._language = d["language"]
         self._datatype = d["datatype"]
+        self._direction = d.get("direction")
 
     def __add__(self, val: Any) -> Literal:
         """
@@ -823,6 +890,9 @@ class Literal(Identifier):
         # convert the val to a Literal, if it isn't already one
         if not isinstance(val, Literal):
             val = Literal(val)
+
+        if self.direction is not None:
+            return self._new_with_metadata(str.__add__(self, val))
 
         # if self is datetime based and value is duration
         if (
@@ -948,6 +1018,11 @@ class Literal(Identifier):
         # convert the val to a Literal, if it isn't already one
         if not isinstance(val, Literal):
             val = Literal(val)
+
+        if self.direction is not None or val.direction is not None:
+            raise TypeError(
+                "Directional language-tagged Literals do not support subtraction"
+            )
 
         if not getattr(self, "datatype"):
             raise TypeError(
@@ -1202,13 +1277,22 @@ class Literal(Identifier):
                 else:
                     return dtself > dtother
 
-            if self.language != other.language:
-                if not self.language:
+            language = self.language
+            other_language = other.language
+            if self.direction is not None or other.direction is not None:
+                language = language.lower() if language else None
+                other_language = other_language.lower() if other_language else None
+
+            if language != other_language:
+                if not language:
                     return False
-                elif not other.language:
+                elif not other_language:
                     return True
                 else:
-                    return self.language > other.language
+                    return language > other_language
+
+            if self.direction != other.direction:
+                return (self.direction or "") > (other.direction or "")
 
             if self.value is not None and other.value is not None:
                 if type(self.value) in _TOTAL_ORDER_CASTERS:
@@ -1283,6 +1367,12 @@ class Literal(Identifier):
     def _comparable_to(self, other: Any) -> bool:
         """Helper method to decide which things are meaningful to rich-compare with this literal."""
         if isinstance(other, Literal):
+            if self.direction is not None or other.direction is not None:
+                if self.direction != other.direction:
+                    return False
+                if (self.language or "").lower() != (other.language or "").lower():
+                    return False
+
             if self.datatype is not None and other.datatype is not None:
                 # two datatyped literals
                 if (
@@ -1347,6 +1437,8 @@ class Literal(Identifier):
             res ^= hash(self._language.lower())
         if self._datatype is not None:
             res ^= hash(self._datatype)
+        if self._direction is not None:
+            res ^= hash(self._direction)
         return res
 
     def __eq__(self, other: Any) -> bool:
@@ -1402,6 +1494,7 @@ class Literal(Identifier):
                 self._datatype == other._datatype
                 and (self._language.lower() if self._language else None)
                 == (other._language.lower() if other._language else None)
+                and self._direction == other._direction
                 and str.__eq__(self, other)
             )
 
@@ -1424,6 +1517,9 @@ class Literal(Identifier):
         Any other operations returns NotImplemented.
         """
         if isinstance(other, Literal):
+            if self.direction != other.direction:
+                return False
+
             # Fast path for comparing numeric literals
             # that are not ill-typed and don't have a None value
             if (
@@ -1452,6 +1548,9 @@ class Literal(Identifier):
 
             if dtself == _XSD_STRING and dtother == _XSD_STRING:
                 # string/plain literals, compare on lexical form
+                return str.__eq__(self, other)
+
+            if dtself == _RDF_DIR_LANG_STRING and dtother == _RDF_DIR_LANG_STRING:
                 return str.__eq__(self, other)
 
             # XML can be compared to HTML, only if html5rdf is enabled
@@ -1691,6 +1790,12 @@ class Literal(Identifier):
 
         encoded: str = self._quote_encode()
 
+        language = self.language
+        if language:
+            if self.direction:
+                return f"{encoded}@{language}--{self.direction}"
+            return f"{encoded}@{language}"
+
         datatype = self.datatype
         quoted_dt = None
         if datatype is not None:
@@ -1714,13 +1819,9 @@ class Literal(Identifier):
                     # still serialize. Warn user about it
                     warnings.warn(f"Serializing weird numerical {self!r}")
 
-        language = self.language
-        if language:
-            return f"{encoded}@{language}"
-        elif datatype:
+        if datatype:
             return f"{encoded}^^{quoted_dt}"
-        else:
-            return encoded
+        return encoded
 
     def _quote_encode(self) -> str:
         # This simpler encoding doesn't work; a newline gets encoded as "\\n",
@@ -1753,8 +1854,10 @@ class Literal(Identifier):
         args = [str.__repr__(self)]
         if self.language is not None:
             args.append("lang=" + repr(self.language))
-        if self.datatype is not None:
+        if self.datatype is not None and self.direction is None:
             args.append("datatype=" + repr(self.datatype))
+        if self.direction is not None:
+            args.append("direction=" + repr(self.direction))
         if self.__class__ == Literal:
             clsName = "rdflib.term.Literal"  # noqa: N806
         else:
@@ -1766,6 +1869,8 @@ class Literal(Identifier):
         Returns an appropriate python datatype derived from this RDF Literal
         """
 
+        if self.direction is not None:
+            return self
         if self.value is not None:
             return self.value
         return self
@@ -1968,6 +2073,7 @@ _RDF_PFX = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
 _RDF_XMLLITERAL = URIRef(_RDF_PFX + "XMLLiteral")
 _RDF_HTMLLITERAL = URIRef(_RDF_PFX + "HTML")
+_RDF_DIR_LANG_STRING = URIRef(_RDF_PFX + "dirLangString")
 
 _XSD_STRING = URIRef(_XSD_PFX + "string")
 _XSD_NORMALISED_STRING = URIRef(_XSD_PFX + "normalizedString")

--- a/test/test_literal/test_direction.py
+++ b/test/test_literal/test_direction.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import copy
+import pickle
+from typing import Any
+
+import pytest
+
+import rdflib
+from rdflib import RDF, XSD, Graph, Literal, Namespace, URIRef
+
+EX = Namespace("https://example.org/")
+
+
+@pytest.mark.parametrize(
+    ("lexical", "language", "direction"),
+    [
+        ("hello", "en", "ltr"),
+        ("مرحبا", "ar", "rtl"),
+    ],
+)
+def test_directional_literal_construction(
+    lexical: str, language: str, direction: str
+) -> None:
+    literal = Literal(lexical, lang=language, direction=direction)
+
+    assert str(literal) == lexical
+    assert literal.language == language
+    assert literal.direction == direction
+    assert literal.datatype == RDF.dirLangString
+    assert literal.value is None
+    assert literal.ill_typed is None
+
+
+def test_direction_is_appended_to_constructor_signature() -> None:
+    literal = Literal("hello", "en", None, None, "ltr")
+
+    assert literal.direction == "ltr"
+    assert literal.datatype == RDF.dirLangString
+
+
+def test_existing_positional_constructor_arguments_are_unchanged() -> None:
+    literal = Literal("01", None, XSD.integer, False)
+
+    assert str(literal) == "01"
+    assert literal.datatype == XSD.integer
+    assert literal.direction is None
+
+
+def test_direction_property_is_read_only() -> None:
+    literal = Literal("hello", lang="en", direction="ltr")
+
+    with pytest.raises(AttributeError):
+        literal.direction = "rtl"  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        del literal.direction
+
+
+@pytest.mark.parametrize("direction", ["", "LTR", "RTL", "auto", "ltr ", 1])
+def test_invalid_direction_is_rejected(direction: Any) -> None:
+    with pytest.raises(ValueError, match="must be 'ltr' or 'rtl'"):
+        Literal("hello", lang="en", direction=direction)
+
+
+@pytest.mark.parametrize("language", [None, ""])
+def test_direction_requires_non_empty_language(language: str | None) -> None:
+    with pytest.raises(ValueError, match="requires a non-empty language tag"):
+        Literal("hello", lang=language, direction="ltr")
+
+
+def test_direction_still_validates_language_tag() -> None:
+    with pytest.raises(ValueError, match="not a valid language tag"):
+        Literal("hello", lang="en--US", direction="ltr")
+
+
+def test_explicit_dir_lang_string_is_allowed_with_complete_metadata() -> None:
+    literal = Literal(
+        "hello",
+        lang="en",
+        datatype=RDF.dirLangString,
+        direction="ltr",
+    )
+
+    assert literal.datatype == RDF.dirLangString
+    assert literal.direction == "ltr"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"datatype": RDF.dirLangString},
+        {"lang": "en", "datatype": RDF.dirLangString},
+        {"datatype": RDF.dirLangString, "direction": "ltr"},
+    ],
+)
+def test_dir_lang_string_requires_language_and_direction(
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        Literal("hello", **kwargs)
+
+
+@pytest.mark.parametrize(
+    "datatype",
+    [RDF.langString, XSD.string, URIRef("https://example.org/datatype")],
+)
+def test_direction_rejects_conflicting_datatype(datatype: URIRef) -> None:
+    with pytest.raises(TypeError):
+        Literal("hello", lang="en", datatype=datatype, direction="ltr")
+
+
+def test_existing_language_and_datatype_restriction_is_unchanged() -> None:
+    with pytest.raises(TypeError, match="only have one of lang or datatype"):
+        Literal("hello", lang="en", datatype=RDF.langString)
+
+
+def test_ordinary_language_literal_is_unchanged() -> None:
+    literal = Literal("hello", lang="en")
+
+    assert literal.language == "en"
+    assert literal.direction is None
+    assert literal.datatype is None
+    assert literal.value == "hello"
+    assert literal.toPython() == "hello"
+    assert literal.n3() == '"hello"@en'
+    assert repr(literal) == "rdflib.term.Literal('hello', lang='en')"
+
+
+def test_term_equality_and_hash_include_direction() -> None:
+    ltr = Literal("hello", lang="en", direction="ltr")
+    same_ltr = Literal("hello", lang="EN", direction="ltr")
+    rtl = Literal("hello", lang="en", direction="rtl")
+    ordinary = Literal("hello", lang="en")
+
+    assert ltr == same_ltr
+    assert hash(ltr) == hash(same_ltr)
+    assert ltr != rtl
+    assert ltr != ordinary
+    assert len({ltr, same_ltr, rtl, ordinary}) == 3
+    assert {ltr: "ltr", rtl: "rtl"}[same_ltr] == "ltr"
+
+
+def test_value_equality_includes_direction() -> None:
+    ltr = Literal("hello", lang="en", direction="ltr")
+    same_ltr = Literal("hello", lang="EN", direction="ltr")
+    rtl = Literal("hello", lang="en", direction="rtl")
+    other_lexical = Literal("goodbye", lang="en", direction="ltr")
+
+    assert ltr.eq(same_ltr) is True
+    assert ltr.eq(rtl) is False
+    assert rtl.eq(ltr) is False
+    assert ltr.eq(other_lexical) is False
+
+
+def test_directional_comparability_includes_language_and_direction() -> None:
+    ltr = Literal("hello", lang="en", direction="ltr")
+
+    assert ltr._comparable_to(Literal("hello", lang="EN", direction="ltr"))
+    assert not ltr._comparable_to(Literal("hello", lang="en", direction="rtl"))
+    assert not ltr._comparable_to(Literal("hello", lang="fr", direction="ltr"))
+
+
+def test_ordering_uses_direction_after_case_insensitive_language() -> None:
+    ltr = Literal("hello", lang="EN", direction="ltr")
+    rtl = Literal("hello", lang="en", direction="rtl")
+
+    assert ltr < rtl
+    assert rtl > ltr
+    assert ltr <= rtl
+    assert rtl >= ltr
+    assert not rtl < ltr
+    assert not ltr > rtl
+    assert sorted([rtl, ltr]) == [ltr, rtl]
+
+
+def test_ordering_equal_directional_literals_is_non_contradictory() -> None:
+    lower_case = Literal("hello", lang="en", direction="ltr")
+    upper_case = Literal("hello", lang="EN", direction="ltr")
+
+    assert lower_case == upper_case
+    assert not lower_case < upper_case
+    assert not upper_case < lower_case
+    assert not lower_case > upper_case
+    assert not upper_case > lower_case
+    assert lower_case <= upper_case
+    assert lower_case >= upper_case
+
+
+def test_ordering_is_antisymmetric_for_directional_literals() -> None:
+    literals = [
+        Literal("a", lang="en", direction="ltr"),
+        Literal("a", lang="en", direction="rtl"),
+        Literal("b", lang="en", direction="ltr"),
+        Literal("a", lang="fr", direction="ltr"),
+    ]
+
+    for left in literals:
+        for right in literals:
+            if left == right:
+                continue
+            assert (left < right) != (right < left)
+            assert (left > right) != (right > left)
+
+
+def test_copy_construction_preserves_direction() -> None:
+    original = Literal("hello", lang="en", direction="ltr")
+    copied = Literal(original)
+
+    assert copied == original
+    assert copied is not original
+    assert copied.language == "en"
+    assert copied.direction == "ltr"
+    assert copied.datatype == RDF.dirLangString
+
+
+def test_copy_construction_can_add_or_replace_direction() -> None:
+    ordinary = Literal("hello", lang="en")
+    ltr = Literal(ordinary, direction="ltr")
+    rtl = Literal(ltr, direction="rtl")
+
+    assert ltr.direction == "ltr"
+    assert rtl.direction == "rtl"
+    assert rtl.language == "en"
+    assert rtl.datatype == RDF.dirLangString
+
+
+def test_copy_construction_rejects_directional_datatype_override() -> None:
+    original = Literal("hello", lang="en", direction="ltr")
+
+    with pytest.raises(TypeError, match="must use rdf:dirLangString"):
+        Literal(original, datatype=XSD.string)
+
+
+def test_shallow_and_deep_copy_preserve_direction() -> None:
+    original = Literal("مرحبا", lang="ar", direction="rtl")
+
+    for copied in (copy.copy(original), copy.deepcopy(original)):
+        assert copied == original
+        assert copied.direction == "rtl"
+        assert copied.datatype == RDF.dirLangString
+
+
+def test_normalize_preserves_direction() -> None:
+    original = Literal("hello", lang="en", direction="ltr", normalize=False)
+    normalized = original.normalize()
+    reconstructed = Literal(original, normalize=True)
+
+    assert normalized == original
+    assert normalized.direction == "ltr"
+    assert reconstructed == original
+    assert reconstructed.direction == "ltr"
+
+
+def test_addition_preserves_direction() -> None:
+    original = Literal("hello", lang="en", direction="ltr")
+    result = original + " world"
+
+    assert result == Literal("hello world", lang="en", direction="ltr")
+    assert result.direction == "ltr"
+    assert result.datatype == RDF.dirLangString
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_pickle_round_trip_preserves_direction(protocol: int) -> None:
+    original = Literal("مرحبا", lang="ar", direction="rtl")
+    restored = pickle.loads(pickle.dumps(original, protocol=protocol))
+
+    assert restored == original
+    assert restored.language == "ar"
+    assert restored.direction == "rtl"
+    assert restored.datatype == RDF.dirLangString
+
+
+def test_old_pickle_constructor_arguments_remain_readable() -> None:
+    restored = Literal("hello", "en", None)
+
+    assert restored == Literal("hello", lang="en")
+    assert restored.direction is None
+
+
+def test_old_pickle_state_without_direction_remains_readable() -> None:
+    restored = Literal("hello")
+    restored.__setstate__((None, {"language": "en", "datatype": None}))
+
+    assert restored.language == "en"
+    assert restored.datatype is None
+    assert restored.direction is None
+
+
+def test_pickle_state_contains_direction() -> None:
+    literal = Literal("hello", lang="en", direction="ltr")
+    _, state = literal.__getstate__()
+
+    assert state["direction"] == "ltr"
+
+
+def test_repr_round_trip_preserves_direction_without_redundant_datatype() -> None:
+    original = Literal("hello", lang="en", direction="ltr")
+    representation = repr(original)
+    restored = eval(representation, {"rdflib": rdflib})
+
+    assert representation == (
+        "rdflib.term.Literal('hello', lang='en', direction='ltr')"
+    )
+    assert "datatype=" not in representation
+    assert restored == original
+    assert restored.direction == "ltr"
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [
+        (Literal("hello", lang="en", direction="ltr"), '"hello"@en--ltr'),
+        (Literal("مرحبا", lang="ar", direction="rtl"), '"مرحبا"@ar--rtl'),
+        (
+            Literal('say "hello"', lang="en", direction="ltr"),
+            '"say \\"hello\\""@en--ltr',
+        ),
+    ],
+)
+def test_n3_renders_directional_syntax(literal: Literal, expected: str) -> None:
+    assert literal.n3() == expected
+    assert literal._literal_n3(use_plain=True) == expected
+
+
+def test_n3_preserves_language_tag_casing() -> None:
+    literal = Literal("hello", lang="EN-gb", direction="ltr")
+
+    assert literal.n3() == '"hello"@EN-gb--ltr'
+
+
+def test_n3_does_not_render_implied_datatype() -> None:
+    literal = Literal("hello", lang="en", direction="ltr")
+
+    def unexpected_datatype_qname(_: URIRef) -> str:
+        pytest.fail("directional syntax must not render a datatype QName")
+
+    assert literal._literal_n3(qname_callback=unexpected_datatype_qname) == (
+        '"hello"@en--ltr'
+    )
+
+
+def test_to_python_preserves_directional_metadata() -> None:
+    literal = Literal("hello", lang="en", direction="ltr")
+
+    assert literal.toPython() is literal
+
+
+def test_graph_keeps_directions_as_distinct_terms() -> None:
+    graph = Graph()
+    ltr = Literal("hello", lang="en", direction="ltr")
+    rtl = Literal("hello", lang="en", direction="rtl")
+
+    graph.add((EX.subject, EX.label, ltr))
+    graph.add((EX.subject, EX.label, rtl))
+
+    assert len(graph) == 2
+    assert set(graph.objects(EX.subject, EX.label)) == {ltr, rtl}
+    assert (EX.subject, EX.label, ltr) in graph
+    assert (EX.subject, EX.label, rtl) in graph
+
+    graph.remove((EX.subject, EX.label, ltr))
+
+    assert (EX.subject, EX.label, ltr) not in graph
+    assert (EX.subject, EX.label, rtl) in graph

--- a/test/test_namespace/test_definednamespace.py
+++ b/test/test_namespace/test_definednamespace.py
@@ -149,6 +149,7 @@ def test_definednamespace_dir():
         RDF.JSON,
         RDF.PlainLiteral,
         RDF.XMLLiteral,
+        RDF.dirLangString,
         RDF.langString,
     ]
 

--- a/test/test_namespace/test_definednamespace_dir.py
+++ b/test/test_namespace/test_definednamespace_dir.py
@@ -26,6 +26,7 @@ def test_definednamespace_dir():
         RDF.JSON,
         RDF.PlainLiteral,
         RDF.XMLLiteral,
+        RDF.dirLangString,
         RDF.langString,
     ]
 

--- a/test/test_serializers/test_directional_literal_safety.py
+++ b/test/test_serializers/test_directional_literal_safety.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from rdflib import Dataset, Graph, Literal, Namespace
+from rdflib.exceptions import Error
+
+EX = Namespace("https://example.org/")
+ERROR_PATTERN = (
+    "Directional language-tagged Literal requires an RDF 1.2-capable serializer"
+)
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    [
+        "xml",
+        "pretty-xml",
+        "n3",
+        "turtle",
+        "longturtle",
+        "nt",
+        "nt11",
+        "json-ld",
+        "hext",
+    ],
+)
+def test_rdf11_graph_serializers_reject_directional_literal(
+    format_name: str,
+) -> None:
+    graph = Graph()
+    graph.add(
+        (
+            EX.subject,
+            EX.label,
+            Literal("hello", lang="en", direction="ltr"),
+        )
+    )
+
+    with pytest.raises(Error, match=ERROR_PATTERN):
+        graph.serialize(format=format_name)
+
+
+@pytest.mark.parametrize("format_name", ["nquads", "trix", "trig", "patch"])
+def test_rdf11_dataset_serializers_reject_directional_literal(
+    format_name: str,
+) -> None:
+    dataset = Dataset()
+    dataset.add(
+        (
+            EX.subject,
+            EX.label,
+            Literal("مرحبا", lang="ar", direction="rtl"),
+            dataset.graph(EX.graph),
+        )
+    )
+
+    with pytest.raises(Error, match=ERROR_PATTERN):
+        dataset.serialize(format=format_name)
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    [
+        "xml",
+        "pretty-xml",
+        "n3",
+        "turtle",
+        "longturtle",
+        "nt",
+        "nt11",
+        "json-ld",
+        "hext",
+    ],
+)
+def test_rdf11_graph_serializers_still_accept_ordinary_language_literal(
+    format_name: str,
+) -> None:
+    graph = Graph()
+    graph.add((EX.subject, EX.label, Literal("hello", lang="en")))
+
+    result = graph.serialize(format=format_name)
+
+    assert result
+
+
+@pytest.mark.parametrize("format_name", ["nquads", "trix", "trig", "patch"])
+def test_rdf11_dataset_serializers_still_accept_ordinary_language_literal(
+    format_name: str,
+) -> None:
+    dataset = Dataset()
+    dataset.add(
+        (
+            EX.subject,
+            EX.label,
+            Literal("hello", lang="en"),
+            dataset.graph(EX.graph),
+        )
+    )
+
+    result = dataset.serialize(format=format_name)
+
+    assert result


### PR DESCRIPTION
# Summary of changes

Part of #3524.

This adds the RDF 1.2 directional language-tagged string core model:

- appends an optional `direction` parameter to `Literal`, accepting only `ltr` and `rtl` with a non-empty language tag;
- exposes read-only `Literal.direction` and adds `RDF.dirLangString`;
- includes direction in term equality, hashing, value comparison, comparability, and deterministic ordering;
- preserves direction through copying, normalization, concatenation, repr, and pickle round-trips;
- renders directional literals as `"text"@lang--direction` through `n3()` and `_literal_n3()`;
- makes existing RDF 1.1 serializers fail clearly instead of dropping direction or emitting RDF 1.2 syntax;
- documents the public API and adds focused regression coverage.

Existing non-directional `Literal` behavior remains unchanged. Existing RDF 1.1 parser and serializer identifiers retain their current syntax behavior. This change does not add parser grammar, RDF 1.2 syntax plugins, version directives, triple terms, canonicalization, graph helpers, CBD handling, or SPARQL changes.

## Verification

- `uv run python -m pytest test/test_literal/test_direction.py test/test_serializers/test_directional_literal_safety.py test/test_namespace/test_definednamespace.py test/test_namespace/test_definednamespace_dir.py` — 219 passed
- `uv run python -m pytest test/test_literal test/test_namespace test/test_serializers` — 834 passed, 3 skipped, 36 xfailed, 24 xpassed
- `uv run python -m pytest test/test_graph test/test_store/test_nodepickler.py test/test_store/test_store.py test/test_store/test_store_memorystore.py test/test_store/test_store_triple_store.py` — 225 passed, 9 xfailed
- `uv run python -m pytest --doctest-modules rdflib/term.py` — 7 passed
- `uv run ruff check .`
- `uv run black --check --diff ./rdflib`
- `uv run mypy --show-error-context --show-error-codes` — 532 source files checked

# Checklist

- [x] Checked that there are no other open pull requests for the same change.
- [x] Checked that all tests and type checking pass.
- [x] Created #3524 to discuss and track the public API change.
- [x] Considered adding an example; the focused documentation is sufficient for this core change.
- [x] Added tests that fail without the change.
- [x] Updated relevant documentation.
- [x] Considered additional documentation for later syntax PRs.
- [x] Maintainer edits are enabled for the branch.
