### PR TITLE
fix: JSON-LD collection syntax can silently duplicate shared RDF lists

### DIFF
--- a/rdflib/plugins/serializers/jsonld.py
+++ b/rdflib/plugins/serializers/jsonld.py
@@ -417,6 +417,16 @@ class Converter:
                 return v
 
     def to_collection(self, graph: Graph, l_: Identifier):
+        """Return the members of the ``rdf:List`` headed by ``l_``, or None.
+
+        None means the chain must not be rendered as ``@list``. Besides a
+        malformed or cyclic chain, that includes a chain any of whose cells is
+        the object of more than one statement: the ``@list`` form inlines the
+        whole chain at a single reference and writes its cells nowhere else, so
+        another statement pointing at one of those cells would be left
+        referring to a node the output never defines, and the serialization
+        would not round-trip.
+        """
         if l_ != RDF.nil and not graph.value(l_, RDF.first):
             return None
         list_nodes: list[Optional[_ObjectType]] = []
@@ -425,6 +435,8 @@ class Converter:
             if l_ == RDF.nil:
                 return list_nodes
             if isinstance(l_, URIRef):
+                return None
+            if len(list(graph.subject_predicates(l_))) != 1:
                 return None
             first, rest = None, None
             for p, o in graph.predicate_objects(l_):

--- a/test/jsonld/test_shared_list_cells.py
+++ b/test/jsonld/test_shared_list_cells.py
@@ -1,0 +1,97 @@
+from rdflib import RDF, BNode, Graph, Literal, Namespace
+from rdflib.compare import isomorphic
+from rdflib.plugins.serializers.jsonld import Converter
+from rdflib.plugins.shared.jsonld.context import Context
+
+
+def _shared_tail_graph():
+    """Two lists whose final cell is the same node, not a copy of it."""
+    ns = Namespace("http://example.org/ns/")
+    g = Graph()
+    tail = BNode()
+    head = BNode()
+    g.add((tail, RDF.first, Literal("b")))
+    g.add((tail, RDF.rest, RDF.nil))
+    g.add((head, RDF.first, Literal("a")))
+    g.add((head, RDF.rest, tail))
+    g.add((ns.s1, ns.p, head))
+    g.add((ns.s2, ns.p, tail))
+    return g, ns, head, tail
+
+
+def test_jsonld_shared_list_tail_round_trips():
+    """
+    A list cell pointed to from more than one place cannot be written as
+    ``@list``: that form inlines the whole chain at a single reference and
+    writes its cells nowhere else, so any other statement referring to one of
+    those cells is left pointing at a node the output never defines.
+
+    Rendering each list independently instead emitted the shared cell once per
+    referring list, so the round-tripped graph gained triples: 6 in, 8 out,
+    non-isomorphic.
+
+    Same defect class as ``test_turtle_shared_list_tail_round_trips`` and
+    ``test_longturtle_shared_list_tail_round_trips``; the JSON-LD converter has
+    its own chain walk and so needed the same reference check.
+    """
+    g, _ns, _head, _tail = _shared_tail_graph()
+
+    data = g.serialize(format="json-ld")
+    g2 = Graph()
+    g2.parse(data=data, format="json-ld")
+
+    assert len(g2) == len(g)
+    assert isomorphic(g, g2)
+    # The chain is stated explicitly rather than inlined. ``"@list": []`` may
+    # still appear: that is ``rdf:nil``, a single IRI, not a list structure.
+    assert '"@list": [\n' not in data.replace('"@list": []', "")
+    assert len(list(g2.triples((None, RDF.first, None)))) == 2
+    assert len(list(g2.triples((None, RDF.rest, None)))) == 2
+
+
+def test_to_collection_rejects_a_multiply_referenced_cell():
+    """The decision itself, so the reason survives a refactor of the caller."""
+    g, _ns, head, tail = _shared_tail_graph()
+    converter = Converter(Context(), False, None)
+
+    assert converter.to_collection(g, head) is None
+    assert converter.to_collection(g, tail) is None
+
+
+def test_a_privately_owned_list_is_still_written_as_a_list():
+    """The fix must not stop ordinary lists from using ``@list``."""
+    ns = Namespace("http://example.org/ns/")
+    g = Graph()
+    g.add((ns.s, ns.p, RDF.nil))
+    collection = BNode()
+    second = BNode()
+    g.add((collection, RDF.first, Literal("a")))
+    g.add((collection, RDF.rest, second))
+    g.add((second, RDF.first, Literal("b")))
+    g.add((second, RDF.rest, RDF.nil))
+    g.add((ns.owner, ns.items, collection))
+
+    data = g.serialize(format="json-ld")
+    g2 = Graph()
+    g2.parse(data=data, format="json-ld")
+
+    assert "@list" in data
+    assert isomorphic(g, g2)
+
+
+def test_a_shared_list_head_round_trips():
+    """Sharing the head, not an interior cell, must round-trip too."""
+    ns = Namespace("http://example.org/ns/")
+    g = Graph()
+    head = BNode()
+    g.add((head, RDF.first, Literal("a")))
+    g.add((head, RDF.rest, RDF.nil))
+    g.add((ns.s1, ns.p, head))
+    g.add((ns.s2, ns.p, head))
+
+    data = g.serialize(format="json-ld")
+    g2 = Graph()
+    g2.parse(data=data, format="json-ld")
+
+    assert len(g2) == len(g)
+    assert isomorphic(g, g2)


### PR DESCRIPTION
Fixes #3542.

## Bug

`Converter.to_collection` walks an `rdf:List` chain and returns its members if the chain looks well formed. It checks that each cell carries one `rdf:first`/`rdf:rest` pair and that the chain is acyclic, but not how many statements point *into* the chain.

The `@list` form inlines the whole chain at a single reference and writes its cells nowhere else. So when a cell is referenced from more than one place, each referring list rendered the shared cells again and the round trip gained triples.

```python
from rdflib import BNode, Graph, Literal, Namespace, RDF
from rdflib.compare import isomorphic

EX = Namespace("http://example.org/")
graph = Graph()
tail, head = BNode(), BNode()
graph.add((tail, RDF.first, Literal("shared")))
graph.add((tail, RDF.rest, RDF.nil))
graph.add((head, RDF.first, Literal("head")))
graph.add((head, RDF.rest, tail))
graph.add((EX.a, EX.items, head))
graph.add((EX.b, EX.items, tail))   # second reference into the chain

reparsed = Graph().parse(data=graph.serialize(format="json-ld"), format="json-ld")
print(len(graph), len(reparsed), isomorphic(graph, reparsed))
```

Before: `6 8 False` — the tail is emitted inside both `@list` values. After: `6 6 True`.

## Fix

The same check #3504 added to `TurtleSerializer.isValidList` and `LongTurtleSerializer.isValidList`, applied to the JSON-LD converter's own chain walk:

```python
if len(list(graph.subject_predicates(l_))) != 1:
    return None
```

A chain with a multiply-referenced cell is then not rendered as a list, and the cells are written out with explicit `rdf:first`/`rdf:rest`, which can express any arrangement of sharing.

`to_collection`'s docstring now records why the condition is there, so the reason is available at the point someone might be tempted to relax it.

## Not affected

- Ordinary privately-owned lists still render as `@list`; a test covers that, since the risk in a change like this is over-rejecting.
- An empty chain still renders as `"@list": []`. That is `rdf:nil`, a single IRI rather than a list structure, so nothing is lost.
- A shared list *head* was already handled; a test pins it alongside the interior-cell case.

## Tests

`test/jsonld/test_shared_list_cells.py`, four cases: the shared interior cell round-tripping, `to_collection` returning `None` for such a chain, an ordinary list still using `@list`, and a shared head. Named and structured to sit alongside the existing `test_turtle_shared_list_tail_round_trips` and `test_longturtle_shared_list_tail_round_trips`.

Full suite run locally on Python 3.10: 1626 passed, 1567 skipped, 47 xfailed. The one failure, `test/test_misc/test_plugins.py::test_sparqleval`, reproduces identically on a clean checkout of `main` in the same environment — it shells out to `pip`, which the uv-created venv does not have — so it is unrelated to this change. `test/jsonld` on its own: 489 passed, 1 xfailed.
