### PR TITLE
fix: handle RDF/XML predicates and rdf:type objects that cannot be shortened

### DIFF
--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -6,7 +6,7 @@ from xml.sax.saxutils import escape, quoteattr
 
 from rdflib.collection import Collection
 from rdflib.graph import Graph
-from rdflib.namespace import RDF, RDFS, Namespace  # , split_uri
+from rdflib.namespace import RDF, RDFS, Namespace, NamespaceManager  # , split_uri
 from rdflib.plugins.parsers.RDFVOC import RDFVOC
 from rdflib.plugins.serializers.xmlwriter import XMLWriter
 from rdflib.serializer import Serializer
@@ -16,6 +16,24 @@ from rdflib.util import first, more_than
 from .xmlwriter import ESCAPE_ENTITIES
 
 __all__ = ["fix", "XMLSerializer", "PrettyXMLSerializer"]
+
+
+def _compute_qname_strict_for_term(
+    nm: NamespaceManager, term: Node
+) -> Tuple[str, str, str]:
+    """Compute the strict qname for predicate ``term``, raising a clear
+    error if it cannot be split into a namespace and a valid XML local
+    name (and therefore cannot be represented in RDF/XML).
+    """
+    try:
+        # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
+        return nm.compute_qname_strict(term)  # type: ignore[arg-type]
+    except ValueError as e:
+        raise ValueError(
+            f"Cannot serialize predicate {term} to RDF/XML: it cannot be "
+            "split into a namespace and a valid XML local name, so it "
+            "cannot be written as an XML element name."
+        ) from e
 
 
 class XMLSerializer(Serializer):
@@ -30,8 +48,7 @@ class XMLSerializer(Serializer):
         bindings: Dict[str, URIRef] = {}
 
         for predicate in set(store.predicates()):
-            # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
-            prefix, namespace, name = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
+            prefix, namespace, name = _compute_qname_strict_for_term(nm, predicate)
             bindings[prefix] = URIRef(namespace)
 
         RDFNS = URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#")  # noqa: N806
@@ -196,13 +213,20 @@ class PrettyXMLSerializer(Serializer):
         self.writer = writer = XMLWriter(stream, nm, encoding)
         namespaces = {}
 
-        possible: Set[Node] = set(store.predicates()).union(
-            store.objects(None, RDF.type)
-        )
+        for predicate in set(store.predicates()):
+            prefix, namespace, local = _compute_qname_strict_for_term(nm, predicate)
+            namespaces[prefix] = namespace
 
-        for predicate in possible:
-            # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
-            prefix, namespace, local = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
+        # rdf:type objects are only used as element names when they can be
+        # shortened; the others are written as rdf:type properties of an
+        # rdf:Description element (see `subject`), so failing to shorten one
+        # is not an error.
+        for type_ in store.objects(None, RDF.type):
+            try:
+                # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
+                prefix, namespace, local = nm.compute_qname_strict(type_)  # type: ignore[arg-type]
+            except ValueError:
+                continue
             namespaces[prefix] = namespace
 
         namespaces["rdf"] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -263,8 +287,8 @@ class PrettyXMLSerializer(Serializer):
             type = first(store.objects(subject, RDF.type))
 
             try:
-                # type error: Argument 1 to "qname" of "NamespaceManager" has incompatible type "Optional[Node]"; expected "str"
-                self.nm.qname(type)  # type: ignore[arg-type]
+                # type error: Argument 1 to "qname_strict" of "NamespaceManager" has incompatible type "Optional[Node]"; expected "str"
+                self.nm.qname_strict(type)  # type: ignore[arg-type]
             except Exception:
                 type = None
 

--- a/test/test_serializers/test_prettyxml.py
+++ b/test/test_serializers/test_prettyxml.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 
-from rdflib.graph import Dataset
+import pytest
+
+from rdflib.compare import isomorphic
+from rdflib.graph import Dataset, Graph
 from rdflib.namespace import RDF, RDFS
 from rdflib.plugins.serializers.rdfxml import PrettyXMLSerializer
 from rdflib.term import BNode, Literal, URIRef
@@ -209,3 +212,41 @@ def _assert_expected_object_types_for_predicates(graph, predicates, types):
             assert (
                 True in some_true
             ), "Bad type %s for object when predicate is <%s>." % (type(o), p)
+
+
+def test_unprefixable_predicate_raises_clear_error():
+    """A predicate equal to a bound namespace/prefix cannot be shortened, and should raise a clear error (regression test for issue #2409)."""
+    g = Graph().parse(data='<a> <> "test"@en .', publicID="http://example.org/")
+    with pytest.raises(ValueError, match="Cannot serialize predicate"):
+        g.serialize(format="pretty-xml")
+
+
+@pytest.mark.parametrize("rdf_format", ["xml", "pretty-xml"])
+def test_unshortenable_rdf_type_object_serializes(rdf_format):
+    """An rdf:type object that cannot be shortened to a qname (e.g. one equal to a bound namespace/prefix) is representable in RDF/XML as an ordinary rdf:type property, and should serialize and round-trip successfully rather than raising (regression test for issue #2409)."""
+    g = Graph().parse(
+        data=(
+            "<http://example.org/a> a <http://example.org/> ;"
+            ' <http://example.org/p> "x" .'
+        ),
+        format="turtle",
+    )
+
+    serialized = g.serialize(format=rdf_format)
+
+    reparsed = Graph().parse(data=serialized, format="xml")
+    assert isomorphic(g, reparsed)
+
+    if rdf_format == "pretty-xml":
+        assert "rdf:Description" in serialized
+        assert '<rdf:type rdf:resource="http://example.org/"/>' in serialized
+
+
+@pytest.mark.parametrize("rdf_format", ["xml", "pretty-xml"])
+def test_unshortenable_predicate_raises_in_both_serializers(rdf_format):
+    """The same unshortenable URI used as a predicate (rather than as an rdf:type object) is not representable in RDF/XML and must still raise, in both serializers (regression test for issue #2409)."""
+    g = Graph().parse(
+        data='<http://example.org/a> <http://example.org/> "x" .', format="turtle"
+    )
+    with pytest.raises(ValueError, match="Cannot serialize predicate"):
+        g.serialize(format=rdf_format)

--- a/test/test_serializers/test_serializer_xml.py
+++ b/test/test_serializers/test_serializer_xml.py
@@ -1,6 +1,8 @@
 from io import BytesIO
 
-from rdflib.graph import Dataset
+import pytest
+
+from rdflib.graph import Dataset, Graph
 from rdflib.namespace import RDFS
 from rdflib.plugins.serializers.rdfxml import XMLSerializer
 from rdflib.term import BNode, URIRef
@@ -187,3 +189,10 @@ def _assert_expected_object_types_for_predicates(graph, predicates, types):
             assert (
                 True in some_true
             ), "Bad type %s for object when predicate is <%s>." % (type(o), p)
+
+
+def test_unprefixable_predicate_raises_clear_error():
+    """A predicate equal to a bound namespace/prefix cannot be shortened, and should raise a clear error (regression test for issue #2409)."""
+    g = Graph().parse(data='<a> <> "test"@en .', publicID="http://example.org/")
+    with pytest.raises(ValueError, match="Cannot serialize predicate"):
+        g.serialize(format="xml")


### PR DESCRIPTION
Closes #2409

# Summary of changes

`XMLSerializer.__bindings()` and `PrettyXMLSerializer.serialize()` called
`NamespaceManager.compute_qname_strict()` on every predicate, and in the pretty
serializer on every `rdf:type` object, without handling the `ValueError` raised
when a URI cannot be split into a namespace and a valid, non-empty XML local
name. `g.serialize(format="xml")` therefore failed with an opaque internal
`ValueError: Can't split 'http://example.org/'`.

There are two distinct cases behind that one error, and they need different
answers:

**Predicates** genuinely cannot be represented. RDF/XML writes a predicate as an
XML element name, which must be a QName, and a URI such as `http://example.org/`
or `http://` has no valid NCName local part under any split. These now raise a
`ValueError` naming the offending predicate and explaining why, instead of an
internal `split_uri` error.

**`rdf:type` objects** are representable. When the type URI can be shortened it
is used as the element name; when it cannot, the subject is written as
`rdf:Description` with an ordinary `<rdf:type rdf:resource="..."/>` property.
`PrettyXMLSerializer.subject()` already contained this fallback, but it was
unreachable because `serialize()` raised during namespace collection first, so
`format="xml"` serialized such graphs correctly while `format="pretty-xml"`
crashed on them. The namespace-collection loop now skips type objects it cannot
shorten, and `subject()`'s fallback check uses `qname_strict` rather than
`qname` (the non-strict variant returns invalid qnames like `ex:` and `ex:123`,
which then fail later in `XMLWriter.push`). Both serializers now produce the same
output for these graphs, and it round-trips.

No backwards-incompatible changes: graphs that serialized before still serialize
identically; graphs that crashed either now serialize correctly (`rdf:type`
objects) or raise a clearer error of the same `ValueError` type (predicates).

This change was prepared with AI assistance; the regression tests were run locally and fail without the fix.

# Checklist

- [x] Checked that there aren't other open pull requests for
  the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  - [x] Added or updated tests that fail without the change.
  - [x] Considered adding additional documentation.
- [x] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
