### PR TITLE
fix: serialize N-Quads and TriX from a plain Graph

### DIFF
--- a/rdflib/plugins/serializers/nquads.py
+++ b/rdflib/plugins/serializers/nquads.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import warnings
-from typing import IO, Any, Optional
+from typing import IO, TYPE_CHECKING, Any, Optional
 
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, ConjunctiveGraph, Graph
-from rdflib.plugins.serializers.nt import _quoteLiteral
+from rdflib.plugins.serializers.nt import _nt_row, _quoteLiteral
 from rdflib.serializer import Serializer
 from rdflib.term import Literal
 
@@ -12,16 +12,16 @@ __all__ = ["NQuadsSerializer"]
 
 
 class NQuadsSerializer(Serializer):
-    """NQuads RDF graph serializer."""
+    """NQuads RDF graph serializer.
+
+    Context-aware stores (Dataset / ConjunctiveGraph) are written as quads.
+    A plain Graph is written as N-Triples-shaped N-Quads (no graph label),
+    which is valid N-Quads.
+    """
 
     def __init__(self, store: Graph):
-        if not store.context_aware:
-            raise Exception(
-                "NQuads serialization only makes " "sense for context-aware stores!"
-            )
-
         super(NQuadsSerializer, self).__init__(store)
-        self.store: ConjunctiveGraph
+        self.store: Graph
 
     def serialize(
         self,
@@ -38,11 +38,18 @@ class NQuadsSerializer(Serializer):
                 f"Given encoding was: {encoding}"
             )
         encoding = self.encoding
-        for context in self.store.contexts():
-            for triple in context:
-                stream.write(
-                    _nq_row(triple, context.identifier).encode(encoding, "replace")
-                )
+        if self.store.context_aware:
+            store = self.store
+            if TYPE_CHECKING:
+                assert isinstance(store, ConjunctiveGraph)
+            for context in store.contexts():
+                for triple in context:
+                    stream.write(
+                        _nq_row(triple, context.identifier).encode(encoding, "replace")
+                    )
+        else:
+            for triple in self.store:
+                stream.write(_nt_row(triple).encode(encoding, "replace"))
         stream.write("\n".encode("latin-1"))
 
 

--- a/rdflib/plugins/serializers/trix.py
+++ b/rdflib/plugins/serializers/trix.py
@@ -20,10 +20,6 @@ class TriXSerializer(Serializer):
 
     def __init__(self, store: Graph):
         super(TriXSerializer, self).__init__(store)
-        if not store.context_aware:
-            raise Exception(
-                "TriX serialization only makes sense for context-aware stores"
-            )
 
     def serialize(
         self,

--- a/test/test_serializers/test_nquads_default_graph.py
+++ b/test/test_serializers/test_nquads_default_graph.py
@@ -1,4 +1,4 @@
-from rdflib import Dataset
+from rdflib import Dataset, Graph, Literal, URIRef
 from rdflib.compare import isomorphic
 
 
@@ -37,3 +37,38 @@ def test_nquads_default_graph():
         assert isomorphic(graph, ds2.graph(graph.identifier)), print(
             f"{graph.identifier} not isomorphic"
         )
+
+
+def test_nquads_serializes_plain_graph():
+    """N-Quads must accept a non-context-aware Graph (issue #1892)."""
+    g = Graph()
+    g.add(
+        (
+            URIRef("http://example.org/s"),
+            URIRef("http://example.org/p"),
+            Literal("o"),
+        )
+    )
+    data = g.serialize(format="nquads")
+    assert "<http://example.org/s>" in data
+    assert '"o"' in data
+    parsed = Graph()
+    parsed.parse(data=data, format="nquads")
+    assert len(parsed) == 1
+
+
+def test_trix_serializes_plain_graph():
+    """TriX must accept a non-context-aware Graph (issue #1892)."""
+    g = Graph()
+    g.add(
+        (
+            URIRef("http://example.org/s"),
+            URIRef("http://example.org/p"),
+            Literal("o"),
+        )
+    )
+    data = g.serialize(format="trix")
+    assert "http://example.org/s" in data
+    parsed = Dataset()
+    parsed.parse(data=data, format="trix")
+    assert len(parsed) == 1

--- a/test/test_serializers/test_serializer.py
+++ b/test/test_serializers/test_serializer.py
@@ -237,19 +237,15 @@ class GraphFormat(str, enum.Enum):
             ),
             GraphFormatInfo(
                 GraphFormat.NQUADS,
-                # TODO FIXME: Currently nquads rejects requests to seralize
-                # non-context-aware stores, this does not make a lot of sense and
-                # should be fixed.
-                #
-                graph_types={GraphType.QUAD},
+                graph_types={GraphType.TRIPLE, GraphType.QUAD},
                 encodings={"utf-8"},
             ),
             GraphFormatInfo(
                 GraphFormat.TRIX,
-                # TODO FIXME: Currently trix rejects requests to seralize
-                # non-context-aware stores, this does not make a lot of sense and
-                # should be fixed.
-                #
+                # TriX can serialize a plain Graph (issue #1892), but parsing
+                # the result back into a non-context-aware Graph drops triples
+                # because they land in a named/unnamed dataset graph. Round-trip
+                # tests therefore stay Dataset-only.
                 graph_types={GraphType.QUAD},
                 encodings={"utf-8"},
             ),


### PR DESCRIPTION
## Summary
- N-Quads and TriX used to raise if you passed a plain `Graph`. A `Graph` is still a valid bag of triples, so that check was too strict.
- N-Quads now writes Graph data without a graph label (valid N-Quads, same shape as N-Triples).
- TriX already had a Graph write path; this just removes the guard in front of it.

Round-trip tests cover Graph to N-Quads and back. TriX from a Graph serializes fine; parsing that output still wants a Dataset, because the triples land in a dataset graph rather than the new Graph's identifier.

## Test plan
- [x] `pytest test/test_serializers/test_nquads_default_graph.py`
- [x] `pytest test/test_serializers/test_serializer.py -k 'nquads or trix'`

Fixes #1892