### PR TITLE
fix: support inverse paths in negated property sets

### DIFF
--- a/rdflib/paths.py
+++ b/rdflib/paths.py
@@ -110,7 +110,7 @@ True
 True
 >>> list(eval_path(g, (e.a, -(e.p1|e.p2), None))) == []
 True
->>> list(eval_path(g, (e.g, -~e.p2, None))) == [(e.g, e.j)]
+>>> list(eval_path(g, (e.g, -~e.p2, None))) == [(e.g, e.c)]
 True
 >>> list(eval_path(g, (e.e, ~(e.p1/e.p2), None))) == [(e.e, e.a)]
 True
@@ -144,7 +144,7 @@ True
 True
 >>> list(eval_path(g, (None, -(e.p1|e.p2), e.c))) == []
 True
->>> list(eval_path(g, (None, -~e.p2, e.j))) == [(e.g, e.j)]
+>>> list(eval_path(g, (None, -~e.p2, e.c))) == [(e.g, e.c)]
 True
 >>> list(eval_path(g, (None, ~(e.p1/e.p2), e.a))) == [(e.e, e.a)]
 True
@@ -490,17 +490,25 @@ class NegatedPath(Path):
             )
 
     def eval(self, graph, subj=None, obj=None):
-        for s, p, o in graph.triples((subj, None, obj)):
-            for a in self.args:
-                if isinstance(a, URIRef):
-                    if p == a:
-                        break
-                elif isinstance(a, InvPath):
-                    if (o, a.arg, s) in graph:
-                        break
-                else:
-                    raise Exception("Invalid path in NegatedPath: %s" % a)
-            else:
+        for path in self.args:
+            if not isinstance(path, (URIRef, InvPath)):
+                raise Exception("Invalid path in NegatedPath: %s" % path)
+
+        forward = {a for a in self.args if isinstance(a, URIRef)}
+        inverse = {a.arg for a in self.args if isinstance(a, InvPath)}
+
+        if forward:
+            for s, p, o in graph.triples((subj, None, obj)):
+                if p not in forward:
+                    yield s, o
+
+        if inverse:
+            for o, p, s in graph.triples((obj, None, subj)):
+                if p not in inverse:
+                    yield s, o
+
+        if not forward and not inverse:
+            for s, _, o in graph.triples((subj, None, obj)):
                 yield s, o
 
     def __repr__(self) -> str:

--- a/rdflib/plugins/sparql/parser.py
+++ b/rdflib/plugins/sparql/parser.py
@@ -473,7 +473,9 @@ GraphNodePath = VarOrTerm | TriplesNodePath
 PathMod = Literal("?") | "*" | "+"
 
 # [96] PathOneInPropertySet ::= iri | A | '^' ( iri | A )
-PathOneInPropertySet = iri | A | Comp("InversePath", "^" + (iri | A))
+PathOneInPropertySet = (
+    iri | A | Suppress("^") + Comp("PathEltOrInverse", Param("part", iri | A))
+)
 
 Path = Forward()
 

--- a/test/test_issues/test_issue3140.py
+++ b/test/test_issues/test_issue3140.py
@@ -1,0 +1,49 @@
+from rdflib import Graph, Namespace
+
+EX = Namespace("http://example.org/gmark/")
+
+
+def test_negated_property_set_with_forward_and_reverse_paths() -> None:
+    graph = Graph()
+    graph.add((EX.C, EX.p2, EX.D))
+    graph.add((EX.B, EX.p1, EX.C))
+    graph.add((EX.A, EX.p0, EX.B))
+
+    results = graph.query(
+        """
+        PREFIX : <http://example.org/gmark/>
+        SELECT ?x1 ?x2
+        WHERE {
+            ?x1 !(:p1|^:p2) ?x2
+        }
+        """
+    )
+
+    assert set(results) == {
+        (EX.A, EX.B),
+        (EX.B, EX.A),
+        (EX.C, EX.B),
+        (EX.C, EX.D),
+    }
+
+
+def test_negated_property_set_with_only_reverse_path() -> None:
+    graph = Graph()
+    graph.add((EX.C, EX.p2, EX.D))
+    graph.add((EX.B, EX.p1, EX.C))
+    graph.add((EX.A, EX.p0, EX.B))
+
+    results = graph.query(
+        """
+        PREFIX : <http://example.org/gmark/>
+        SELECT ?x1 ?x2
+        WHERE {
+            ?x1 !^:p2 ?x2
+        }
+        """
+    )
+
+    assert set(results) == {
+        (EX.B, EX.A),
+        (EX.C, EX.B),
+    }


### PR DESCRIPTION
## Summary of changes

- preserve inverse predicates while parsing negated property sets
- evaluate forward and inverse exclusions against their respective graph directions
- update the direct-path examples and add regressions for mixed and inverse-only sets

Fixes #3140.

This is a bug fix and does not change RDFLib's public API.

## Validation

- `python -m pytest rdflib/paths.py test/test_path.py test/test_issues/test_issue3140.py test/test_misc/test_plugins.py -q -m "not testcontainer and not webtest"` — 26 passed
- `python -m pytest -q -m "not testcontainer and not webtest"` — 9,185 passed, 62 skipped, 485 deselected, 332 xfailed, 37 xpassed
- Black 24.8.0, Ruff, and targeted mypy checks pass

## Checklist

- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked the complete offline suite, focused tests, formatting, lint, and relevant type checking.
- [x] Added regression tests that fail without the change.
- [x] Updated the affected direct-path doctest examples.
- [x] Enabled maintainer edits.
