### PR TITLE
feat: deterministic N-Triples serialization via an opt-in canon parameter

### DIFF
--- a/rdflib/plugins/serializers/nt.py
+++ b/rdflib/plugins/serializers/nt.py
@@ -4,6 +4,7 @@ import codecs
 import warnings
 from typing import IO, TYPE_CHECKING, Any, Optional, Union
 
+from rdflib.compare import to_canonical_graph
 from rdflib.graph import Graph
 from rdflib.serializer import Serializer
 from rdflib.term import Literal
@@ -33,6 +34,16 @@ class NTSerializer(Serializer):
         encoding: Optional[str] = "utf-8",
         **kwargs: Any,
     ) -> None:
+        """Write the graph as N-Triples.
+
+        When the optional parameter ``canon`` is set to ``True``, the graph is
+        canonicalized and the statements are written in sorted order, so
+        isomorphic graphs serialize to identical bytes. This mirrors the
+        ``canon`` parameter of the longturtle serializer, and carries the same
+        cost: canonicalization is not free, and the statements are held in
+        memory to be sorted. It is off by default, so ordinary serialization
+        still streams statement by statement.
+        """
         if base is not None:
             warnings.warn("NTSerializer does not support base.")
         if encoding != "utf-8":
@@ -40,6 +51,17 @@ class NTSerializer(Serializer):
                 "NTSerializer always uses UTF-8 encoding. "
                 f"Given encoding was: {encoding}"
             )
+
+        if kwargs.get("canon", False):
+            # Sort the rendered rows rather than the triples: two distinct
+            # terms can have the same str(), which would leave their relative
+            # order down to the store's iteration order, whereas identical
+            # rows mean identical statements.
+            for row in sorted(
+                _nt_row(triple) for triple in to_canonical_graph(self.store)
+            ):
+                stream.write(row.encode())
+            return
 
         for triple in self.store:
             stream.write(_nt_row(triple).encode())

--- a/test/test_serializers/test_serializer_ntriples_canon.py
+++ b/test/test_serializers/test_serializer_ntriples_canon.py
@@ -1,0 +1,119 @@
+import os
+import subprocess
+import sys
+
+from rdflib import BNode, Graph, Literal, Namespace
+from rdflib.compare import isomorphic
+
+BUILD = """
+from rdflib import RDF, BNode, Graph, Literal, Namespace
+ns = Namespace("http://example.org/ns/")
+g = Graph()
+hub = BNode()
+for i in range(4):
+    g.add((ns[f"s{i}"], ns.ref, hub))
+g.add((hub, ns.value, Literal("hub")))
+cells = [BNode() for _ in range(4)]
+for i, cell in enumerate(cells):
+    g.add((cell, RDF.first, Literal(f"v{i}")))
+    g.add((cell, RDF.rest, cells[i + 1] if i + 1 < len(cells) else RDF.nil))
+g.add((ns.a, ns.items, cells[0]))
+"""
+
+
+def _graph() -> Graph:
+    namespace: dict = {}
+    exec(BUILD, namespace)
+    return namespace["g"]
+
+
+def test_canon_produces_identical_bytes_across_processes():
+    """``canon=True`` must survive a change of process, which is the point of it.
+
+    Hash seeds rather than repeated calls in one process: the store's iteration
+    order is stable within a process, so repeating a call proves nothing.
+    """
+    script = (
+        BUILD
+        + """
+import sys
+sys.stdout.write(g.serialize(format="nt", canon=True))
+"""
+    )
+    outputs = {
+        subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**os.environ, "PYTHONHASHSEED": str(seed)},
+        ).stdout
+        for seed in (0, 1, 2, 3, 5, 8)
+    }
+    assert len(outputs) == 1, f"canon=True gave {len(outputs)} different documents"
+
+
+def test_canon_output_is_sorted():
+    lines = [
+        line
+        for line in _graph().serialize(format="nt", canon=True).splitlines()
+        if line
+    ]
+    assert lines == sorted(lines)
+
+
+def test_canon_preserves_the_graph():
+    g = _graph()
+    reparsed = Graph()
+    reparsed.parse(data=g.serialize(format="nt", canon=True), format="nt")
+    assert len(reparsed) == len(g)
+    assert isomorphic(reparsed, g)
+
+
+def test_canon_is_off_by_default():
+    """Ordinary serialization must be untouched.
+
+    Default output keeps the graph's own blank-node labels, so it differs from
+    the canonicalized form -- which is what shows the parameter is doing
+    something rather than being ignored.
+    """
+    g = _graph()
+    default = g.serialize(format="nt")
+
+    reparsed = Graph()
+    reparsed.parse(data=default, format="nt")
+    assert isomorphic(reparsed, g)
+    assert len(default.splitlines()) == len(g)
+    assert default != g.serialize(format="nt", canon=True)
+
+
+def test_an_unrecognised_keyword_is_still_ignored():
+    """The parameter is opt-in via kwargs; nothing else may start failing."""
+    g = _graph()
+    assert g.serialize(format="nt", something_else=True) == g.serialize(format="nt")
+
+
+def test_canon_works_for_nt11():
+    """NT11Serializer subclasses NTSerializer, so it inherits the parameter."""
+    g = _graph()
+    reparsed = Graph()
+    reparsed.parse(data=g.serialize(format="nt11", canon=True), format="nt")
+    assert isomorphic(reparsed, g)
+
+
+def test_canon_on_an_empty_graph():
+    assert Graph().serialize(format="nt", canon=True) == ""
+
+
+def test_canon_relabels_blank_nodes_independently_of_their_input_names():
+    """Canonicalization is what makes the sort meaningful across runs."""
+    ns = Namespace("http://example.org/ns/")
+    first, second = Graph(), Graph()
+    for graph, name in ((first, "aaa"), (second, "zzz")):
+        node = BNode(name)
+        graph.add((ns.s, ns.p, node))
+        graph.add((node, ns.q, Literal("v")))
+
+    assert first.serialize(format="nt", canon=True) == second.serialize(
+        format="nt", canon=True
+    )


### PR DESCRIPTION
Gives `NTSerializer` the opt-in `canon` parameter that #3008 added to `longturtle`, so N-Triples output can be made deterministic.

## Problem

The N-Triples serializer writes statements in the order the store iterates them, which follows set iteration and so varies between processes. The same graph serializes to different bytes in different runs:

```python
import os, subprocess, sys

SCRIPT = '''
import sys
from rdflib import BNode, Graph, Literal, Namespace
EX = Namespace("http://example.org/")
g = Graph()
hub = BNode("cb0")
triples = [(EX[f"s{i}"], EX.ref, hub) for i in range(3)]
triples.append((hub, EX.value, Literal("hub")))
for t in sorted(triples, key=lambda t: (str(t[0]), str(t[1]), str(t[2]))):
    g.add(t)
sys.stdout.write(g.serialize(format="nt"))
'''

outs = {subprocess.run([sys.executable, "-c", SCRIPT], capture_output=True, text=True,
                       env={**os.environ, "PYTHONHASHSEED": str(s)}).stdout
        for s in (0, 1, 2, 3, 5, 8)}
print(len(outs))   # 5 before this change, 1 with canon=True
```

Note the graph is built by sorted insertion with a fixed blank-node label, so nothing on the caller's side varies — sorting on the way *in* does not help, because the ordering comes from the serializer's own iteration.

For anyone keeping RDF in version control this is diff noise: regenerating a file rewrites it even when the graph has not changed. That is the same motivation as #1890.

## Approach

`canon` follows the precedent #3008 set for `longturtle` rather than inventing a second mechanism: same parameter name, same default of `False`, same meaning — canonicalize, then order deterministically.

```python
g.serialize(format="nt", canon=True)
```

Two deliberate choices:

- **Default off, and the default path is untouched.** Ordinary serialization still streams statement by statement with no list materialised, so there is no time or memory cost for existing users. #1890 framed sorting as something to pay for when you want it, and the docstring says what it costs.
- **The rendered rows are sorted, not the triples.** Two distinct terms can share a `str()` — `Literal("x")` and `URIRef("x")`, say — which would leave their relative order down to the very store iteration order this is meant to remove. Identical rows mean identical statements, so sorting rows is total.

`NT11Serializer` inherits it by subclassing.

## Not included

`nquads` has a separate `NQuadsSerializer` class and is not touched here, to keep this reviewable — happy to follow up. The RDF/XML serializers have the same instability (5 distinct documents over the same six seeds for `xml`, 3 for `pretty-xml`) but need a design decision about where determinism belongs for a nesting format, so I have raised that separately rather than guessing.

## Tests

`test/test_serializers/test_serializer_ntriples_canon.py`, eight cases: byte-identical output across six hash seeds in fresh processes; output is sorted; the graph is preserved and isomorphic; the default is off and its output differs from the canonical form; `nt11` inherits it; an empty graph; blank-node labels canonicalized independently of their input names; and an unrecognised keyword still ignored.

Full suite on Python 3.10: **7677 passed**, 1811 skipped, 328 xfailed, 36 xpassed. The one failure, `test/test_misc/test_plugins.py::test_parser`, reproduces identically on a clean checkout in the same environment — it shells out to `pip`, which a uv-created venv does not have — so it is unrelated. `ruff`, `black` 24.8.0 and `mypy` all clean on the changed files.
