### PR TITLE
Use RDF and XML prefixes in pretty-xml for unbound namespaces

### DIFF
--- a/rdflib/plugins/serializers/rdfxml.py
+++ b/rdflib/plugins/serializers/rdfxml.py
@@ -193,7 +193,12 @@ class PrettyXMLSerializer(Serializer):
         assert self.max_depth > 0, "max_depth must be greater than 0"
 
         self.nm = nm = store.namespace_manager
-        self.writer = writer = XMLWriter(stream, nm, encoding)
+        self.writer = writer = XMLWriter(
+            stream,
+            nm,
+            encoding,
+            extra_ns={"rdf": Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")},
+        )
         namespaces = {}
 
         possible: Set[Node] = set(store.predicates()).union(
@@ -204,8 +209,6 @@ class PrettyXMLSerializer(Serializer):
             # type error: Argument 1 to "compute_qname_strict" of "NamespaceManager" has incompatible type "Node"; expected "str"
             prefix, namespace, local = nm.compute_qname_strict(predicate)  # type: ignore[arg-type]
             namespaces[prefix] = namespace
-
-        namespaces["rdf"] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
         writer.push(RDFVOC.RDF)
 

--- a/rdflib/plugins/serializers/xmlwriter.py
+++ b/rdflib/plugins/serializers/xmlwriter.py
@@ -4,6 +4,7 @@ import codecs
 from typing import IO, TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 from xml.sax.saxutils import escape, quoteattr
 
+from rdflib.namespace import XMLNS
 from rdflib.term import URIRef
 
 if TYPE_CHECKING:
@@ -91,10 +92,12 @@ class XMLWriter:
         write = self.stream.write
         write("\n")
         for prefix, namespace in namespaces:
+            # Allow user-provided namespace bindings to prevail
+            if prefix in self.extra_ns:
+                continue
             if prefix:
                 write('  xmlns:%s="%s"\n' % (prefix, namespace))
-            # Allow user-provided namespace bindings to prevail
-            elif prefix not in self.extra_ns:
+            else:
                 write('  xmlns="%s"\n' % namespace)
 
         for prefix, namespace in self.extra_ns.items():
@@ -126,5 +129,9 @@ class XMLWriter:
                     return ":".join([pre, uri[len(ns) :]])
                 else:
                     return uri[len(ns) :]
+
+        # The xml prefix is predefined and never declared
+        if uri.startswith(XMLNS):
+            return "xml:" + uri[len(XMLNS) :]
 
         return self.nm.qname_strict(uri)

--- a/test/test_serializers/test_prettyxml.py
+++ b/test/test_serializers/test_prettyxml.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
-from rdflib.graph import Dataset
+from rdflib.compare import isomorphic
+from rdflib.graph import Dataset, Graph
 from rdflib.namespace import RDF, RDFS
 from rdflib.plugins.serializers.rdfxml import PrettyXMLSerializer
 from rdflib.term import BNode, Literal, URIRef
@@ -209,3 +210,17 @@ def _assert_expected_object_types_for_predicates(graph, predicates, types):
             assert (
                 True in some_true
             ), "Bad type %s for object when predicate is <%s>." % (type(o), p)
+
+
+def test_pretty_xml_bind_namespaces_none():
+    # https://github.com/RDFLib/rdflib/issues/2408
+    graph = Graph(bind_namespaces="none")
+    graph.parse(data='prefix ex: <http://example.org/> ex:a ex:b "test"@en .')
+
+    result = graph.serialize(format="pretty-xml")
+
+    assert "<rdf:RDF" in result
+    assert 'rdf:about="http://example.org/a"' in result
+    assert 'xml:lang="en"' in result
+    assert "ns1" not in result
+    assert isomorphic(graph, Graph().parse(data=result, format="xml"))


### PR DESCRIPTION

Fixes #2408.

With `Graph(bind_namespaces="none")`, the `pretty-xml` serializer declared `xmlns:rdf` but wrote its own element and attribute names through the namespace manager, which has no `rdf` or `xml` binding in that mode and therefore invented `ns1` and `ns2`. The output used `ns1:RDF`, `ns1:about` and `ns2:lang` without declaring those prefixes, so it was not well-formed XML. The plain `xml` serializer was not affected because it hard-codes those names.

Changes:

- `PrettyXMLSerializer` now passes the RDF namespace to `XMLWriter` as an extra namespace, the same mechanism the TriX serializer already uses. The writer declares `xmlns:rdf` from there, so the manual entry in the `namespaces` dict is gone.
- `XMLWriter.qname` resolves URIs in the XML namespace to the predefined `xml` prefix, which never needs a declaration.
- `XMLWriter.namespaces` skips any prefix that is also given as an extra namespace, so `xmlns:rdf` is declared once when the manager binds `rdf` as well. Before, that check only covered the default prefix.

Output for graphs with the default namespace bindings is unchanged. No public API changes.

# Checklist

- [x] Checked that there aren't other open pull requests for the same change.
- [x] Checked that all tests and type checking passes.
- If the change has a potential impact on users of this project:
  - [x] Added or updated tests that fail without the change.
- [x] Considered granting push permissions to the PR branch, so maintainers can fix minor issues and keep your PR up to date.
