### PR TITLE
Undef enum

### DIFF
--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -5,6 +5,7 @@ Implementation of the JSON-LD Context structure. See: http://json-ld.org/
 # https://github.com/RDFLib/rdflib-jsonld/blob/feature/json-ld-1.1/rdflib_jsonld/context.py
 from __future__ import annotations
 
+from enum import Enum
 from collections import namedtuple
 from collections.abc import Collection, Generator
 from typing import (
@@ -51,11 +52,11 @@ from .util import norm_url, source_to_json, split_iri
 NODE_KEYS = {GRAPH, ID, INCLUDED, JSON, LIST, NEST, NONE, REV, SET, TYPE, VALUE, LANG}
 
 
-class Defined(int):
-    pass
+class Defined(Enum):
+    UNDEF = 0
 
 
-UNDEF = Defined(0)
+UNDEF = Defined.UNDEF
 
 # From <https://tools.ietf.org/html/rfc3986#section-2.2>
 URI_GEN_DELIMS = (":", "/", "?", "#", "[", "]", "@")

--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -5,9 +5,9 @@ Implementation of the JSON-LD Context structure. See: http://json-ld.org/
 # https://github.com/RDFLib/rdflib-jsonld/blob/feature/json-ld-1.1/rdflib_jsonld/context.py
 from __future__ import annotations
 
-from enum import Enum
 from collections import namedtuple
 from collections.abc import Collection, Generator
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -52,6 +52,8 @@ from .util import norm_url, source_to_json, split_iri
 NODE_KEYS = {GRAPH, ID, INCLUDED, JSON, LIST, NEST, NONE, REV, SET, TYPE, VALUE, LANG}
 
 
+# Following PEP 484, we define the UNDEF as an Enum member
+# Ultimately this should become a PEP 661 sentinel.
 class Defined(Enum):
     UNDEF = 0
 

--- a/rdflib/plugins/shared/jsonld/context.py
+++ b/rdflib/plugins/shared/jsonld/context.py
@@ -57,6 +57,10 @@ NODE_KEYS = {GRAPH, ID, INCLUDED, JSON, LIST, NEST, NONE, REV, SET, TYPE, VALUE,
 class Defined(Enum):
     UNDEF = 0
 
+    def __bool__(self) -> bool:
+        # Ensure that UNDEF is falsy
+        return False
+
 
 UNDEF = Defined.UNDEF
 


### PR DESCRIPTION

# Summary of changes

Remake of #3276.

Convert `Defined` into an enum. The justification of this [is PEP 484](https://peps.python.org/pep-0484/#support-for-singleton-types-in-unions), which suggests that singletons should be represented as enums with a single element. The reason why this matters is because it lets you say `if x is not UNDEF` and the type checker will correctly narrow the type to be no longer `Defined`, because all enum variants have been excluded.

# Checklist

<!--
If an item on this list doesn't apply to your pull request, just remove it.

If, for some reason, you can't check some items on the checklist, or you are
unsure about them, submit your PR as is and ask for help.
-->

- [ ] Checked that there aren't other open pull requests for
  the same change.
- [ ] Checked that all tests and type checking passes.
- If the change adds new features or changes the RDFLib public API:
  <!-- This can be removed if no new features are added and the RDFLib public API is
  not changed. -->
  - [ ] Created an issue to discuss the change and get in-principle agreement.
  - [ ] Considered adding an example in `./examples`.
- If the change has a potential impact on users of this project:
  <!-- This can be removed if the change does not affect users of this project. -->
  - [ ] Added or updated tests that fail without the change.
  - [ ] Updated relevant documentation to avoid inaccuracies.
  - [ ] Considered adding additional documentation.
- [ ] Considered granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork),
  so maintainers can fix minor issues and keep your PR up to date.
